### PR TITLE
fix: mobile bottom padding for nav bar spacing

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -40,7 +40,7 @@ export default async function DashboardLayout({
           notifications={notifications}
         />
         <main className="flex-1 min-w-0 overflow-x-hidden pt-[env(safe-area-inset-top)] md:pt-0 md:overflow-auto" id="tour-main">
-          <div className="max-w-5xl mx-auto px-4 md:px-6 py-4 md:py-8 pb-[calc(5rem+env(safe-area-inset-bottom))] md:pb-8">
+          <div className="max-w-5xl mx-auto px-4 md:px-6 py-4 md:py-8 pb-[calc(6rem+env(safe-area-inset-bottom))] md:pb-8">
             {children}
           </div>
         </main>

--- a/src/app/(investor)/layout.tsx
+++ b/src/app/(investor)/layout.tsx
@@ -26,7 +26,7 @@ export default async function InvestorLayout({
         isAdmin={profile?.is_admin ?? false}
       />
         <main className="flex-1 min-w-0 overflow-x-hidden pt-[env(safe-area-inset-top)] md:pt-0 md:overflow-auto">
-          <div className="max-w-5xl mx-auto px-4 md:px-6 py-4 md:py-8 pb-[calc(5rem+env(safe-area-inset-bottom))] md:pb-8">
+          <div className="max-w-5xl mx-auto px-4 md:px-6 py-4 md:py-8 pb-[calc(6rem+env(safe-area-inset-bottom))] md:pb-8">
             {children}
           </div>
         </main>


### PR DESCRIPTION
## Summary
- Increases mobile bottom padding from `5rem` to `6rem` on both dashboard and investor layouts
- Adds ~16px of breathing room between content and the fixed bottom navigation bar
- Only affects mobile — desktop `md:pb-8` is unchanged

## Test plan
- [ ] Open dashboard on mobile (or narrow viewport) — verify content doesn't sit flush against bottom nav
- [ ] Open investor panel on mobile — same check
- [ ] Verify desktop layout is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)