### PR TITLE
fix(auth): validate `next` param to prevent open redirect

### DIFF
--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -4,7 +4,10 @@ import { createServerClient } from '@supabase/ssr';
 export async function GET(request: NextRequest) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get('code');
-  const next = searchParams.get('next') ?? '/';
+  // Validate `next` to prevent open redirect: only allow relative paths starting with a
+  // single `/` (e.g. "/dashboard"). Reject protocol-relative (`//`) or absolute URLs.
+  const rawNext = searchParams.get('next') ?? '/';
+  const next = /^\/(?!\/)/.test(rawNext) ? rawNext : '/';
 
   if (code) {
     const response = NextResponse.redirect(`${origin}${next}`);


### PR DESCRIPTION
## Summary
- **Severity:** High (CWE-601 — Open Redirect)
- **File:** `src/app/api/auth/callback/route.ts`

## Problem
The `next` query parameter was passed directly into `NextResponse.redirect()` without validation. An attacker could craft a link like `/api/auth/callback?code=X&next=//evil.com/phish` which, after a successful auth exchange, redirects the user to an external site.

## Fix
Reject any `next` value that does not start with a single `/` (protocol-relative and absolute URLs fall back to `/`):
```ts
const rawNext = searchParams.get('next') ?? '/';
const next = /^\/(?!\/)/.test(rawNext) ? rawNext : '/';
```

🤖 Generated by error-log-monitor