### PR TITLE
fix(api): guard request body parsing against malformed input

### DIFF
--- a/src/app/api/docs/upload/route.ts
+++ b/src/app/api/docs/upload/route.ts
@@ -35,7 +35,12 @@ export async function POST(req: NextRequest) {
   const admin = await getAdminUser();
   if (!admin) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
 
-  const formData = await req.formData();
+  let formData: FormData;
+  try {
+    formData = await req.formData();
+  } catch {
+    return NextResponse.json({ error: 'Invalid multipart form data' }, { status: 400 });
+  }
   const file = formData.get('file') as File | null;
 
   if (!file) return NextResponse.json({ error: 'No file provided' }, { status: 400 });

--- a/src/app/api/invite/route.ts
+++ b/src/app/api/invite/route.ts
@@ -69,13 +69,13 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Admin only' }, { status: 403 });
   }
 
-  const body = await request.json();
-  const { email: rawEmail, department, isContractor, isInvestor } = body as {
-    email: string;
-    department: string;
-    isContractor: boolean;
-    isInvestor?: boolean;
-  };
+  let body: { email: string; department: string; isContractor: boolean; isInvestor?: boolean };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+  const { email: rawEmail, department, isContractor, isInvestor } = body;
 
   const email = typeof rawEmail === 'string' ? rawEmail.trim() : '';
   if (!email || !EMAIL_REGEX.test(email)) {

--- a/src/app/api/tasks/[id]/comments/attachments/route.ts
+++ b/src/app/api/tasks/[id]/comments/attachments/route.ts
@@ -33,7 +33,12 @@ export async function POST(
 
   const { id: taskId } = await params;
 
-  const formData = await req.formData();
+  let formData: FormData;
+  try {
+    formData = await req.formData();
+  } catch {
+    return NextResponse.json({ error: 'Invalid multipart form data' }, { status: 400 });
+  }
   const file = formData.get('file') as File | null;
   const commentId = formData.get('comment_id') as string | null;
 

--- a/src/app/api/tasks/[id]/deliverables/route.ts
+++ b/src/app/api/tasks/[id]/deliverables/route.ts
@@ -90,7 +90,12 @@ export async function POST(
     return NextResponse.json({ error: 'Only the assignee or an admin can upload deliverables for this task' }, { status: 403 });
   }
 
-  const formData = await req.formData();
+  let formData: FormData;
+  try {
+    formData = await req.formData();
+  } catch {
+    return NextResponse.json({ error: 'Invalid multipart form data' }, { status: 400 });
+  }
   const file = formData.get('file') as File | null;
   if (!file) return NextResponse.json({ error: 'No file provided' }, { status: 400 });
   if (file.size > MAX_FILE_SIZE) {


### PR DESCRIPTION
## Summary
- **Severity:** High (invite route) / Medium (upload routes)
- **Files changed:** 4

## Problems

### 1. Unhandled `request.json()` in `/api/invite` (High)
Sending a non-JSON body (or a request with the wrong Content-Type) caused an unhandled exception and a 500 response.

### 2. Unhandled `req.formData()` in upload routes (Medium)
Three file-upload routes called `req.formData()` without error handling:
- `/api/tasks/[id]/comments/attachments`
- `/api/tasks/[id]/deliverables`
- `/api/docs/upload`

Sending a non-multipart request caused an unhandled exception and a 500 response.

## Fix
Each call is now wrapped in a `try/catch` that returns `400 Bad Request` with a descriptive message instead of propagating the parse error.

🤖 Generated by error-log-monitor