### PR TITLE
fix(attachments): extend signed URL expiry from 1 hour to 1 year

### DIFF
--- a/src/app/api/tasks/[id]/comments/attachments/route.ts
+++ b/src/app/api/tasks/[id]/comments/attachments/route.ts
@@ -5,7 +5,10 @@ import { cookies } from 'next/headers';
 
 const BUCKET = 'chat-attachments';
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
-const SIGNED_URL_EXPIRY_SEC = 3600; // 1 hour
+// Use 1 year expiry so stored file_url values don't go stale in the DB.
+// The frontend reads file_url directly from task_comment_attachments via Supabase query,
+// so a short expiry causes all attachment links to break after the signed URL expires.
+const SIGNED_URL_EXPIRY_SEC = 365 * 24 * 60 * 60; // 1 year
 
 async function getSupabaseAndUser() {
   const cookieStore = await cookies();


### PR DESCRIPTION
## Problem

Chat attachments store a signed URL in the `task_comment_attachments.file_url` column. The frontend reads this column directly via Supabase realtime query in `TaskDetail.tsx` — it does **not** hit an API endpoint that could regenerate the URL on demand.

With `SIGNED_URL_EXPIRY_SEC = 3600` (1 hour), every attachment link permanently breaks one hour after upload. Users see broken images/files in chat history.

## Fix

Increase `SIGNED_URL_EXPIRY_SEC` to `365 * 24 * 60 * 60` (1 year) so stored URLs remain valid long-term.

## Notes

- The deliverables route is **not** affected — its `GET` handler regenerates signed URLs from `storage_path` on every request and never stores the URL in the DB.
- A proper architectural fix would add a server-side endpoint to regenerate URLs from `storage_path` on read, eliminating reliance on stored signed URLs entirely. That change requires a frontend update and is tracked as a follow-up.
- TypeScript passes clean (`tsc --noEmit` exit 0).

**Severity:** Medium — all previously uploaded chat attachments have broken links after 1 hour.