### PR TITLE
fix(deliverables): extend signed URL expiry from 1 hour to 1 year

### DIFF
--- a/src/app/api/tasks/[id]/deliverables/route.ts
+++ b/src/app/api/tasks/[id]/deliverables/route.ts
@@ -6,7 +6,7 @@ import type { TaskDeliverable } from '@/lib/types';
 
 const BUCKET = 'task-deliverables';
 const MAX_FILE_SIZE = 25 * 1024 * 1024; // 25 MB
-const SIGNED_URL_EXPIRY_SEC = 3600; // 1 hour
+const SIGNED_URL_EXPIRY_SEC = 365 * 24 * 3600; // 1 year — deliverables are long-lived; 1 h caused links to expire before admins could review them
 
 async function getSupabaseAndUser() {
   const cookieStore = await cookies();


### PR DESCRIPTION
## Problem

Deliverable download links (in `/api/tasks/[id]/deliverables`) were generated with a 1-hour signed URL expiry. Because deliverables are long-lived task assets reviewed by admins, links routinely expired before anyone accessed them — resulting in broken downloads.

## Root cause

`SIGNED_URL_EXPIRY_SEC = 3600` in `src/app/api/tasks/[id]/deliverables/route.ts`

## Fix

Extended to 1 year (`365 * 24 * 3600`), matching the fix already applied to the chat-attachments route in PR #9.

## Related
- Companion fix for chat attachments: #9

---
🤖 Auto-generated by [error-log-monitor](https://github.com/hurdd-gif/seeko)