### PR TITLE
fix: type profile updates to fix TS build error on Render

### DIFF
--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -29,7 +29,7 @@ export async function PATCH(request: NextRequest) {
     return NextResponse.json({ error: 'Missing userId' }, { status: 400 });
   }
 
-  const updates: Record<string, unknown> = {};
+  const updates: { department?: string; is_contractor?: boolean } = {};
   if (department !== undefined) updates.department = department;
   if (is_contractor !== undefined) updates.is_contractor = is_contractor;
 


### PR DESCRIPTION
## Summary
- `Record<string, unknown>` is not assignable to Supabase's typed `.update()` param
- Changed to explicit `{ department?: string; is_contractor?: boolean }` type

## Test plan
- [ ] Render build succeeds (currently failing on this TS error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)