### PR TITLE
fix: cast profile updates as never for untyped Supabase client

### DIFF
--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -41,7 +41,7 @@ export async function PATCH(request: NextRequest) {
 
   const { error } = await admin
     .from('profiles')
-    .update(updates)
+    .update(updates as never)
     .eq('id', userId);
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });


### PR DESCRIPTION
## Summary
- Previous fix (#12) used explicit types but Supabase client has no generated types for `profiles`, so `.update()` still expects `never`
- Cast as `never` to bypass — proper fix is generating Supabase types

## Test plan
- [ ] Render build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)