### PR TITLE
Mobile polish: chat UX, investor layout, haptics, status permissions

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -58,7 +58,7 @@ export default async function DashboardLayout({
           notifications={notifications}
         />
         <main className="flex-1 min-w-0 overflow-x-hidden pt-[env(safe-area-inset-top)] md:pt-0 md:overflow-auto" id="tour-main">
-          <div className="max-w-5xl mx-auto px-4 md:px-6 py-4 md:py-8 pb-[calc(6rem+env(safe-area-inset-bottom))] md:pb-8">
+          <div className="max-w-5xl mx-auto px-4 md:px-6 py-4 md:py-8 pb-24 md:pb-8">
             <PageTransition>{children}</PageTransition>
           </div>
         </main>

--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -21,6 +21,7 @@ import { EmptyState } from '@/components/ui/empty-state';
 import { AnimatedNumber } from '@/components/ui/AnimatedNumber';
 import { UpcomingTasks } from '@/components/dashboard/UpcomingTasks';
 import { DashboardAreaCard } from '@/components/dashboard/DashboardAreaCard';
+import { CollapsibleAreas } from '@/components/dashboard/CollapsibleAreas';
 import {
   CheckSquare,
   Activity,
@@ -133,10 +134,10 @@ export default async function OverviewPage() {
   const completed  = tasks.filter(t => t.status === 'Complete').length;
 
   const stats = [
-    { label: 'Open Tasks',    value: openTasks,   icon: CheckSquare, accent: true, primary: true, href: '/tasks' },
-    { label: 'Completed',     value: completed,    icon: Activity,    accent: false, primary: false },
-    { label: 'Team Members',  value: team.length, icon: Users,       accent: false, primary: false },
-    { label: 'Documents',     value: docs.length, icon: FileText,    accent: false, primary: false },
+    { label: 'Open Tasks',  value: openTasks,   icon: CheckSquare, accent: true, primary: true, href: '/tasks' },
+    { label: 'Completed',   value: completed,    icon: Activity,    accent: false, primary: false },
+    { label: 'Team',        value: team.length, icon: Users,       accent: false, primary: false },
+    { label: 'Docs',        value: docs.length, icon: FileText,    accent: false, primary: false },
   ];
 
   const upcoming = tasks
@@ -216,28 +217,6 @@ export default async function OverviewPage() {
           </StaggerItem>
         ))}
       </Stagger>
-
-      {/* ── Game Areas ──────────────────────────────────── */}
-      {areas.length > 0 && (
-        <FadeRise delay={delay(TIMING.areas)} y={SECTION.offsetY}>
-          <Card>
-            <CardHeader>
-              <div className="flex items-center gap-2">
-                <Map className="size-4 text-muted-foreground" />
-                <CardTitle className="text-xl font-semibold text-foreground">Game Areas</CardTitle>
-              </div>
-              <CardDescription className="line-clamp-1">{areasSubtitle}</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <Stagger className="grid grid-cols-1 md:grid-cols-3 gap-4" delayMs={delay(TIMING.areasInner)}>
-                {areas.map(area => (
-                  <DashboardAreaCard key={area.id} area={area} isAdmin={isAdmin} />
-                ))}
-              </Stagger>
-            </CardContent>
-          </Card>
-        </FadeRise>
-      )}
 
       {/* ── Tasks + Activity ────────────────────────────── */}
       <FadeRise delay={delay(TIMING.grid)} y={SECTION.offsetY}>
@@ -328,6 +307,35 @@ export default async function OverviewPage() {
 
         </div>
       </FadeRise>
+
+      {/* ── Game Areas — after tasks on mobile for better priority ── */}
+      {areas.length > 0 && (
+        <FadeRise delay={delay(TIMING.areas)} y={SECTION.offsetY}>
+          {/* Desktop: always expanded */}
+          <div className="hidden md:block">
+            <Card>
+              <CardHeader>
+                <div className="flex items-center gap-2">
+                  <Map className="size-4 text-muted-foreground" />
+                  <CardTitle className="text-xl font-semibold text-foreground">Game Areas</CardTitle>
+                </div>
+                <CardDescription className="line-clamp-1">{areasSubtitle}</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Stagger className="grid grid-cols-1 md:grid-cols-3 gap-4" delayMs={delay(TIMING.areasInner)}>
+                  {areas.map(area => (
+                    <DashboardAreaCard key={area.id} area={area} isAdmin={isAdmin} />
+                  ))}
+                </Stagger>
+              </CardContent>
+            </Card>
+          </div>
+          {/* Mobile: collapsible */}
+          <div className="md:hidden">
+            <CollapsibleAreas areas={areas} isAdmin={isAdmin} subtitle={areasSubtitle} />
+          </div>
+        </FadeRise>
+      )}
     </div>
   );
 }

--- a/src/app/(investor)/investor/page.tsx
+++ b/src/app/(investor)/investor/page.tsx
@@ -19,6 +19,7 @@ import { FadeRise, Stagger, StaggerItem } from '@/components/motion';
 import { EmptyState } from '@/components/ui/empty-state';
 import { Badge } from '@/components/ui/badge';
 import { InvestorAreaCard } from '@/components/dashboard/InvestorAreaCard';
+import { CollapsibleInvestorAreas } from '@/components/dashboard/CollapsibleInvestorAreas';
 import {
   CheckSquare,
   Map,
@@ -136,45 +137,134 @@ export default async function InvestorPage() {
         )}
       </FadeRise>
 
-      {/* ── Game Areas ──────────────────────────────────── */}
+      {/* ── Blocked tasks callout — early on mobile for visibility ── */}
+      {blocked > 0 && (
+        <FadeRise delay={delay(TIMING.hero + 50)}>
+          <Card className="border-red-900/40 bg-red-950/10">
+            <CardContent className="flex items-center gap-3 py-4">
+              <AlertCircle className="size-4 text-red-400 shrink-0" />
+              <p className="text-sm text-muted-foreground">
+                <span className="font-medium text-foreground">{blocked} task{blocked !== 1 ? 's' : ''} blocked.</span>
+                {' '}The team is actively working to unblock progress.
+              </p>
+            </CardContent>
+          </Card>
+        </FadeRise>
+      )}
+
+      {/* ── Overdue tasks callout ───────────────────────── */}
+      {overdueCount > 0 && (
+        <FadeRise delay={delay(TIMING.hero + (blocked > 0 ? 100 : 50))}>
+          <Card className="border-amber-900/40 bg-amber-950/10">
+            <CardContent className="flex items-center gap-3 py-4">
+              <AlertCircle className="size-4 text-amber-400 shrink-0" />
+              <p className="text-sm text-muted-foreground">
+                <span className="font-medium text-foreground">{overdueCount} task{overdueCount !== 1 ? 's' : ''} past due.</span>
+                {' '}The team is reprioritising and updating deadlines.
+              </p>
+            </CardContent>
+          </Card>
+        </FadeRise>
+      )}
+
+      {/* ── This Week — promoted above areas on mobile ──── */}
       <FadeRise delay={delay(TIMING.areas)}>
-        <Card>
-          <CardHeader>
-            <div className="flex items-center gap-2">
-              <Map className="size-4 text-muted-foreground" />
-              <CardTitle className="text-xl font-semibold text-foreground">Game Areas</CardTitle>
-            </div>
-            <CardDescription className="line-clamp-1">
-              {areas.length > 0 ? areasSubtitle : 'Progress by area.'}
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            {areas.length === 0 ? (
+        <div className="md:hidden">
+          <Card>
+            <CardHeader>
+              <div className="flex items-center gap-2">
+                <TrendingUp className="size-4 text-muted-foreground" />
+                <CardTitle className="text-xl font-semibold text-foreground">This Week</CardTitle>
+              </div>
+              <CardDescription>Summary of the last 7 days.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {updates.length === 0 ? (
+                <EmptyState
+                  icon="TrendingUp"
+                  title="No updates yet"
+                  description="Activity from the past week will be summarised here."
+                />
+              ) : (
+                <ul className="flex flex-col gap-3">
+                  {updates.map((bullet, i) => (
+                    <li key={i} className="flex items-start gap-2.5">
+                      <span
+                        className="mt-1.5 h-1.5 w-1.5 rounded-full shrink-0"
+                        style={{ backgroundColor: 'var(--color-seeko-accent)' }}
+                        aria-hidden
+                      />
+                      <span className="text-sm text-muted-foreground">{bullet}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </FadeRise>
+
+      {/* ── Game Areas ──────────────────────────────────── */}
+      <FadeRise delay={delay(TIMING.areas + 50)}>
+        {areas.length === 0 ? (
+          <Card>
+            <CardHeader>
+              <div className="flex items-center gap-2">
+                <Map className="size-4 text-muted-foreground" />
+                <CardTitle className="text-xl font-semibold text-foreground">Game Areas</CardTitle>
+              </div>
+              <CardDescription>Progress by area.</CardDescription>
+            </CardHeader>
+            <CardContent>
               <EmptyState
                 icon="Map"
                 title="No game areas yet"
                 description="Areas will appear here when the team adds them."
               />
-            ) : (
-              <Stagger
-                className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"
-                delayMs={delay(TIMING.areasStaggerDelayMs)}
-                staggerMs={0.08}
-              >
-                {areas.map(area => (
-                  <InvestorAreaCard
-                    key={area.id}
-                    area={area}
-                    tasksInArea={tasks.filter(t => t.area_id === area.id)}
-                  />
-                ))}
-              </Stagger>
-            )}
-          </CardContent>
-        </Card>
+            </CardContent>
+          </Card>
+        ) : (
+          <>
+            {/* Desktop: always expanded */}
+            <div className="hidden md:block">
+              <Card>
+                <CardHeader>
+                  <div className="flex items-center gap-2">
+                    <Map className="size-4 text-muted-foreground" />
+                    <CardTitle className="text-xl font-semibold text-foreground">Game Areas</CardTitle>
+                  </div>
+                  <CardDescription className="line-clamp-1">{areasSubtitle}</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <Stagger
+                    className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"
+                    delayMs={delay(TIMING.areasStaggerDelayMs)}
+                    staggerMs={0.08}
+                  >
+                    {areas.map(area => (
+                      <InvestorAreaCard
+                        key={area.id}
+                        area={area}
+                        tasksInArea={tasks.filter(t => t.area_id === area.id)}
+                      />
+                    ))}
+                  </Stagger>
+                </CardContent>
+              </Card>
+            </div>
+            {/* Mobile: collapsible */}
+            <div className="md:hidden">
+              <CollapsibleInvestorAreas
+                areas={areas}
+                tasks={tasks as TaskWithAssignee[]}
+                subtitle={areasSubtitle}
+              />
+            </div>
+          </>
+        )}
       </FadeRise>
 
-      {/* ── Recent Tasks + Updates ─────────────────────────── */}
+      {/* ── Recent Tasks + Updates (desktop grid) ────────── */}
       <FadeRise delay={delay(TIMING.grid)}>
         <div className="grid grid-cols-1 gap-6 md:grid-cols-5">
 
@@ -202,11 +292,33 @@ export default async function InvestorPage() {
                 >
                   {(tasks as TaskWithAssignee[])
                     .slice(0, 15)
-                    .map((task, i) => (
-                      <StaggerItem key={task.id} className="flex gap-3 py-4 border-b border-border last:border-0 last:pb-0">
-                        <div className="flex flex-1 min-w-0 flex-col gap-0.5">
-                          <p className="text-sm font-medium text-foreground truncate">{task.name}</p>
-                          <div className="flex items-center gap-2 flex-nowrap overflow-hidden">
+                    .map((task) => (
+                      <StaggerItem key={task.id}>
+                        {/* Desktop row */}
+                        <div className="hidden md:flex gap-3 py-4 border-b border-border last:border-0 last:pb-0">
+                          <div className="flex flex-1 min-w-0 flex-col gap-0.5">
+                            <p className="text-sm font-medium text-foreground truncate">{task.name}</p>
+                            <div className="flex items-center gap-2 flex-nowrap overflow-hidden">
+                              <Badge variant="outline" className="text-[11px] py-0 px-1.5 font-normal shrink-0">
+                                {task.status}
+                              </Badge>
+                              {task.assignee?.display_name && (
+                                <span className="text-xs text-muted-foreground truncate">
+                                  {task.assignee.display_name}
+                                </span>
+                              )}
+                              {task.deadline && (
+                                <span className="text-xs text-muted-foreground shrink-0">
+                                  Due {new Date(task.deadline).toLocaleDateString()}
+                                </span>
+                              )}
+                            </div>
+                          </div>
+                        </div>
+                        {/* Mobile row — stacked layout */}
+                        <div className="flex md:hidden flex-col gap-1.5 py-3.5 border-b border-border last:border-0 last:pb-0">
+                          <p className="text-sm font-medium text-foreground line-clamp-2">{task.name}</p>
+                          <div className="flex items-center gap-2">
                             <Badge variant="outline" className="text-[11px] py-0 px-1.5 font-normal shrink-0">
                               {task.status}
                             </Badge>
@@ -215,12 +327,12 @@ export default async function InvestorPage() {
                                 {task.assignee.display_name}
                               </span>
                             )}
-                            {task.deadline && (
-                              <span className="text-xs text-muted-foreground shrink-0">
-                                Due {new Date(task.deadline).toLocaleDateString()}
-                              </span>
-                            )}
                           </div>
+                          {task.deadline && (
+                            <span className="text-[11px] text-muted-foreground">
+                              Due {new Date(task.deadline).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+                            </span>
+                          )}
                         </div>
                       </StaggerItem>
                     ))}
@@ -229,8 +341,8 @@ export default async function InvestorPage() {
             </CardContent>
           </Card>
 
-          {/* Updates / Weekly Summary */}
-          <Card className="md:col-span-2">
+          {/* Updates / Weekly Summary — desktop only (mobile version is above) */}
+          <Card className="hidden md:block md:col-span-2">
             <CardHeader>
               <div className="flex items-center gap-2">
                 <TrendingUp className="size-4 text-muted-foreground" />
@@ -264,36 +376,6 @@ export default async function InvestorPage() {
 
         </div>
       </FadeRise>
-
-      {/* ── Blocked tasks callout ───────────────────────── */}
-      {blocked > 0 && (
-        <FadeRise delay={delay(TIMING.grid + 100)}>
-          <Card className="border-red-900/40 bg-red-950/10">
-            <CardContent className="flex items-center gap-3 py-4">
-              <AlertCircle className="size-4 text-red-400 shrink-0" />
-              <p className="text-sm text-muted-foreground">
-                <span className="font-medium text-foreground">{blocked} task{blocked !== 1 ? 's' : ''} blocked.</span>
-                {' '}The team is actively working to unblock progress.
-              </p>
-            </CardContent>
-          </Card>
-        </FadeRise>
-      )}
-
-      {/* ── Overdue tasks callout ───────────────────────── */}
-      {overdueCount > 0 && (
-        <FadeRise delay={delay(TIMING.grid + (blocked > 0 ? 150 : 100))}>
-          <Card className="border-amber-900/40 bg-amber-950/10">
-            <CardContent className="flex items-center gap-3 py-4">
-              <AlertCircle className="size-4 text-amber-400 shrink-0" />
-              <p className="text-sm text-muted-foreground">
-                <span className="font-medium text-foreground">{overdueCount} task{overdueCount !== 1 ? 's' : ''} past due.</span>
-                {' '}The team is reprioritising and updating deadlines.
-              </p>
-            </CardContent>
-          </Card>
-        </FadeRise>
-      )}
 
     </div>
   );

--- a/src/app/(investor)/layout.tsx
+++ b/src/app/(investor)/layout.tsx
@@ -26,7 +26,7 @@ export default async function InvestorLayout({
         isAdmin={profile?.is_admin ?? false}
       />
         <main className="flex-1 min-w-0 overflow-x-hidden pt-[env(safe-area-inset-top)] md:pt-0 md:overflow-auto">
-          <div className="max-w-5xl mx-auto px-4 md:px-6 py-4 md:py-8 pb-[calc(6rem+env(safe-area-inset-bottom))] md:pb-8">
+          <div className="max-w-5xl mx-auto px-4 md:px-6 py-4 md:py-8 pb-24 md:pb-8">
             {children}
           </div>
         </main>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -275,6 +275,11 @@ html {
   backface-visibility: hidden;
 }
 
+/* Hide mobile bottom nav when a full-screen modal is open */
+:root[data-modal-open] .mobile-bottom-nav {
+  display: none !important;
+}
+
 /* Kill paragraph margin inside table cells so rows aren't bloated */
 .doc-content td p,
 .doc-content th p,

--- a/src/components/HapticsProvider.tsx
+++ b/src/components/HapticsProvider.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import { createContext, useContext, useEffect, type ReactNode } from 'react';
+import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react';
 import { useWebHaptics } from 'web-haptics/react';
+
+const STORAGE_KEY = 'seeko-haptics-enabled';
 
 export type HapticPreset =
   | 'success'
@@ -18,6 +20,8 @@ export type HapticPreset =
 
 type HapticsContextValue = {
   trigger: (preset: HapticPreset) => void;
+  enabled: boolean;
+  setEnabled: (enabled: boolean) => void;
 };
 
 const HapticsContext = createContext<HapticsContextValue | null>(null);
@@ -43,20 +47,47 @@ function isInteractiveTarget(el: EventTarget | null): el is HTMLElement {
   return false;
 }
 
+function readStoredEnabled(): boolean {
+  if (typeof window === 'undefined') return true;
+  try {
+    const val = localStorage.getItem(STORAGE_KEY);
+    return val === null ? true : val === 'true';
+  } catch {
+    return true;
+  }
+}
+
 export function HapticsProvider({ children }: { children: ReactNode }) {
-  const { trigger } = useWebHaptics();
+  const { trigger: rawTrigger } = useWebHaptics();
+  const [enabled, setEnabledState] = useState(true);
 
   useEffect(() => {
-    if (!isMobile()) return;
+    setEnabledState(readStoredEnabled());
+  }, []);
+
+  const setEnabled = useCallback((value: boolean) => {
+    setEnabledState(value);
+    try {
+      localStorage.setItem(STORAGE_KEY, String(value));
+    } catch { /* ignore */ }
+  }, []);
+
+  const trigger = useCallback((preset: HapticPreset) => {
+    if (!enabled) return;
+    rawTrigger(preset);
+  }, [enabled, rawTrigger]);
+
+  useEffect(() => {
+    if (!isMobile() || !enabled) return;
     const onTap = (e: Event) => {
-      if (isInteractiveTarget(e.target)) trigger('selection');
+      if (isInteractiveTarget(e.target)) rawTrigger('selection');
     };
     document.addEventListener('click', onTap, true);
     return () => document.removeEventListener('click', onTap, true);
-  }, [trigger]);
+  }, [rawTrigger, enabled]);
 
   return (
-    <HapticsContext.Provider value={{ trigger }}>
+    <HapticsContext.Provider value={{ trigger, enabled, setEnabled }}>
       {children}
     </HapticsContext.Provider>
   );
@@ -67,6 +98,8 @@ export function useHaptics(): HapticsContextValue {
   if (!ctx) {
     return {
       trigger: () => {},
+      enabled: true,
+      setEnabled: () => {},
     };
   }
   return ctx;

--- a/src/components/dashboard/CollapsibleAreas.tsx
+++ b/src/components/dashboard/CollapsibleAreas.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useState } from 'react';
+import { motion, AnimatePresence } from 'motion/react';
+import { ChevronDown, Map } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { DashboardAreaCard } from '@/components/dashboard/DashboardAreaCard';
+import { Stagger } from '@/components/motion';
+import type { Area } from '@/lib/types';
+
+interface CollapsibleAreasProps {
+  areas: Area[];
+  isAdmin: boolean;
+  subtitle: string;
+}
+
+export function CollapsibleAreas({ areas, isAdmin, subtitle }: CollapsibleAreasProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Card>
+      <button
+        onClick={() => setOpen(prev => !prev)}
+        className="w-full text-left"
+      >
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Map className="size-4 text-muted-foreground" />
+              <CardTitle className="text-xl font-semibold text-foreground">Game Areas</CardTitle>
+            </div>
+            <motion.div
+              animate={{ rotate: open ? 180 : 0 }}
+              transition={{ type: 'spring', stiffness: 300, damping: 25 }}
+            >
+              <ChevronDown className="size-4 text-muted-foreground" />
+            </motion.div>
+          </div>
+          <CardDescription className="line-clamp-1">{subtitle}</CardDescription>
+        </CardHeader>
+      </button>
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ type: 'spring', stiffness: 300, damping: 28 }}
+            className="overflow-hidden"
+          >
+            <CardContent>
+              <Stagger className="grid grid-cols-1 gap-4" delayMs={0.05}>
+                {areas.map(area => (
+                  <DashboardAreaCard key={area.id} area={area} isAdmin={isAdmin} />
+                ))}
+              </Stagger>
+            </CardContent>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </Card>
+  );
+}

--- a/src/components/dashboard/CollapsibleInvestorAreas.tsx
+++ b/src/components/dashboard/CollapsibleInvestorAreas.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useState } from 'react';
+import { motion, AnimatePresence } from 'motion/react';
+import { ChevronDown, Map } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { InvestorAreaCard } from '@/components/dashboard/InvestorAreaCard';
+import { Stagger } from '@/components/motion';
+import type { Area, TaskWithAssignee } from '@/lib/types';
+
+interface CollapsibleInvestorAreasProps {
+  areas: Area[];
+  tasks: TaskWithAssignee[];
+  subtitle: string;
+}
+
+export function CollapsibleInvestorAreas({ areas, tasks, subtitle }: CollapsibleInvestorAreasProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Card>
+      <button
+        onClick={() => setOpen(prev => !prev)}
+        className="w-full text-left"
+      >
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Map className="size-4 text-muted-foreground" />
+              <CardTitle className="text-xl font-semibold text-foreground">Game Areas</CardTitle>
+            </div>
+            <motion.div
+              animate={{ rotate: open ? 180 : 0 }}
+              transition={{ type: 'spring', stiffness: 300, damping: 25 }}
+            >
+              <ChevronDown className="size-4 text-muted-foreground" />
+            </motion.div>
+          </div>
+          <CardDescription className="line-clamp-1">{subtitle}</CardDescription>
+        </CardHeader>
+      </button>
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ type: 'spring', stiffness: 300, damping: 28 }}
+            className="overflow-hidden"
+          >
+            <CardContent>
+              <Stagger className="grid grid-cols-1 gap-4" delayMs={0.05}>
+                {areas.map(area => (
+                  <InvestorAreaCard
+                    key={area.id}
+                    area={area}
+                    tasksInArea={tasks.filter(t => t.area_id === area.id)}
+                  />
+                ))}
+              </Stagger>
+            </CardContent>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </Card>
+  );
+}

--- a/src/components/dashboard/PaymentCreateDialog.tsx
+++ b/src/components/dashboard/PaymentCreateDialog.tsx
@@ -9,6 +9,7 @@ import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
 import { Select } from '@/components/ui/select';
 import { toast } from 'sonner';
 import type { Profile } from '@/lib/types';
+import { uuid } from '@/lib/utils';
 
 type TeamMember = Profile & { paypal_email?: string };
 
@@ -41,7 +42,7 @@ export function PaymentCreateDialog({
   onCreated,
 }: PaymentCreateDialogProps) {
   const [recipient, setRecipient] = useState<TeamMember | null>(initialRecipient);
-  const [items, setItems] = useState<LineItem[]>([{ id: crypto.randomUUID(), label: '', amount: '' }]);
+  const [items, setItems] = useState<LineItem[]>([{ id: uuid(), label: '', amount: '' }]);
   const [saving, setSaving] = useState(false);
   const [success, setSuccess] = useState(false);
   const [copied, setCopied] = useState(false);
@@ -52,7 +53,7 @@ export function PaymentCreateDialog({
 
   useEffect(() => {
     if (open) {
-      setItems([{ id: crypto.randomUUID(), label: '', amount: '' }]);
+      setItems([{ id: uuid(), label: '', amount: '' }]);
       setSaving(false);
       setSuccess(false);
       setCopied(false);
@@ -62,7 +63,7 @@ export function PaymentCreateDialog({
   const total = items.reduce((sum, i) => sum + (parseFloat(i.amount) || 0), 0);
 
   function addItem() {
-    setItems(prev => [...prev, { id: crypto.randomUUID(), label: '', amount: '' }]);
+    setItems(prev => [...prev, { id: uuid(), label: '', amount: '' }]);
   }
 
   function removeItem(id: string) {
@@ -88,7 +89,7 @@ export function PaymentCreateDialog({
 
   function handleClose() {
     setRecipient(initialRecipient);
-    setItems([{ id: crypto.randomUUID(), label: '', amount: '' }]);
+    setItems([{ id: uuid(), label: '', amount: '' }]);
     setSaving(false);
     setSuccess(false);
     setCopied(false);

--- a/src/components/dashboard/SettingsPanel.tsx
+++ b/src/components/dashboard/SettingsPanel.tsx
@@ -12,7 +12,7 @@ import { Select } from '@/components/ui/select';
 import { Separator } from '@/components/ui/separator';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
-import { Camera, Check, Eye, MousePointer, Monitor, UserX, AlertTriangle, RotateCcw, DollarSign } from 'lucide-react';
+import { Camera, Check, Eye, MousePointer, Monitor, UserX, AlertTriangle, RotateCcw, DollarSign, Vibrate } from 'lucide-react';
 import { toast } from 'sonner';
 import { Profile, UserEvent, Task, Payment } from '@/lib/types';
 import { useHaptics } from '@/components/HapticsProvider';
@@ -20,6 +20,7 @@ import { useTour } from '@/components/ui/tour';
 import { PaymentRequestDialog } from '@/components/dashboard/PaymentRequestDialog';
 import { formatCurrency } from '@/lib/format';
 import { cn } from '@/lib/utils';
+import { Switch } from '@/components/ui/switch';
 
 const COMMON_TIMEZONES = [
   'America/New_York', 'America/Chicago', 'America/Denver', 'America/Los_Angeles',
@@ -350,6 +351,8 @@ export function SettingsPanel({ profile, isAdmin, team, revalidate, completedTas
 
       <ReplayTourCard userId={profile.id} />
 
+      <HapticsToggleCard />
+
       {!profile.is_investor && (
         <Card>
           <CardHeader>
@@ -675,5 +678,34 @@ function ReplayTourCard({ userId }: { userId: string }) {
         </div>
       </CardHeader>
     </Card>
+  );
+}
+
+function HapticsToggleCard() {
+  const { enabled, setEnabled, trigger } = useHaptics();
+
+  return (
+    <div className="md:hidden">
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Vibrate className="size-4 text-muted-foreground" />
+              <div>
+                <CardTitle>Haptic Feedback</CardTitle>
+                <CardDescription>Vibration feedback on taps and actions.</CardDescription>
+              </div>
+            </div>
+            <Switch
+              checked={enabled}
+              onCheckedChange={(v) => {
+                setEnabled(v);
+                if (v) trigger('success');
+              }}
+            />
+          </div>
+        </CardHeader>
+      </Card>
+    </div>
   );
 }

--- a/src/components/dashboard/TaskDetail.tsx
+++ b/src/components/dashboard/TaskDetail.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import { createPortal } from 'react-dom';
 import { createBrowserClient } from '@supabase/ssr';
 import { motion, AnimatePresence, LayoutGroup } from 'motion/react';
 import {
@@ -28,7 +29,7 @@ import { toast } from 'sonner';
 import { Dialog, DialogHeader, DialogTitle, DialogClose } from '@/components/ui/dialog';
 import { HandoffDialog } from './HandoffDialog';
 import { Badge } from '@/components/ui/badge';
-import { cn } from '@/lib/utils';
+import { cn, uuid } from '@/lib/utils';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
@@ -121,6 +122,45 @@ function renderContent(text: string, teamNames: string[], docTitles: string[]): 
   });
 }
 
+function useLongPress(callback: () => void, ms = 400) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const firedRef = useRef(false);
+
+  const start = useCallback((e: React.TouchEvent) => {
+    firedRef.current = false;
+    timerRef.current = setTimeout(() => {
+      firedRef.current = true;
+      callback();
+    }, ms);
+  }, [callback, ms]);
+
+  const cancel = useCallback(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = null;
+  }, []);
+
+  const end = useCallback((e: React.TouchEvent) => {
+    cancel();
+    // If the long-press fired, swallow the touchend to prevent ghost taps
+    if (firedRef.current) {
+      e.preventDefault();
+    }
+  }, [cancel]);
+
+  const preventContext = useCallback((e: React.SyntheticEvent) => {
+    // Prevent native iOS context menu from appearing
+    e.preventDefault();
+  }, []);
+
+  return {
+    onTouchStart: start,
+    onTouchEnd: end,
+    onTouchMove: cancel,
+    onTouchCancel: cancel,
+    onContextMenu: preventContext,
+  };
+}
+
 function CommentItem({
   comment,
   isOwn,
@@ -155,6 +195,9 @@ function CommentItem({
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [showReactionPicker, setShowReactionPicker] = useState(false);
   const reactionPickerRef = useRef<HTMLDivElement>(null);
+  const [mobileActions, setMobileActions] = useState(false);
+
+  const longPress = useLongPress(useCallback(() => setMobileActions(true), []));
 
   const [lightbox, setLightbox] = useState<{ url: string; name: string; type: string } | null>(null);
 
@@ -209,7 +252,9 @@ function CommentItem({
       }}
       exit={{ opacity: 0, height: 0, marginBottom: 0 }}
       transition={{ duration: isHighlighted ? 2 : 0.15, backgroundColor: { duration: 2, delay: 0.5 } }}
-      className={cn('group relative flex gap-3 rounded-md px-2 -mx-2', isGrouped ? 'py-0 mt-0.5 pl-[44px]' : 'py-1 mt-3 first:mt-0')}
+      className={cn('group relative flex gap-3 rounded-md px-2 -mx-2 md:select-auto select-none [&_*]:select-none md:[&_*]:select-auto', isGrouped ? 'py-0 mt-0.5 pl-[44px]' : 'py-1 mt-3 first:mt-0')}
+      style={{ WebkitTouchCallout: 'none', WebkitUserSelect: 'none' } as React.CSSProperties}
+      {...longPress}
     >
       {!isGrouped && (
         <Avatar className="size-8 shrink-0 mt-0.5">
@@ -444,7 +489,7 @@ function CommentItem({
             <div className="relative" ref={reactionPickerRef}>
               <button
                 onClick={() => setShowReactionPicker(v => !v)}
-                className="inline-flex items-center justify-center size-6 rounded-full border border-transparent text-muted-foreground/40 opacity-0 group-hover:opacity-100 hover:border-border hover:text-muted-foreground transition-all text-xs"
+                className="inline-flex items-center justify-center size-6 rounded-full border border-transparent text-muted-foreground/40 md:opacity-0 md:group-hover:opacity-100 hover:border-border hover:text-muted-foreground transition-all text-xs"
               >
                 +
               </button>
@@ -474,9 +519,9 @@ function CommentItem({
         )}
       </div>
 
-      {/* Hover actions — overlay top-right of message row */}
+      {/* Hover actions — desktop only, overlay top-right of message row */}
       {!editing && !confirmingDelete && (
-        <div className="absolute top-0.5 right-1 flex items-center gap-0.5 rounded-md border border-border bg-card px-0.5 py-0.5 opacity-0 group-hover:opacity-100 transition-opacity z-10 shadow-sm">
+        <div className="absolute top-0.5 right-1 hidden md:flex items-center gap-0.5 rounded-md border border-border bg-card px-0.5 py-0.5 opacity-0 group-hover:opacity-100 transition-opacity z-10 shadow-sm">
           <button onClick={() => onReply(comment)} className="rounded p-1 text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors" title="Reply"><Reply className="size-3" /></button>
           {isOwn && (
             <>
@@ -485,6 +530,76 @@ function CommentItem({
             </>
           )}
         </div>
+      )}
+
+      {/* Mobile action sheet — triggered by long-press, portaled to body */}
+      {typeof document !== 'undefined' && createPortal(
+        <AnimatePresence>
+          {mobileActions && (
+            <motion.div
+              className="fixed inset-0 z-[100] flex items-end justify-center md:hidden"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.15 }}
+            >
+              <div className="absolute inset-0 bg-black/50" onClick={() => setMobileActions(false)} />
+              <motion.div
+                initial={{ y: '100%' }}
+                animate={{ y: 0 }}
+                exit={{ y: '100%' }}
+                transition={{ type: 'spring', stiffness: 400, damping: 34 }}
+                className="relative w-full max-w-md rounded-t-2xl border-t border-border bg-card pb-[env(safe-area-inset-bottom)]"
+              >
+                <div className="flex justify-center pt-3 pb-1">
+                  <div className="h-1 w-10 rounded-full bg-muted-foreground/20" />
+                </div>
+                {/* Quick reactions */}
+                <div className="flex justify-center gap-2 px-4 py-3">
+                  {REACTION_EMOJIS.map(emoji => (
+                    <button
+                      key={emoji}
+                      onClick={() => { onReact(comment.id, emoji); setMobileActions(false); }}
+                      className="flex items-center justify-center size-10 rounded-full bg-muted/60 text-base active:scale-90 transition-transform"
+                    >
+                      {emoji}
+                    </button>
+                  ))}
+                </div>
+                <div className="border-t border-border mx-4" />
+                {/* Actions */}
+                <div className="flex flex-col py-2 px-2">
+                  <button
+                    onClick={() => { onReply(comment); setMobileActions(false); }}
+                    className="flex items-center gap-3 rounded-lg px-4 py-3 text-sm text-foreground active:bg-muted/60 transition-colors"
+                  >
+                    <Reply className="size-4 text-muted-foreground" />
+                    Reply
+                  </button>
+                  {isOwn && (
+                    <>
+                      <button
+                        onClick={() => { setEditText(comment.content); setEditing(true); setMobileActions(false); }}
+                        className="flex items-center gap-3 rounded-lg px-4 py-3 text-sm text-foreground active:bg-muted/60 transition-colors"
+                      >
+                        <Pencil className="size-4 text-muted-foreground" />
+                        Edit
+                      </button>
+                      <button
+                        onClick={() => { setConfirmingDelete(true); setMobileActions(false); }}
+                        className="flex items-center gap-3 rounded-lg px-4 py-3 text-sm text-red-400 active:bg-red-500/10 transition-colors"
+                      >
+                        <Trash2 className="size-4" />
+                        Delete
+                      </button>
+                    </>
+                  )}
+                </div>
+              </motion.div>
+            </motion.div>
+          )}
+        </AnimatePresence>,
+        document.body
       )}
     </motion.div>
   );
@@ -512,6 +627,13 @@ interface TaskDetailProps {
 
 export function TaskDetail({ task, open, onOpenChange, team, docs, currentUserId, highlightCommentId, isAdmin = false }: TaskDetailProps) {
   const isDesktop = useMediaQuery('(min-width: 768px)');
+
+  // Signal to bottom nav that a modal is open (so it can hide)
+  useEffect(() => {
+    if (!open) return;
+    document.documentElement.setAttribute('data-modal-open', '');
+    return () => document.documentElement.removeAttribute('data-modal-open');
+  }, [open]);
 
   // Escape key handler for desktop slide-out
   useEffect(() => {
@@ -722,7 +844,7 @@ export function TaskDetail({ task, open, onOpenChange, team, docs, currentUserId
     } else {
       // Add reaction (optimistic)
       const optimistic: TaskCommentReaction = {
-        id: crypto.randomUUID(),
+        id: uuid(),
         comment_id: commentId,
         user_id: currentUserId,
         emoji,
@@ -753,6 +875,7 @@ export function TaskDetail({ task, open, onOpenChange, team, docs, currentUserId
     const q = autocompleteQuery.toLowerCase();
     if (autocompleteMode === 'slash') {
       return SLASH_COMMANDS
+        .filter(c => isAdmin || c.cmd !== '/blocked')
         .filter(c => c.label.toLowerCase().includes(q) || c.cmd.toLowerCase().includes('/' + q))
         .map(c => ({ id: c.cmd, label: c.label, icon: 'slash' as const, cmd: c.cmd, slashIcon: c.icon, slashClassName: c.className }));
     }
@@ -842,7 +965,8 @@ export function TaskDetail({ task, open, onOpenChange, team, docs, currentUserId
   }
 
   const handleSlashCommand = useCallback(async (command: string): Promise<boolean> => {
-    if (!isAdmin) return false;
+    const canChangeStatus = isAdmin || task.assignee_id === currentUserId;
+    if (!canChangeStatus) return false;
     const cmd = command.toLowerCase().trim();
     const statusMap: Record<string, string> = {
       '/complete': 'Complete',
@@ -856,10 +980,11 @@ export function TaskDetail({ task, open, onOpenChange, team, docs, currentUserId
     };
     const newStatus = statusMap[cmd];
     if (!newStatus) return false;
+    if (newStatus === 'Blocked' && !isAdmin) return false;
     await supabase.from('tasks').update({ status: newStatus }).eq('id', task.id);
     toast.success(`Status changed to ${newStatus}`);
     return true;
-  }, [isAdmin, task.id, supabase]);
+  }, [isAdmin, task.id, task.assignee_id, currentUserId, supabase]);
 
   const handleSend = useCallback(async () => {
     if ((!input.trim() && pendingFiles.length === 0) || sending) return;
@@ -877,7 +1002,7 @@ export function TaskDetail({ task, open, onOpenChange, team, docs, currentUserId
 
     const currentProfile = team.find(m => m.id === currentUserId);
     const optimistic: TaskComment = {
-      id: crypto.randomUUID(),
+      id: uuid(),
       task_id: task.id,
       user_id: currentUserId,
       content: input.trim(),
@@ -1044,7 +1169,7 @@ export function TaskDetail({ task, open, onOpenChange, team, docs, currentUserId
                 animate={{ opacity: PANEL.backdropOpacity.open }}
                 exit={{ opacity: PANEL.backdropOpacity.closed }}
                 transition={{ duration: DURATION_BACKDROP_MS / 1000 }}
-                className="fixed inset-0 z-50"
+                className="fixed inset-0 z-[70]"
               >
                 <div
                   role="presentation"
@@ -1344,7 +1469,7 @@ export function TaskDetail({ task, open, onOpenChange, team, docs, currentUserId
         </div>
       )}
 
-      <div className="flex items-end gap-2 rounded-lg bg-muted/20 p-2">
+      <div className="flex items-end gap-2 rounded-lg bg-muted/40 md:bg-muted/20 border border-border/50 md:border-transparent p-2">
         <textarea
           ref={inputRef}
           value={input}
@@ -1352,8 +1477,11 @@ export function TaskDetail({ task, open, onOpenChange, team, docs, currentUserId
           onKeyDown={handleKeyDown}
           placeholder="Write a message..."
           rows={1}
-          className="flex-1 resize-none bg-transparent text-sm text-foreground placeholder:text-muted-foreground/50 focus:outline-none min-h-[36px] max-h-[120px] py-1.5"
+          className="flex-1 resize-none bg-transparent text-[15px] md:text-sm text-foreground placeholder:text-muted-foreground/50 focus:outline-none min-h-[36px] max-h-[120px] py-1.5"
           style={{ height: 'auto', overflow: 'hidden' }}
+          onFocus={() => {
+            setTimeout(() => commentsEndRef.current?.scrollIntoView({ behavior: 'smooth' }), 300);
+          }}
           onInput={e => {
             const el = e.currentTarget;
             el.style.height = 'auto';
@@ -1361,8 +1489,8 @@ export function TaskDetail({ task, open, onOpenChange, team, docs, currentUserId
             el.style.overflow = el.scrollHeight > 120 ? 'auto' : 'hidden';
           }}
         />
-        <label className="cursor-pointer rounded p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors shrink-0">
-          <Paperclip className="size-4" />
+        <label className="cursor-pointer rounded p-2 md:p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors shrink-0">
+          <Paperclip className="size-5 md:size-4" />
           <input
             type="file"
             multiple
@@ -1376,11 +1504,11 @@ export function TaskDetail({ task, open, onOpenChange, team, docs, currentUserId
         </label>
         <Button
           size="icon"
-          className={cn('size-8 shrink-0 transition-colors', (input.trim() || pendingFiles.length > 0) && !sending ? 'bg-seeko-accent text-black hover:bg-seeko-accent/90' : '')}
+          className={cn('size-10 md:size-8 shrink-0 transition-colors rounded-full md:rounded-md', (input.trim() || pendingFiles.length > 0) && !sending ? 'bg-seeko-accent text-black hover:bg-seeko-accent/90' : '')}
           onClick={handleSend}
           disabled={!input.trim() && pendingFiles.length === 0 || sending}
         >
-          <Send className="size-3.5" />
+          <Send className="size-4 md:size-3.5" />
         </Button>
       </div>
     </div>
@@ -1388,7 +1516,7 @@ export function TaskDetail({ task, open, onOpenChange, team, docs, currentUserId
 
   const tabBar = (
     <LayoutGroup>
-      <div className="flex gap-1 px-6 py-1.5 shrink-0 border-b border-border">
+      <div className="flex gap-1 px-4 md:px-6 py-1.5 shrink-0 border-b border-border">
         <button
           className={cn(
             'relative rounded-lg px-4 py-1.5 text-sm font-medium transition-colors',
@@ -1432,7 +1560,7 @@ export function TaskDetail({ task, open, onOpenChange, team, docs, currentUserId
         {open && (
           /* Centered card modal */
           <motion.div
-            className="fixed inset-0 z-50 flex items-center justify-center p-4"
+            className="fixed inset-0 z-[60] flex items-end md:items-center justify-center p-0 md:p-4"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
@@ -1443,14 +1571,14 @@ export function TaskDetail({ task, open, onOpenChange, team, docs, currentUserId
               onClick={() => onOpenChange(false)}
             />
             <motion.div
-              className="relative w-full rounded-xl border border-border bg-card shadow-2xl flex flex-col overflow-hidden"
+              className="relative w-full rounded-t-2xl md:rounded-xl border border-border bg-card shadow-2xl flex flex-col overflow-hidden"
               initial={{ opacity: 0, scale: 0.95, y: 10, maxWidth: 576, maxHeight: '70vh' }}
               animate={{
                 opacity: 1,
                 scale: 1,
                 y: 0,
                 maxWidth: activeTab === 'chat' ? 820 : 576,
-                maxHeight: activeTab === 'chat' ? '92vh' : '70vh',
+                maxHeight: activeTab === 'chat' ? '95dvh' : '75vh',
               }}
               exit={{ opacity: 0, scale: 0.97, y: 8 }}
               transition={{
@@ -1458,8 +1586,12 @@ export function TaskDetail({ task, open, onOpenChange, team, docs, currentUserId
                 opacity: { duration: 0.12 },
               }}
             >
+              {/* Drag handle — mobile only */}
+              <div className="flex justify-center pt-2.5 pb-0 md:hidden">
+                <div className="h-1 w-10 rounded-full bg-muted-foreground/20" />
+              </div>
               {/* Header */}
-              <div className="flex items-start gap-3 px-6 pt-5 pb-3 shrink-0">
+              <div className="flex items-start gap-3 px-4 md:px-6 pt-3 md:pt-5 pb-3 shrink-0">
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2.5">
                     <h2 className="text-xl font-semibold text-foreground truncate">{task.name}</h2>
@@ -1496,7 +1628,7 @@ export function TaskDetail({ task, open, onOpenChange, team, docs, currentUserId
               {/* Tab content */}
               <AnimatePresence mode="wait" initial={false}>
                 {activeTab === 'details' && (
-                  <motion.div key="details" className="flex-1 overflow-y-auto px-6 py-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden" initial={{ opacity: 0, y: 6 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -6 }} transition={{ type: 'spring', stiffness: 500, damping: 35, opacity: { duration: 0.12 } }}>
+                  <motion.div key="details" className="flex-1 overflow-y-auto px-4 md:px-6 py-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden" initial={{ opacity: 0, y: 6 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -6 }} transition={{ type: 'spring', stiffness: 500, damping: 35, opacity: { duration: 0.12 } }}>
                     {detailsContent}
                   </motion.div>
                 )}
@@ -1519,10 +1651,10 @@ export function TaskDetail({ task, open, onOpenChange, team, docs, currentUserId
                       if (files.length > 0) setPendingFiles(prev => [...prev, ...files]);
                     }}
                   >
-                    <div className="flex-1 overflow-y-auto px-6 py-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                    <div className="flex-1 overflow-y-auto px-3 md:px-6 py-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
                       {chatMessages}
                     </div>
-                    <div className="shrink-0 border-t border-border px-5 py-3">
+                    <div className="shrink-0 border-t border-border px-3 md:px-5 py-3">
                       {chatCompose}
                     </div>
                   </motion.div>

--- a/src/components/dashboard/TaskList.tsx
+++ b/src/components/dashboard/TaskList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo, useCallback, useEffect } from 'react';
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { motion, AnimatePresence } from 'motion/react';
 import { createBrowserClient } from '@supabase/ssr';
@@ -16,6 +16,7 @@ import {
   UserPlus,
   Trash2,
   ArrowRightLeft,
+  X,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Task, Profile, TaskWithAssignee, TaskStatus, Department, Priority } from '@/lib/types';
@@ -339,7 +340,18 @@ export function TaskList({ tasks: initialTasks, isAdmin = false, team = [], docs
   }, [allTasks, deleted]);
 
   /* ---------------------------------------------------------------- */
-  /*  Render: task row (3-column grid)                                 */
+  /*  Status bottom sheet (mobile)                                     */
+  /* ---------------------------------------------------------------- */
+
+  const [statusSheetTask, setStatusSheetTask] = useState<Task | TaskWithAssignee | null>(null);
+
+  const openStatusSheet = useCallback((e: React.MouseEvent | React.TouchEvent, task: Task | TaskWithAssignee) => {
+    e.stopPropagation();
+    setStatusSheetTask(task);
+  }, []);
+
+  /* ---------------------------------------------------------------- */
+  /*  Render: task row — responsive (stacked on mobile)                */
   /* ---------------------------------------------------------------- */
 
   const renderTaskRow = (task: Task | TaskWithAssignee) => {
@@ -362,19 +374,18 @@ export function TaskList({ tasks: initialTasks, isAdmin = false, team = [], docs
 
     return (
       <StaggerItem key={task.id}>
+        {/* Desktop: original row layout */}
         <div
           role="button"
           tabIndex={0}
           onClick={() => setSelectedTask(task)}
           onKeyDown={e => { if (e.key === 'Enter') setSelectedTask(task); }}
-          className="flex items-center gap-4 px-4 py-3 transition-colors hover:bg-muted/50 cursor-pointer"
+          className="hidden md:flex items-center gap-4 px-4 py-3 transition-colors hover:bg-muted/50 cursor-pointer"
         >
-          {/* Task name */}
           <span className="min-w-0 flex-1 truncate text-sm text-foreground">
             {task.name}
           </span>
 
-          {/* Assignee avatar */}
           <div className="flex items-center -space-x-2 w-24 justify-center shrink-0">
             {assignee ? (
               <Avatar className="size-8 border-2 border-card">
@@ -388,7 +399,6 @@ export function TaskList({ tasks: initialTasks, isAdmin = false, team = [], docs
             )}
           </div>
 
-          {/* Status pill */}
           <div className="w-32 flex justify-center shrink-0">
             {isAdmin ? (
               <DropdownMenu>
@@ -426,7 +436,6 @@ export function TaskList({ tasks: initialTasks, isAdmin = false, team = [], docs
             )}
           </div>
 
-          {/* Kebab menu */}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
@@ -495,6 +504,100 @@ export function TaskList({ tasks: initialTasks, isAdmin = false, team = [], docs
               )}
             </DropdownMenuContent>
           </DropdownMenu>
+        </div>
+
+        {/* Mobile: stacked layout — full-width name, status + assignee on second line */}
+        <div
+          role="button"
+          tabIndex={0}
+          onClick={() => setSelectedTask(task)}
+          onKeyDown={e => { if (e.key === 'Enter') setSelectedTask(task); }}
+          className="flex md:hidden flex-col gap-2 px-4 py-3 transition-colors active:bg-muted/50 cursor-pointer"
+        >
+          <div className="flex items-center gap-3">
+            <span className="min-w-0 flex-1 text-sm font-medium text-foreground line-clamp-2">
+              {task.name}
+            </span>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="size-8 shrink-0"
+                  onClick={e => e.stopPropagation()}
+                >
+                  <MoreHorizontal className="size-4" />
+                  <span className="sr-only">Task actions</span>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-44">
+                {isAdmin && (
+                  <>
+                    <DropdownMenuLabel>Assign to</DropdownMenuLabel>
+                    {team.map(member => (
+                      <DropdownMenuItem key={member.id} onClick={() => handleAssign(task.id, member.id)} className="flex items-center gap-2">
+                        <Avatar className="size-5">
+                          <AvatarImage src={member.avatar_url ?? undefined} alt={member.display_name ?? ''} />
+                          <AvatarFallback className="text-[7px] bg-secondary">{getInitials(member.display_name ?? '?')}</AvatarFallback>
+                        </Avatar>
+                        <span className="text-xs truncate">{member.display_name ?? 'Unnamed'}</span>
+                        {assignee?.id === member.id && <CheckCircle2 className="size-3 text-seeko-accent ml-auto" />}
+                      </DropdownMenuItem>
+                    ))}
+                    {assignee && (
+                      <DropdownMenuItem onClick={() => handleAssign(task.id, null)} className="flex items-center gap-2 text-muted-foreground">
+                        <UserPlus className="size-3.5" />
+                        <span className="text-xs">Unassign</span>
+                      </DropdownMenuItem>
+                    )}
+                    <DropdownMenuSeparator />
+                  </>
+                )}
+                {(isAdmin || task.assignee_id === currentUserId) && (
+                  <DropdownMenuItem onClick={() => setHandoffTask(task)} className="flex items-center gap-2">
+                    <ArrowRightLeft className="size-3.5" />
+                    <span>Hand Off</span>
+                  </DropdownMenuItem>
+                )}
+                {isAdmin && (
+                  <DropdownMenuItem onClick={() => handleDelete(task.id)} className="flex items-center gap-2 text-destructive">
+                    <Trash2 className="size-3.5" />
+                    <span>Delete</span>
+                  </DropdownMenuItem>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+          <div className="flex items-center gap-2">
+            {/* Tappable status pill — opens bottom sheet on mobile */}
+            <button
+              onClick={e => {
+                e.stopPropagation();
+                if (isAdmin || task.assignee_id === currentUserId) openStatusSheet(e, task);
+              }}
+              className={cn(
+                'inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium uppercase tracking-wide whitespace-nowrap',
+                badgeStyle,
+                (isAdmin || task.assignee_id === currentUserId) && 'active:scale-95 transition-transform'
+              )}
+            >
+              <BadgeIcon className="size-3" />
+              {status}
+            </button>
+            {assignee && (
+              <div className="flex items-center gap-1.5 ml-auto">
+                <Avatar className="size-5 border border-card">
+                  <AvatarImage src={assignee.avatar_url ?? undefined} alt={assignee.display_name ?? ''} />
+                  <AvatarFallback className="text-[7px] bg-secondary">
+                    {getInitials(assignee.display_name ?? '?')}
+                  </AvatarFallback>
+                </Avatar>
+                <span className="text-xs text-muted-foreground truncate max-w-[100px]">
+                  {assignee.display_name?.split(' ')[0] ?? ''}
+                </span>
+              </div>
+            )}
+          </div>
         </div>
       </StaggerItem>
     );
@@ -605,13 +708,15 @@ export function TaskList({ tasks: initialTasks, isAdmin = false, team = [], docs
           />
         </div>
 
-        {/* Column headers */}
-        <div className="flex items-center gap-4 border-b border-border px-4 py-2">
+        {/* Column headers — desktop only */}
+        <div className="hidden md:flex items-center gap-4 border-b border-border px-4 py-2">
           <span className="flex-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">Name</span>
-          <span className="w-24 text-center text-xs font-medium uppercase tracking-wide text-muted-foreground shrink-0">Assignees</span>
+          <span className="w-24 text-center text-xs font-medium uppercase tracking-wide text-muted-foreground shrink-0">Assignee</span>
           <span className="w-32 text-center text-xs font-medium uppercase tracking-wide text-muted-foreground shrink-0">Status</span>
           <span className="w-8 shrink-0" />
         </div>
+        {/* Mobile separator */}
+        <div className="md:hidden border-b border-border" />
 
         {/* Task rows */}
         <CardContent className="p-0">
@@ -696,6 +801,81 @@ export function TaskList({ tasks: initialTasks, isAdmin = false, team = [], docs
           }}
         />
       )}
+
+      {/* Status change bottom sheet (mobile) */}
+      <AnimatePresence>
+        {statusSheetTask && (
+          <>
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.15 }}
+              className="fixed inset-0 z-50 bg-black/40"
+              onClick={() => setStatusSheetTask(null)}
+            />
+            <motion.div
+              initial={{ opacity: 0, y: 200 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 200 }}
+              transition={{ type: 'spring', stiffness: 400, damping: 32 }}
+              className="fixed bottom-0 left-0 right-0 z-[51] rounded-t-2xl border-t border-border/50"
+              style={{
+                background: 'rgba(34, 34, 34, 0.98)',
+                backdropFilter: 'saturate(180%) blur(20px)',
+                WebkitBackdropFilter: 'saturate(180%) blur(20px)',
+                paddingBottom: 'calc(env(safe-area-inset-bottom) + 0.75rem)',
+              }}
+            >
+              <div className="flex items-center justify-between px-5 pt-4 pb-1">
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-semibold text-foreground truncate">{statusSheetTask.name}</p>
+                  <p className="text-xs text-muted-foreground">Change status</p>
+                </div>
+                <button
+                  onClick={() => setStatusSheetTask(null)}
+                  className="flex size-8 items-center justify-center rounded-full bg-white/[0.06] text-muted-foreground shrink-0 ml-3"
+                >
+                  <X className="size-4" />
+                </button>
+              </div>
+              <div className="grid grid-cols-2 gap-2 px-4 py-3">
+                {ALL_STATUSES.filter(s => isAdmin || s !== 'Blocked').map(s => {
+                  const cfg = STATUS_ICONS[s];
+                  const Icon = cfg.icon;
+                  const currentStatus = getEffectiveStatus(statusSheetTask);
+                  const isCurrentStatus = s === currentStatus;
+                  const style = STATUS_BADGE_STYLE[s] ?? '';
+                  return (
+                    <motion.button
+                      key={s}
+                      whileTap={{ scale: 0.95 }}
+                      onClick={() => {
+                        handleStatusChange(statusSheetTask.id, s);
+                        setStatusSheetTask(null);
+                      }}
+                      className={cn(
+                        'flex items-center gap-3 rounded-xl border px-4 py-3.5 text-left transition-colors',
+                        isCurrentStatus
+                          ? style + ' ring-1 ring-foreground/10'
+                          : 'border-border/50 hover:bg-white/[0.04]'
+                      )}
+                    >
+                      <Icon className={cn('size-5', cfg.className)} />
+                      <div>
+                        <p className={cn('text-sm font-medium', isCurrentStatus ? '' : 'text-foreground')}>{s}</p>
+                        {isCurrentStatus && (
+                          <p className="text-[10px] text-muted-foreground uppercase tracking-wide">Current</p>
+                        )}
+                      </div>
+                    </motion.button>
+                  );
+                })}
+              </div>
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/src/components/layout/InvestorSidebar.tsx
+++ b/src/components/layout/InvestorSidebar.tsx
@@ -235,7 +235,12 @@ export function InvestorSidebar({ email, displayName, avatarUrl, isAdmin = false
           <>
             {createPortal(
               <header
-                className={`md:hidden flex items-center justify-between px-4 h-14 w-full shrink-0 ${!useHeaderSlot ? 'fixed top-0 left-0 right-0 z-40 mobile-fixed-layer' : ''}`}
+                className={`md:hidden flex items-center justify-between px-4 h-14 w-full shrink-0 border-b border-border ${!useHeaderSlot ? 'fixed top-0 left-0 right-0 z-40 mobile-fixed-layer' : ''}`}
+                style={{
+                  background: 'rgba(26, 26, 26, 0.80)',
+                  backdropFilter: 'saturate(180%) blur(20px)',
+                  WebkitBackdropFilter: 'saturate(180%) blur(20px)',
+                }}
               >
                 <div className="flex items-center gap-2.5 min-w-0">
                   <Image src="/seeko-s.png" alt="SEEKO" width={20} height={20} unoptimized />
@@ -262,60 +267,76 @@ export function InvestorSidebar({ email, displayName, avatarUrl, isAdmin = false
                   paddingBottom: 'env(safe-area-inset-bottom)',
                 }}
               >
-                <div className="flex items-stretch h-14">
-                  <motion.div className="flex flex-1" whileTap={{ scale: BOTTOM_NAV.tapScale }} transition={BOTTOM_NAV.tapSpring}>
-                    <Link
-                      href="/investor"
-                      onClick={() => trigger('selection')}
-                      className={[
-                        'flex flex-1 flex-col items-center justify-center gap-1 text-[10px] font-medium transition-colors',
-                        pathname === '/investor' ? 'text-seeko-accent' : 'text-muted-foreground',
-                      ].join(' ')}
-                    >
-                      <LayoutDashboard className="size-5" />
-                      Dashboard
-                    </Link>
-                  </motion.div>
-                  <motion.div className="flex flex-1" whileTap={{ scale: BOTTOM_NAV.tapScale }} transition={BOTTOM_NAV.tapSpring}>
-                    <Link
-                      href="/investor/payments"
-                      onClick={() => trigger('selection')}
-                      className={[
-                        'flex flex-1 flex-col items-center justify-center gap-1 text-[10px] font-medium transition-colors',
-                        pathname === '/investor/payments' ? 'text-seeko-accent' : 'text-muted-foreground',
-                      ].join(' ')}
-                    >
-                      <DollarSign className="size-5" />
-                      Payments
-                    </Link>
-                  </motion.div>
-                  <motion.div className="flex flex-1" whileTap={{ scale: BOTTOM_NAV.tapScale }} transition={BOTTOM_NAV.tapSpring}>
-                    <button
-                      type="button"
-                      onClick={(e) => { trigger('selection'); handleDownloadPdf(e); }}
-                      disabled={pdfLoading}
-                      className="flex flex-1 flex-col items-center justify-center gap-1 text-[10px] font-medium transition-colors text-muted-foreground disabled:opacity-50"
-                    >
-                      <FileDown className="size-5" />
-                      {pdfLoading ? '…' : 'PDF'}
-                    </button>
-                  </motion.div>
-                  {isAdmin && (
-                    <motion.div className="flex flex-1" whileTap={{ scale: BOTTOM_NAV.tapScale }} transition={BOTTOM_NAV.tapSpring}>
+                <LayoutGroup id="investor-mobile-nav">
+                  <div className="flex items-stretch h-14">
+                    <motion.div className="relative flex flex-1" whileTap={{ scale: BOTTOM_NAV.tapScale }} transition={BOTTOM_NAV.tapSpring}>
+                      {pathname === '/investor' && (
+                        <motion.div
+                          layoutId="investor-mobile-indicator"
+                          className="absolute top-0 left-1/2 -translate-x-1/2 w-5 h-0.5 rounded-full bg-seeko-accent"
+                          transition={NAV_HIGHLIGHT.spring}
+                        />
+                      )}
                       <Link
-                        href="/"
+                        href="/investor"
                         onClick={() => trigger('selection')}
                         className={[
                           'flex flex-1 flex-col items-center justify-center gap-1 text-[10px] font-medium transition-colors',
-                          pathname === '/' ? 'text-seeko-accent' : 'text-muted-foreground',
+                          pathname === '/investor' ? 'text-seeko-accent' : 'text-muted-foreground',
                         ].join(' ')}
                       >
-                        <Home className="size-5" />
-                        Main
+                        <LayoutDashboard className="size-5" />
+                        Dashboard
                       </Link>
                     </motion.div>
-                  )}
-                </div>
+                    <motion.div className="relative flex flex-1" whileTap={{ scale: BOTTOM_NAV.tapScale }} transition={BOTTOM_NAV.tapSpring}>
+                      {pathname === '/investor/payments' && (
+                        <motion.div
+                          layoutId="investor-mobile-indicator"
+                          className="absolute top-0 left-1/2 -translate-x-1/2 w-5 h-0.5 rounded-full bg-seeko-accent"
+                          transition={NAV_HIGHLIGHT.spring}
+                        />
+                      )}
+                      <Link
+                        href="/investor/payments"
+                        onClick={() => trigger('selection')}
+                        className={[
+                          'flex flex-1 flex-col items-center justify-center gap-1 text-[10px] font-medium transition-colors',
+                          pathname === '/investor/payments' ? 'text-seeko-accent' : 'text-muted-foreground',
+                        ].join(' ')}
+                      >
+                        <DollarSign className="size-5" />
+                        Payments
+                      </Link>
+                    </motion.div>
+                    <motion.div className="relative flex flex-1" whileTap={{ scale: BOTTOM_NAV.tapScale }} transition={BOTTOM_NAV.tapSpring}>
+                      <button
+                        type="button"
+                        onClick={(e) => { trigger('selection'); handleDownloadPdf(e); }}
+                        disabled={pdfLoading}
+                        className="flex flex-1 flex-col items-center justify-center gap-1 text-[10px] font-medium transition-colors text-muted-foreground disabled:opacity-50"
+                      >
+                        <FileDown className="size-5" />
+                        {pdfLoading ? '…' : 'PDF'}
+                      </button>
+                    </motion.div>
+                    {isAdmin && (
+                      <motion.div className="relative flex flex-1" whileTap={{ scale: BOTTOM_NAV.tapScale }} transition={BOTTOM_NAV.tapSpring}>
+                        <Link
+                          href="/"
+                          onClick={() => trigger('selection')}
+                          className={[
+                            'flex flex-1 flex-col items-center justify-center gap-1 text-[10px] font-medium transition-colors',
+                            pathname === '/' ? 'text-seeko-accent' : 'text-muted-foreground',
+                          ].join(' ')}
+                        >
+                          <Home className="size-5" />
+                          Main
+                        </Link>
+                      </motion.div>
+                    )}
+                  </div>
+                </LayoutGroup>
               </nav>,
               document.body
             )}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -70,6 +70,8 @@ import {
   ChevronRight,
   TrendingUp,
   DollarSign,
+  MoreHorizontal,
+  X,
 } from 'lucide-react';
 import dynamic from 'next/dynamic';
 import { Button } from '@/components/ui/button';
@@ -125,7 +127,18 @@ export function Sidebar({
   const [hovered, setHovered] = useState(false);
   const [tooltip, setTooltip] = useState<{ label: string; y: number } | null>(null);
   const [mounted, setMounted] = useState(false);
+  const [moreOpen, setMoreOpen] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
   useEffect(() => setMounted(true), []);
+
+  // Watch for data-modal-open attribute on <html> to hide bottom nav
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      setModalOpen(document.documentElement.hasAttribute('data-modal-open'));
+    });
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-modal-open'] });
+    return () => observer.disconnect();
+  }, []);
 
   const toggleCollapsed = () => {
     setCollapsed(prev => {
@@ -396,7 +409,12 @@ export function Sidebar({
           <>
             {createPortal(
               <header
-                className={`md:hidden flex items-center justify-between px-4 h-14 w-full shrink-0 ${!useHeaderSlot ? 'fixed top-0 left-0 right-0 z-40 mobile-fixed-layer' : ''}`}
+                className={`md:hidden flex items-center justify-between px-4 h-14 w-full shrink-0 border-b border-border/50 ${!useHeaderSlot ? 'fixed top-0 left-0 right-0 z-40 mobile-fixed-layer' : ''}`}
+                style={{
+                  background: 'rgba(26, 26, 26, 0.92)',
+                  backdropFilter: 'saturate(180%) blur(16px)',
+                  WebkitBackdropFilter: 'saturate(180%) blur(16px)',
+                }}
               >
                 <div className="flex items-center gap-2.5">
                   <Image src="/seeko-s.png" alt="SEEKO" width={20} height={20} unoptimized />
@@ -423,38 +441,144 @@ export function Sidebar({
               headerEl
             )}
             {createPortal(
-              <nav
-                className="md:hidden fixed bottom-0 left-0 right-0 z-50"
-                style={{
-                  background: 'rgba(26, 26, 26, 0.96)',
-                  backdropFilter: 'saturate(180%) blur(16px)',
-                  WebkitBackdropFilter: 'saturate(180%) blur(16px)',
-                  paddingBottom: 'env(safe-area-inset-bottom)',
-                }}
-              >
-                <div className="flex items-stretch h-14">
-                  {NAV.map(({ href, mobileLabel, icon: Icon, tourKey }) => {
-                    const isActive = href === '/' ? pathname === '/' : pathname.startsWith(href);
-                    const tourId = tourKey != null ? TOUR_STEP_IDS[tourKey] : undefined;
-                    return (
-                      <motion.div key={href} className="flex flex-1" whileTap={{ scale: BOTTOM_NAV.tapScale }} transition={BOTTOM_NAV.tapSpring}>
-                        <Link
-                          id={tourId}
-                          href={href}
-                          onClick={() => trigger('selection')}
-                          className={[
-                            'flex flex-1 flex-col items-center justify-center gap-1 text-[10px] font-medium transition-colors',
-                            isActive ? 'text-seeko-accent' : 'text-muted-foreground',
-                          ].join(' ')}
-                        >
-                          <Icon className="size-5" />
-                          {mobileLabel}
-                        </Link>
+              <>
+                <nav
+                  className={`md:hidden fixed bottom-0 left-0 right-0 z-50 transition-opacity duration-150 mobile-bottom-nav ${moreOpen || modalOpen ? 'opacity-0 pointer-events-none' : ''}`}
+                  style={{
+                    background: 'rgba(26, 26, 26, 0.96)',
+                    backdropFilter: 'saturate(180%) blur(16px)',
+                    WebkitBackdropFilter: 'saturate(180%) blur(16px)',
+                    paddingBottom: 'env(safe-area-inset-bottom)',
+                  }}
+                >
+                  {/* Active indicator bar */}
+                  <div className="relative flex items-stretch h-14">
+                    {(() => {
+                      const MAX_MOBILE_TABS = 5;
+                      const primaryNav = NAV.slice(0, MAX_MOBILE_TABS - (NAV.length > MAX_MOBILE_TABS ? 1 : 0));
+                      const overflowNav = NAV.length > MAX_MOBILE_TABS ? NAV.slice(MAX_MOBILE_TABS - 1) : [];
+                      const hasOverflow = overflowNav.length > 0;
+                      const isOverflowActive = overflowNav.some(({ href }) =>
+                        href === '/' ? pathname === '/' : pathname.startsWith(href)
+                      );
+
+                      return (
+                        <>
+                          {primaryNav.map(({ href, mobileLabel, icon: Icon, tourKey }) => {
+                            const isActive = href === '/' ? pathname === '/' : pathname.startsWith(href);
+                            const tourId = tourKey != null ? TOUR_STEP_IDS[tourKey] : undefined;
+                            return (
+                              <motion.div key={href} className="flex flex-1" whileTap={{ scale: BOTTOM_NAV.tapScale }} transition={BOTTOM_NAV.tapSpring}>
+                                <Link
+                                  id={tourId}
+                                  href={href}
+                                  onClick={() => { trigger('selection'); setMoreOpen(false); }}
+                                  className={[
+                                    'flex flex-1 flex-col items-center justify-center gap-1 text-[10px] font-medium transition-colors relative',
+                                    isActive ? 'text-seeko-accent' : 'text-muted-foreground',
+                                  ].join(' ')}
+                                >
+                                  {isActive && (
+                                    <motion.div
+                                      layoutId="mobile-nav-indicator"
+                                      className="absolute top-0 left-1/2 -translate-x-1/2 w-5 h-0.5 rounded-full bg-seeko-accent"
+                                      transition={BOTTOM_NAV.tapSpring}
+                                    />
+                                  )}
+                                  <Icon className="size-5" />
+                                  {mobileLabel}
+                                </Link>
+                              </motion.div>
+                            );
+                          })}
+                          {hasOverflow && (
+                            <motion.div className="flex flex-1" whileTap={{ scale: BOTTOM_NAV.tapScale }} transition={BOTTOM_NAV.tapSpring}>
+                              <button
+                                onClick={() => { trigger('selection'); setMoreOpen(prev => !prev); }}
+                                className={[
+                                  'flex flex-1 flex-col items-center justify-center gap-1 text-[10px] font-medium transition-colors relative',
+                                  moreOpen || isOverflowActive ? 'text-seeko-accent' : 'text-muted-foreground',
+                                ].join(' ')}
+                              >
+                                {isOverflowActive && !moreOpen && (
+                                  <motion.div
+                                    layoutId="mobile-nav-indicator"
+                                    className="absolute top-0 left-1/2 -translate-x-1/2 w-5 h-0.5 rounded-full bg-seeko-accent"
+                                    transition={BOTTOM_NAV.tapSpring}
+                                  />
+                                )}
+                                <MoreHorizontal className="size-5" />
+                                More
+                              </button>
+                            </motion.div>
+                          )}
+                        </>
+                      );
+                    })()}
+                  </div>
+                </nav>
+                {/* More menu overlay */}
+                <AnimatePresence>
+                  {moreOpen && (
+                    <>
+                      <motion.div
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={{ opacity: 0 }}
+                        transition={{ duration: 0.15 }}
+                        className="md:hidden fixed inset-0 z-[60] bg-black/40"
+                        onClick={() => setMoreOpen(false)}
+                      />
+                      <motion.div
+                        initial={{ opacity: 0, y: 60 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={{ opacity: 0, y: 60 }}
+                        transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+                        className="md:hidden fixed bottom-0 left-0 right-0 z-[61] rounded-t-2xl border-t border-border/50 overflow-hidden"
+                        style={{
+                          background: 'rgba(26, 26, 26, 0.98)',
+                          backdropFilter: 'saturate(180%) blur(20px)',
+                          WebkitBackdropFilter: 'saturate(180%) blur(20px)',
+                          paddingBottom: 'env(safe-area-inset-bottom)',
+                        }}
+                      >
+                        {/* Drag handle */}
+                        <div className="flex justify-center pt-3 pb-1">
+                          <div className="w-9 h-1 rounded-full bg-white/[0.15]" />
+                        </div>
+                        <div className="flex items-center justify-between px-5 pb-2">
+                          <span className="text-sm font-semibold text-foreground">More</span>
+                          <button
+                            onClick={() => setMoreOpen(false)}
+                            className="flex size-8 items-center justify-center rounded-full bg-white/[0.06] text-muted-foreground"
+                          >
+                            <X className="size-4" />
+                          </button>
+                        </div>
+                        <div className="flex flex-col gap-1 px-3 pb-4">
+                          {NAV.slice(4).map(({ href, mobileLabel, icon: Icon }) => {
+                            const isActive = href === '/' ? pathname === '/' : pathname.startsWith(href);
+                            return (
+                              <Link
+                                key={href}
+                                href={href}
+                                onClick={() => { trigger('selection'); setMoreOpen(false); }}
+                                className={[
+                                  'flex items-center gap-3 rounded-xl px-4 py-3.5 text-sm font-medium transition-colors',
+                                  isActive ? 'bg-seeko-accent/10 text-seeko-accent' : 'text-foreground hover:bg-white/[0.04]',
+                                ].join(' ')}
+                              >
+                                <Icon className="size-5" />
+                                {mobileLabel}
+                              </Link>
+                            );
+                          })}
+                        </div>
                       </motion.div>
-                    );
-                  })}
-                </div>
-              </nav>,
+                    </>
+                  )}
+                </AnimatePresence>
+              </>,
               document.body
             )}
           </>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,14 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/** Safe UUID v4 — falls back for browsers without crypto.randomUUID (older Safari/WebKit). */
+export function uuid(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return '10000000-1000-4000-8000-100000000000'.replace(/[018]/g, c => {
+    const n = Number(c);
+    return (n ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (n / 4)))).toString(16);
+  });
+}


### PR DESCRIPTION
## Summary
- **Chat UX**: Long-press action sheet with portal rendering, iOS-safe touch handling, larger touch targets, prominent compose bar, bottom-sheet modal on mobile
- **Bottom nav**: Hides automatically when task detail modal is open (MutationObserver watches `data-modal-open` attribute)
- **Investor panel**: Reordered mobile layout, collapsible area cards, frosted glass header, animated nav indicator matching main dashboard style
- **Haptics toggle**: Enable/disable haptic feedback in Settings (mobile only), persisted to localStorage
- **Status permissions**: Non-admins can no longer select "Blocked" status in the mobile bottom sheet or via slash commands — assignees can still change to other statuses
- **Cleanup**: Removed debug `console.log` from payments verify route, fixed double safe-area padding in investor layout

## Test plan
- [ ] Open task detail on mobile — verify long-press shows action sheet (not iOS text selection)
- [ ] Verify bottom nav disappears when task detail modal is open
- [ ] Check investor panel mobile layout — areas should be collapsible, nav indicator animates
- [ ] Toggle haptic feedback off/on in Settings → verify it persists across page reload
- [ ] As non-admin, open status bottom sheet on mobile → "Blocked" should not appear
- [ ] As non-admin, type `/blocked` in chat → should not change status
- [ ] As admin, verify "Blocked" still appears in status sheet and slash commands work

🤖 Generated with [Claude Code](https://claude.com/claude-code)