### PR TITLE
fix(security): fail closed when PAYMENTS_JWT_SECRET env var is missing

### DIFF
--- a/src/app/api/payments/verify/route.ts
+++ b/src/app/api/payments/verify/route.ts
@@ -56,7 +56,11 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Invalid password' }, { status: 401 });
   }
 
-  const secret = new TextEncoder().encode(process.env.PAYMENTS_JWT_SECRET ?? 'fallback-secret');
+  const jwtSecret = process.env.PAYMENTS_JWT_SECRET;
+  if (!jwtSecret) {
+    return NextResponse.json({ error: 'Payments not configured' }, { status: 500 });
+  }
+  const secret = new TextEncoder().encode(jwtSecret);
   const token = await new SignJWT({ sub: user.id, scope: 'payments' })
     .setProtectedHeader({ alg: 'HS256' })
     .setExpirationTime('24h')

--- a/src/lib/payments-auth.ts
+++ b/src/lib/payments-auth.ts
@@ -30,7 +30,12 @@ export async function getPaymentsAuth(tokenHeader?: string | null) {
   let tokenValid = false;
   if (isAdmin && tokenHeader) {
     try {
-      const secret = new TextEncoder().encode(process.env.PAYMENTS_JWT_SECRET ?? 'fallback-secret');
+      const jwtSecret = process.env.PAYMENTS_JWT_SECRET;
+      if (!jwtSecret) {
+        tokenValid = false;
+        return { supabase, user, isAdmin, isInvestor, tokenValid };
+      }
+      const secret = new TextEncoder().encode(jwtSecret);
       const { payload } = await jwtVerify(tokenHeader, secret);
       tokenValid = payload.sub === user.id && payload.scope === 'payments';
     } catch {


### PR DESCRIPTION
## Summary

- **Critical security fix**: Both `src/app/api/payments/verify/route.ts` and `src/lib/payments-auth.ts` fell back to the hardcoded literal `'fallback-secret'` when `PAYMENTS_JWT_SECRET` was not set in the environment. Anyone who knew this value could forge valid payment JWT tokens.
- `verify/route.ts`: now returns `500 'Payments not configured'` if the env var is absent (same pattern as `PAYMENTS_ACCESS_HASH`).
- `payments-auth.ts`: now returns `tokenValid: false` early if the env var is absent, failing closed instead of accepting forged tokens.

## Test plan

- [ ] Verify existing payments flow works normally with `PAYMENTS_JWT_SECRET` set
- [ ] Verify `/api/payments/verify` returns 500 when `PAYMENTS_JWT_SECRET` is unset
- [ ] Verify payment routes reject tokens when `PAYMENTS_JWT_SECRET` is unset
- [ ] Confirm TypeScript check passes (`npx tsc --noEmit`)

🤖 Generated by error-log-monitor