### PR TITLE
fix: boot member cleanup & segmented invite code input

### DIFF
--- a/src/app/api/admin/boot-member/route.ts
+++ b/src/app/api/admin/boot-member/route.ts
@@ -65,17 +65,53 @@ export async function POST(req: NextRequest) {
     process.env.SUPABASE_SERVICE_ROLE_KEY!
   );
 
-  // Nullify task assignments
+  // Clean up all data referencing this user before deleting profile/auth
+  // Order matters: children first, then profile, then auth user
+
+  // 1. Nullify task assignments
   await service.from('tasks').update({ assignee_id: null }).eq('assignee_id', userId);
 
-  // Delete profile
-  await service.from('profiles').delete().eq('id', userId);
+  // 2. Delete task comment reactions by this user
+  await service.from('task_comment_reactions').delete().eq('user_id', userId);
 
-  // Delete auth user
+  // 3. Delete task comments by this user
+  await service.from('task_comments').delete().eq('user_id', userId);
+
+  // 4. Delete task handoffs involving this user
+  await service.from('task_handoffs').delete().eq('from_user_id', userId);
+  await service.from('task_handoffs').delete().eq('to_user_id', userId);
+
+  // 5. Delete task deliverables uploaded by this user
+  await service.from('task_deliverables').delete().eq('uploaded_by', userId);
+
+  // 6. Delete payment items for payments created by or for this user
+  const { data: userPayments } = await service
+    .from('payments')
+    .select('id')
+    .or(`recipient_id.eq.${userId},created_by.eq.${userId}`);
+  if (userPayments && userPayments.length > 0) {
+    const paymentIds = userPayments.map(p => p.id);
+    await service.from('payment_items').delete().in('payment_id', paymentIds);
+  }
+
+  // 7. Delete payments referencing this user
+  await service.from('payments').delete().or(`recipient_id.eq.${userId},created_by.eq.${userId}`);
+
+  // 8. Notifications (should cascade, but be safe)
+  await service.from('notifications').delete().eq('user_id', userId);
+
+  // 8b. Activity log entries
+  await service.from('activity_log').delete().eq('user_id', userId);
+
+  // 9. Delete profile
+  const { error: profileErr } = await service.from('profiles').delete().eq('id', userId);
+  if (profileErr) {
+    return NextResponse.json({ error: 'Database error deleting user' }, { status: 500 });
+  }
+
+  // 10. Delete auth user
   const { error: deleteErr } = await service.auth.admin.deleteUser(userId);
   if (deleteErr) {
-    // TODO: Replace with proper logging system
-    // Failed to delete auth user during boot member operation
     return NextResponse.json({ error: deleteErr.message }, { status: 500 });
   }
 

--- a/src/components/auth/InviteCodeForm.tsx
+++ b/src/components/auth/InviteCodeForm.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { createClient } from '@/lib/supabase/client';
 import { useHaptics } from '@/components/HapticsProvider';
+import { SegmentedCodeInput } from './SegmentedCodeInput';
 
 export function InviteCodeForm() {
   const router = useRouter();
@@ -58,19 +59,13 @@ export function InviteCodeForm() {
       </div>
 
       <div>
-        <label htmlFor="invite-token" className="block text-xs font-medium text-muted-foreground mb-1.5">
-          Invite code
+        <label className="block text-xs font-medium text-muted-foreground mb-2 text-center">
+          Enter the 8-digit code from your invite email
         </label>
-        <input
-          id="invite-token"
-          type="text"
+        <SegmentedCodeInput
           value={token}
-          onChange={e => setToken(e.target.value.replace(/\D/g, '').slice(0, 8))}
-          required
-          placeholder="8-digit code from your email"
-          inputMode="numeric"
-          maxLength={8}
-          className="w-full px-3 py-2 rounded-lg bg-card border border-border text-foreground text-sm placeholder:text-muted-foreground/50 focus:outline-none focus:border-seeko-accent transition-colors font-mono tracking-widest"
+          onChange={setToken}
+          disabled={loading}
         />
       </div>
 

--- a/src/components/auth/SegmentedCodeInput.tsx
+++ b/src/components/auth/SegmentedCodeInput.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+/* ─────────────────────────────────────────────────────────
+ * ANIMATION STORYBOARD — Segmented Code Input
+ *
+ *    0ms   8 cells render, empty
+ *   user types → digit fills cell, scale-bounce 0.95→1.05→1
+ *   auto-advance to next cell on entry
+ *   on paste → all cells fill with stagger (40ms each)
+ *   on complete → subtle glow pulse on all cells
+ * ───────────────────────────────────────────────────────── */
+
+import { useState, useRef, useCallback, useEffect, type KeyboardEvent, type ClipboardEvent } from 'react';
+import { cn } from '@/lib/utils';
+
+const CELL_COUNT = 8;
+
+interface SegmentedCodeInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+}
+
+export function SegmentedCodeInput({ value, onChange, disabled }: SegmentedCodeInputProps) {
+  const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
+  const [focusedIndex, setFocusedIndex] = useState(-1);
+  const digits = Array.from({ length: CELL_COUNT }, (_, i) => value[i] ?? '');
+  const [animatingCells, setAnimatingCells] = useState<Set<number>>(new Set());
+
+  const focusCell = useCallback((index: number) => {
+    if (index >= 0 && index < CELL_COUNT) {
+      inputRefs.current[index]?.focus();
+    }
+  }, []);
+
+  const updateDigit = useCallback((index: number, digit: string) => {
+    const newDigits = [...digits];
+    newDigits[index] = digit;
+    const newValue = newDigits.join('').replace(/\D/g, '').slice(0, CELL_COUNT);
+    onChange(newValue);
+
+    setAnimatingCells(prev => new Set(prev).add(index));
+    setTimeout(() => {
+      setAnimatingCells(prev => {
+        const next = new Set(prev);
+        next.delete(index);
+        return next;
+      });
+    }, 300);
+  }, [digits, onChange]);
+
+  const handleKeyDown = useCallback((index: number, e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Backspace') {
+      e.preventDefault();
+      if (digits[index]) {
+        updateDigit(index, '');
+      } else if (index > 0) {
+        updateDigit(index - 1, '');
+        focusCell(index - 1);
+      }
+    } else if (e.key === 'ArrowLeft' && index > 0) {
+      e.preventDefault();
+      focusCell(index - 1);
+    } else if (e.key === 'ArrowRight' && index < CELL_COUNT - 1) {
+      e.preventDefault();
+      focusCell(index + 1);
+    } else if (/^\d$/.test(e.key)) {
+      e.preventDefault();
+      updateDigit(index, e.key);
+      if (index < CELL_COUNT - 1) {
+        focusCell(index + 1);
+      }
+    }
+  }, [digits, updateDigit, focusCell]);
+
+  const handlePaste = useCallback((e: ClipboardEvent<HTMLInputElement>) => {
+    e.preventDefault();
+    const pasted = e.clipboardData.getData('text').replace(/\D/g, '').slice(0, CELL_COUNT);
+    if (!pasted) return;
+
+    onChange(pasted);
+
+    // Stagger animation for pasted cells
+    pasted.split('').forEach((_, i) => {
+      setTimeout(() => {
+        setAnimatingCells(prev => new Set(prev).add(i));
+        setTimeout(() => {
+          setAnimatingCells(prev => {
+            const next = new Set(prev);
+            next.delete(i);
+            return next;
+          });
+        }, 300);
+      }, i * 40);
+    });
+
+    // Focus the cell after last pasted digit
+    const nextIndex = Math.min(pasted.length, CELL_COUNT - 1);
+    setTimeout(() => focusCell(nextIndex), pasted.length * 40);
+  }, [onChange, focusCell]);
+
+  // Auto-focus first cell on mount
+  useEffect(() => {
+    const timer = setTimeout(() => focusCell(0), 100);
+    return () => clearTimeout(timer);
+  }, [focusCell]);
+
+  const isComplete = value.replace(/\D/g, '').length === CELL_COUNT;
+
+  return (
+    <div className="flex items-center justify-center gap-1">
+      {digits.map((digit, i) => (
+        <div key={i} className="flex items-center">
+          {i === 4 && (
+            <div className="w-2 flex items-center justify-center text-muted-foreground/30 text-sm font-light">
+              -
+            </div>
+          )}
+          <div
+            className={cn(
+              'relative w-8 h-10 md:w-10 md:h-12 rounded-lg border-2 transition-all duration-200',
+              isComplete
+                ? 'border-seeko-accent shadow-[0_0_8px_rgba(110,231,183,0.15)]'
+                : focusedIndex === i
+                  ? 'border-seeko-accent shadow-[0_0_0_2px_rgba(110,231,183,0.15)]'
+                  : digit
+                    ? 'border-[rgba(240,240,240,0.15)]'
+                    : 'border-border',
+              animatingCells.has(i) && 'scale-105',
+            )}
+          >
+            <input
+              ref={el => { inputRefs.current[i] = el; }}
+              type="text"
+              inputMode="numeric"
+              maxLength={1}
+              value={digit}
+              disabled={disabled}
+              onChange={() => {}}
+              onKeyDown={e => handleKeyDown(i, e)}
+              onPaste={handlePaste}
+              onFocus={() => setFocusedIndex(i)}
+              onBlur={() => setFocusedIndex(-1)}
+              className="absolute inset-0 w-full h-full bg-transparent text-center text-base md:text-lg font-mono font-semibold text-foreground focus:outline-none caret-transparent"
+              aria-label={`Digit ${i + 1}`}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Fix "Database error deleting user"**: Boot member route now cleans up all FK-dependent tables (task comments, reactions, handoffs, deliverables, payments, payment items, notifications, activity log) before deleting the profile and auth user
- **Segmented code input**: Replace plain text invite code field with an 8-digit segmented input (4-4 grouping, auto-advance, paste support)
- Mobile polish: chat UX, investor layout, haptics toggle, status permissions for non-admins

## Test plan
- [ ] Try removing a team member via admin panel — should succeed without "Database error"
- [ ] Switch to "Join team" tab on login — segmented code cells should fit within the card
- [ ] Paste an 8-digit code — cells should fill with stagger animation
- [ ] Verify non-admins cannot select "Blocked" status

🤖 Generated with [Claude Code](https://claude.com/claude-code)