### PR TITLE
Redesign investor dashboard and payments page

### DIFF
--- a/src/app/(investor)/investor/page.tsx
+++ b/src/app/(investor)/investor/page.tsx
@@ -3,11 +3,10 @@
  *
  * Read top-to-bottom. Each value is ms after mount.
  *
- *    0ms   hero fades up (title + subtitle)
- *  100ms   game areas card fades up
- *  150ms   area tiles stagger in (50ms delay, then 80ms apart)
- *  300ms   recent tasks + this week section fades up
- *  350ms   task rows stagger in (50ms delay, 60ms apart)
+ *    0ms   hero fades up (title + health summary)
+ *   50ms   KPI strip stat cards stagger in (80ms apart)
+ *  200ms   game areas card fades up (open by default)
+ *  350ms   recent activity card fades up (grouped by day)
  * ───────────────────────────────────────────────────────── */
 
 import { createClient } from '@/lib/supabase/server';
@@ -15,34 +14,24 @@ import { fetchProfile, fetchAreas, fetchActivity, fetchAllTasksWithAssignees } f
 import { Area } from '@/lib/types';
 import type { TaskWithAssignee } from '@/lib/types';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { FadeRise, Stagger, StaggerItem } from '@/components/motion';
+import { FadeRise } from '@/components/motion';
 import { EmptyState } from '@/components/ui/empty-state';
-import { Badge } from '@/components/ui/badge';
-import { InvestorAreaCard } from '@/components/dashboard/InvestorAreaCard';
+import { InvestorKPIStrip } from '@/components/dashboard/InvestorKPIStrip';
 import { CollapsibleInvestorAreas } from '@/components/dashboard/CollapsibleInvestorAreas';
-import {
-  CheckSquare,
-  Map,
-  TrendingUp,
-  AlertCircle,
-} from 'lucide-react';
+import { Map, Activity } from 'lucide-react';
 
 export const dynamic = 'force-dynamic';
 
 const TIMING = {
-  hero:            0,   // title + subtitle
-  areas:         100,   // game areas card
-  areasStagger:  150,   // area tiles start (delay 50ms after areas)
-  areasStaggerDelayMs: 50,
-  grid:          300,   // recent tasks + this week
-  tasksStagger:  350,   // task rows start (delay 50ms after grid)
-  tasksStaggerDelayMs: 50,
-  staggerMs:      60,   // ms between task rows
+  hero:      0,
+  kpi:      50,
+  areas:   200,
+  summary: 350,
 };
 
 const delay = (ms: number) => ms / 1000;
 
-/** Relative time for "Updated X ago" (minutes, hours, days). */
+/** Relative time for "Updated X ago". */
 function timeAgo(dateStr: string): string {
   const ms = Date.now() - new Date(dateStr).getTime();
   const mins = Math.floor(ms / 60_000);
@@ -53,33 +42,70 @@ function timeAgo(dateStr: string): string {
   return `${Math.floor(hours / 24)}d ago`;
 }
 
-/** Summarise last 7 days activity into high-level bullets for the Updates section. */
-function buildUpdates(
-  activity: Awaited<ReturnType<typeof fetchActivity>>,
-  areas: Area[],
-) {
-  const cutoff = Date.now() - 7 * 24 * 60 * 60 * 1000;
-  const recent = activity.filter(a => new Date(a.created_at).getTime() > cutoff);
+/** Color for activity action type. */
+function actionColor(action: string): string {
+  if (action === 'Completed') return 'var(--color-seeko-accent)';
+  if (action === 'Blocked') return 'var(--color-status-blocked)';
+  if (action === 'Started' || action === 'Moved to review') return 'var(--color-status-progress)';
+  return 'var(--color-muted-foreground)';
+}
 
-  const completed  = recent.filter(a => a.action === 'Completed').length;
-  const started    = recent.filter(a => a.action === 'Started').length;
-  const inReview   = recent.filter(a => a.action === 'Moved to review').length;
-  const blocked    = recent.filter(a => a.action === 'Blocked').length;
-  const comments   = recent.filter(a => a.action === 'Commented on').length;
+/** Group activity entries by day label. */
+function groupByDay(entries: { created_at: string }[]): { label: string; items: typeof entries }[] {
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  const yesterday = today - 86_400_000;
 
-  const bullets: string[] = [];
-  if (completed > 0) bullets.push(`${completed} task${completed !== 1 ? 's' : ''} completed this week`);
-  if (started > 0)   bullets.push(`${started} task${started !== 1 ? 's' : ''} started`);
-  if (inReview > 0)  bullets.push(`${inReview} task${inReview !== 1 ? 's' : ''} moved to review`);
-  if (blocked > 0)   bullets.push(`${blocked} task${blocked !== 1 ? 's' : ''} currently blocked`);
-  if (comments > 0)  bullets.push(`${comments} comment${comments !== 1 ? 's' : ''} added`);
+  const groups: Record<string, typeof entries> = {};
+  for (const entry of entries) {
+    const entryDate = new Date(entry.created_at);
+    const entryDay = new Date(entryDate.getFullYear(), entryDate.getMonth(), entryDate.getDate()).getTime();
+    let label: string;
+    if (entryDay >= today) label = 'Today';
+    else if (entryDay >= yesterday) label = 'Yesterday';
+    else label = entryDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    if (!groups[label]) groups[label] = [];
+    groups[label].push(entry);
+  }
+  return Object.entries(groups).map(([label, items]) => ({ label, items }));
+}
 
-  const activeAreas = areas.filter(a => a.status === 'Active');
-  if (activeAreas.length > 0) {
-    bullets.push(`${activeAreas.length} area${activeAreas.length !== 1 ? 's' : ''} in active development`);
+/** Build a one-line health summary for the investor. */
+function buildHealthSummary(
+  completedThisWeek: number,
+  blocked: number,
+  overdue: number,
+  areas: { name: string; progress: number }[],
+): string {
+  const parts: string[] = [];
+
+  // Progress signal
+  if (completedThisWeek > 0) {
+    parts.push(`${completedThisWeek} task${completedThisWeek !== 1 ? 's' : ''} completed this week`);
   }
 
-  return bullets;
+  // Area progress
+  const progressing = areas.filter(a => a.progress > 0);
+  if (progressing.length > 0 && progressing.length === areas.length) {
+    parts.push('all areas progressing');
+  } else if (progressing.length > 0) {
+    parts.push(`${progressing.length} of ${areas.length} areas progressing`);
+  }
+
+  // Issues
+  if (blocked > 0 && overdue > 0) {
+    parts.push(`${blocked} blocked and ${overdue} overdue`);
+  } else if (blocked > 0) {
+    parts.push(`${blocked} blocked task${blocked !== 1 ? 's' : ''} need attention`);
+  } else if (overdue > 0) {
+    parts.push(`${overdue} overdue task${overdue !== 1 ? 's' : ''}`);
+  }
+
+  if (parts.length === 0) return 'No activity this week yet.';
+
+  // Capitalize first part
+  const sentence = parts.join(', ') + '.';
+  return sentence.charAt(0).toUpperCase() + sentence.slice(1);
 }
 
 export default async function InvestorPage() {
@@ -94,118 +120,83 @@ export default async function InvestorPage() {
     fetchActivity(30).catch(() => []),
   ]);
 
+  // ── Stat computations ─────────────────────────────────
+  const totalTasks     = tasks.length;
+  const completedTasks = tasks.filter(t => t.status === 'Complete').length;
+  const overallPct     = totalTasks > 0 ? Math.round((completedTasks / totalTasks) * 100) : 0;
   const blocked        = tasks.filter(t => t.status === 'Blocked').length;
   const overdueCount   = tasks.filter(t => t.deadline && new Date(t.deadline) < new Date()).length;
+  const activeAreas    = areas.filter(a => a.status === 'Active').length;
 
-  const updates = buildUpdates(activity, areas);
+  // Tasks completed this week (from activity log)
+  const weekAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+  const completedThisWeek = activity.filter(
+    a => a.action === 'Completed' && new Date(a.created_at).getTime() > weekAgo
+  ).length;
+
   const areasSubtitle = areas.length > 0
-    ? areas.map(a => a.name).join(' · ')
+    ? `${completedTasks} of ${totalTasks} tasks complete · ${areas.map(a => a.name).join(' · ')}`
     : 'No active areas';
 
   const firstName = profile?.display_name?.split(' ')[0];
 
-  // Latest activity or task update for "Updated X ago"
-  const latestActivity = activity[0]?.created_at;
-  const latestTaskUpdate = tasks
-    .map(t => t.updated_at)
-    .filter((t): t is string => !!t)
-    .sort((a, b) => new Date(b).getTime() - new Date(a).getTime())[0];
-  const lastUpdatedRaw = [latestActivity, latestTaskUpdate]
-    .filter((t): t is string => !!t)
-    .sort((a, b) => new Date(b).getTime() - new Date(a).getTime())[0];
-  const lastUpdated = lastUpdatedRaw ? timeAgo(lastUpdatedRaw) : null;
+  // Health summary
+  const healthSummary = buildHealthSummary(
+    completedThisWeek,
+    blocked,
+    overdueCount,
+    areas.map(a => ({ name: a.name, progress: a.progress })),
+  );
+  const hasIssues = blocked > 0 || overdueCount > 0;
+
+  // Build task-to-area lookup for activity context
+  const taskAreaLookup: Record<string, string> = {};
+  for (const task of tasks) {
+    const area = areas.find(a => a.id === task.area_id);
+    if (area) taskAreaLookup[task.name] = area.name;
+  }
+
+  // Recent activity entries (last 12, grouped by day)
+  const recentActivity = activity.slice(0, 12);
+  const activityGroups = groupByDay(recentActivity);
 
   return (
     <div className="flex flex-col gap-6">
 
-      {/* ── Hero (primary entry point) ───────────────────── */}
-      <FadeRise delay={delay(TIMING.hero)} className="pb-4">
-        <h1
-          className="text-2xl font-semibold tracking-tight text-foreground"
-          style={{ color: 'var(--color-seeko-accent)' }}
-        >
-          Investor Panel
-        </h1>
-        <p className="text-sm text-muted-foreground mt-1">
-          {firstName ? `Welcome, ${firstName}. ` : ''}
-          Here's the current state of SEEKO.
-        </p>
-        {lastUpdated && (
-          <p className="text-xs text-muted-foreground/80 mt-1.5" aria-label={`Last updated ${lastUpdated}`}>
-            Updated {lastUpdated}
-          </p>
-        )}
-      </FadeRise>
-
-      {/* ── Blocked tasks callout — early on mobile for visibility ── */}
-      {blocked > 0 && (
-        <FadeRise delay={delay(TIMING.hero + 50)}>
-          <Card className="border-red-900/40 bg-red-950/10">
-            <CardContent className="flex items-center gap-3 py-4">
-              <AlertCircle className="size-4 text-red-400 shrink-0" />
-              <p className="text-sm text-muted-foreground">
-                <span className="font-medium text-foreground">{blocked} task{blocked !== 1 ? 's' : ''} blocked.</span>
-                {' '}The team is actively working to unblock progress.
-              </p>
-            </CardContent>
-          </Card>
-        </FadeRise>
-      )}
-
-      {/* ── Overdue tasks callout ───────────────────────── */}
-      {overdueCount > 0 && (
-        <FadeRise delay={delay(TIMING.hero + (blocked > 0 ? 100 : 50))}>
-          <Card className="border-amber-900/40 bg-amber-950/10">
-            <CardContent className="flex items-center gap-3 py-4">
-              <AlertCircle className="size-4 text-amber-400 shrink-0" />
-              <p className="text-sm text-muted-foreground">
-                <span className="font-medium text-foreground">{overdueCount} task{overdueCount !== 1 ? 's' : ''} past due.</span>
-                {' '}The team is reprioritising and updating deadlines.
-              </p>
-            </CardContent>
-          </Card>
-        </FadeRise>
-      )}
-
-      {/* ── This Week — promoted above areas on mobile ──── */}
-      <FadeRise delay={delay(TIMING.areas)}>
-        <div className="md:hidden">
-          <Card>
-            <CardHeader>
-              <div className="flex items-center gap-2">
-                <TrendingUp className="size-4 text-muted-foreground" />
-                <CardTitle className="text-xl font-semibold text-foreground">This Week</CardTitle>
-              </div>
-              <CardDescription>Summary of the last 7 days.</CardDescription>
-            </CardHeader>
-            <CardContent>
-              {updates.length === 0 ? (
-                <EmptyState
-                  icon="TrendingUp"
-                  title="No updates yet"
-                  description="Activity from the past week will be summarised here."
-                />
-              ) : (
-                <ul className="flex flex-col gap-3">
-                  {updates.map((bullet, i) => (
-                    <li key={i} className="flex items-start gap-2.5">
-                      <span
-                        className="mt-1.5 h-1.5 w-1.5 rounded-full shrink-0"
-                        style={{ backgroundColor: 'var(--color-seeko-accent)' }}
-                        aria-hidden
-                      />
-                      <span className="text-sm text-muted-foreground">{bullet}</span>
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </CardContent>
-          </Card>
+      {/* ── Hero + Health Summary ─────────────────────────── */}
+      <FadeRise delay={delay(TIMING.hero)} className="pb-2">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h1
+              className="text-2xl font-semibold tracking-tight"
+              style={{ color: 'var(--color-seeko-accent)' }}
+            >
+              Investor Panel
+            </h1>
+            <p className="text-sm text-muted-foreground mt-1">
+              {firstName ? `Welcome, ${firstName}. ` : ''}Here&apos;s the current state of SEEKO.
+            </p>
+          </div>
+        </div>
+        <div className={`mt-3 rounded-lg px-3.5 py-2.5 text-sm ${hasIssues ? 'bg-red-950/15 border border-red-900/30 text-red-300' : 'bg-muted/50 border border-border/50 text-muted-foreground'}`}>
+          {healthSummary}
         </div>
       </FadeRise>
 
-      {/* ── Game Areas ──────────────────────────────────── */}
-      <FadeRise delay={delay(TIMING.areas + 50)}>
+      {/* ── KPI Strip ────────────────────────────────────── */}
+      <InvestorKPIStrip
+        overallPct={overallPct}
+        completedThisWeek={completedThisWeek}
+        blocked={blocked}
+        overdue={overdueCount}
+        activeAreas={activeAreas}
+        areas={areas.map(a => ({ id: a.id, name: a.name, progress: a.progress }))}
+        isAdmin={profile?.is_admin ?? false}
+        delay={TIMING.kpi}
+      />
+
+      {/* ── Game Areas (open by default) ─────────────────── */}
+      <FadeRise delay={delay(TIMING.areas)}>
         {areas.length === 0 ? (
           <Card>
             <CardHeader>
@@ -224,157 +215,71 @@ export default async function InvestorPage() {
             </CardContent>
           </Card>
         ) : (
-          <>
-            {/* Desktop: always expanded */}
-            <div className="hidden md:block">
-              <Card>
-                <CardHeader>
-                  <div className="flex items-center gap-2">
-                    <Map className="size-4 text-muted-foreground" />
-                    <CardTitle className="text-xl font-semibold text-foreground">Game Areas</CardTitle>
-                  </div>
-                  <CardDescription className="line-clamp-1">{areasSubtitle}</CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <Stagger
-                    className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"
-                    delayMs={delay(TIMING.areasStaggerDelayMs)}
-                    staggerMs={0.08}
-                  >
-                    {areas.map(area => (
-                      <InvestorAreaCard
-                        key={area.id}
-                        area={area}
-                        tasksInArea={tasks.filter(t => t.area_id === area.id)}
-                      />
-                    ))}
-                  </Stagger>
-                </CardContent>
-              </Card>
-            </div>
-            {/* Mobile: collapsible */}
-            <div className="md:hidden">
-              <CollapsibleInvestorAreas
-                areas={areas}
-                tasks={tasks as TaskWithAssignee[]}
-                subtitle={areasSubtitle}
-              />
-            </div>
-          </>
+          <CollapsibleInvestorAreas
+            areas={areas}
+            tasks={tasks as TaskWithAssignee[]}
+            subtitle={areasSubtitle}
+            defaultOpen
+            isAdmin={profile?.is_admin ?? false}
+          />
         )}
       </FadeRise>
 
-      {/* ── Recent Tasks + Updates (desktop grid) ────────── */}
-      <FadeRise delay={delay(TIMING.grid)}>
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-5">
-
-          {/* Recent Tasks */}
-          <Card className="md:col-span-3">
-            <CardHeader>
-              <div className="flex items-center gap-2">
-                <CheckSquare className="size-4 text-muted-foreground" />
-                <CardTitle className="text-xl font-semibold text-foreground">Recent Tasks</CardTitle>
-              </div>
-              <CardDescription>Latest tasks and their current status.</CardDescription>
-            </CardHeader>
-            <CardContent className="px-4 pt-1">
-              {tasks.length === 0 ? (
-                <EmptyState
-                  icon="CheckSquare"
-                  title="No tasks yet"
-                  description="Tasks will appear here as the team adds them."
-                />
-              ) : (
-                <Stagger
-                  className="relative flex flex-col gap-0"
-                  staggerMs={delay(TIMING.staggerMs)}
-                  delayMs={delay(TIMING.tasksStaggerDelayMs)}
-                >
-                  {(tasks as TaskWithAssignee[])
-                    .slice(0, 15)
-                    .map((task) => (
-                      <StaggerItem key={task.id}>
-                        {/* Desktop row */}
-                        <div className="hidden md:flex gap-3 py-4 border-b border-border last:border-0 last:pb-0">
-                          <div className="flex flex-1 min-w-0 flex-col gap-0.5">
-                            <p className="text-sm font-medium text-foreground truncate">{task.name}</p>
-                            <div className="flex items-center gap-2 flex-nowrap overflow-hidden">
-                              <Badge variant="outline" className="text-[11px] py-0 px-1.5 font-normal shrink-0">
-                                {task.status}
-                              </Badge>
-                              {task.assignee?.display_name && (
-                                <span className="text-xs text-muted-foreground truncate">
-                                  {task.assignee.display_name}
-                                </span>
+      {/* ── Recent Activity (grouped by day) ──────────────── */}
+      <FadeRise delay={delay(TIMING.summary)}>
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <Activity className="size-4 text-muted-foreground" />
+              <CardTitle className="text-xl font-semibold text-foreground">Recent Activity</CardTitle>
+            </div>
+            <CardDescription>Latest updates from the team.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {recentActivity.length === 0 ? (
+              <EmptyState
+                icon="Activity"
+                title="No activity yet"
+                description="Team updates will appear here."
+              />
+            ) : (
+              <div className="flex flex-col gap-0">
+                {activityGroups.map(group => (
+                  <div key={group.label}>
+                    <p className="text-[11px] font-medium text-muted-foreground/60 uppercase tracking-wider pt-3 pb-1.5 first:pt-0">
+                      {group.label}
+                    </p>
+                    {group.items.map((entry, i) => {
+                      const areaName = taskAreaLookup[(entry as typeof recentActivity[number]).target];
+                      return (
+                        <div key={i} className="flex items-start gap-3 py-2.5 border-b border-border last:border-0">
+                          <span
+                            className="mt-1.5 h-2 w-2 rounded-full shrink-0"
+                            style={{ backgroundColor: actionColor((entry as typeof recentActivity[number]).action) }}
+                            aria-hidden
+                          />
+                          <div className="min-w-0 flex-1">
+                            <p className="text-sm text-foreground">
+                              {areaName && (
+                                <span className="text-muted-foreground/60 mr-1.5">{areaName} &mdash;</span>
                               )}
-                              {task.deadline && (
-                                <span className="text-xs text-muted-foreground shrink-0">
-                                  Due {new Date(task.deadline).toLocaleDateString()}
-                                </span>
-                              )}
-                            </div>
+                              <span className="font-medium">{(entry as typeof recentActivity[number]).action}</span>
+                              {' '}
+                              <span className="text-muted-foreground">{(entry as typeof recentActivity[number]).target}</span>
+                            </p>
+                            <p className="text-xs text-muted-foreground/70 mt-0.5">
+                              {timeAgo(entry.created_at)}
+                            </p>
                           </div>
                         </div>
-                        {/* Mobile row — stacked layout */}
-                        <div className="flex md:hidden flex-col gap-1.5 py-3.5 border-b border-border last:border-0 last:pb-0">
-                          <p className="text-sm font-medium text-foreground line-clamp-2">{task.name}</p>
-                          <div className="flex items-center gap-2">
-                            <Badge variant="outline" className="text-[11px] py-0 px-1.5 font-normal shrink-0">
-                              {task.status}
-                            </Badge>
-                            {task.assignee?.display_name && (
-                              <span className="text-xs text-muted-foreground truncate">
-                                {task.assignee.display_name}
-                              </span>
-                            )}
-                          </div>
-                          {task.deadline && (
-                            <span className="text-[11px] text-muted-foreground">
-                              Due {new Date(task.deadline).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
-                            </span>
-                          )}
-                        </div>
-                      </StaggerItem>
-                    ))}
-                </Stagger>
-              )}
-            </CardContent>
-          </Card>
-
-          {/* Updates / Weekly Summary — desktop only (mobile version is above) */}
-          <Card className="hidden md:block md:col-span-2">
-            <CardHeader>
-              <div className="flex items-center gap-2">
-                <TrendingUp className="size-4 text-muted-foreground" />
-                <CardTitle className="text-xl font-semibold text-foreground">This Week</CardTitle>
+                      );
+                    })}
+                  </div>
+                ))}
               </div>
-              <CardDescription>Summary of the last 7 days.</CardDescription>
-            </CardHeader>
-            <CardContent>
-              {updates.length === 0 ? (
-                <EmptyState
-                  icon="TrendingUp"
-                  title="No updates yet"
-                  description="Activity from the past week will be summarised here."
-                />
-              ) : (
-                <ul className="flex flex-col gap-3">
-                  {updates.map((bullet, i) => (
-                    <li key={i} className="flex items-start gap-2.5">
-                      <span
-                        className="mt-1.5 h-1.5 w-1.5 rounded-full shrink-0"
-                        style={{ backgroundColor: 'var(--color-seeko-accent)' }}
-                        aria-hidden
-                      />
-                      <span className="text-sm text-muted-foreground">{bullet}</span>
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </CardContent>
-          </Card>
-
-        </div>
+            )}
+          </CardContent>
+        </Card>
       </FadeRise>
 
     </div>

--- a/src/app/(investor)/investor/payments/page.tsx
+++ b/src/app/(investor)/investor/payments/page.tsx
@@ -7,6 +7,10 @@ import type { Payment } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
 
+function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(amount);
+}
+
 export default async function InvestorPaymentsPage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
@@ -25,7 +29,9 @@ export default async function InvestorPaymentsPage() {
 
   const now = new Date();
   const monthStart = new Date(now.getFullYear(), now.getMonth(), 1).toISOString();
+  const lastMonthStart = new Date(now.getFullYear(), now.getMonth() - 1, 1).toISOString();
   const thisMonthPayments = payments.filter(p => p.paid_at && p.paid_at >= monthStart);
+  const lastMonthPayments = payments.filter(p => p.paid_at && p.paid_at >= lastMonthStart && p.paid_at < monthStart);
 
   const stats = {
     thisMonth: thisMonthPayments.reduce((sum, p) => sum + Number(p.amount), 0),
@@ -33,16 +39,41 @@ export default async function InvestorPaymentsPage() {
     peoplePaid: new Set(payments.map(p => p.recipient_id)).size,
   };
 
+  const lastMonthTotal = lastMonthPayments.reduce((sum, p) => sum + Number(p.amount), 0);
+
+  // Count distinct months for average calculation
+  const distinctMonths = new Set(
+    payments
+      .filter(p => p.paid_at)
+      .map(p => {
+        const d = new Date(p.paid_at!);
+        return `${d.getFullYear()}-${d.getMonth()}`;
+      })
+  ).size;
+
+  // Smart summary line
+  const thisMonthRecipients = new Set(thisMonthPayments.map(p => p.recipient_id)).size;
+  const summaryLine = stats.thisMonth > 0
+    ? `${formatCurrency(stats.thisMonth)} disbursed this month to ${thisMonthRecipients} team member${thisMonthRecipients !== 1 ? 's' : ''}.`
+    : payments.length > 0
+      ? `${formatCurrency(stats.allTime)} disbursed across ${stats.peoplePaid} team member${stats.peoplePaid !== 1 ? 's' : ''} total.`
+      : 'No payments recorded yet.';
+
   return (
     <div className="flex flex-col gap-6">
       <FadeRise delay={0}>
         <h1 className="text-2xl font-semibold tracking-tight text-foreground">Payments</h1>
         <p className="text-sm text-muted-foreground mt-1">
-          Completed payments to the team.
+          {summaryLine}
         </p>
       </FadeRise>
 
-      <PaymentsInvestor payments={payments} stats={stats} />
+      <PaymentsInvestor
+        payments={payments}
+        stats={stats}
+        lastMonthTotal={lastMonthTotal}
+        monthCount={distinctMonths}
+      />
     </div>
   );
 }

--- a/src/components/dashboard/CollapsibleInvestorAreas.tsx
+++ b/src/components/dashboard/CollapsibleInvestorAreas.tsx
@@ -12,10 +12,12 @@ interface CollapsibleInvestorAreasProps {
   areas: Area[];
   tasks: TaskWithAssignee[];
   subtitle: string;
+  defaultOpen?: boolean;
+  isAdmin?: boolean;
 }
 
-export function CollapsibleInvestorAreas({ areas, tasks, subtitle }: CollapsibleInvestorAreasProps) {
-  const [open, setOpen] = useState(false);
+export function CollapsibleInvestorAreas({ areas, tasks, subtitle, defaultOpen = false, isAdmin = false }: CollapsibleInvestorAreasProps) {
+  const [open, setOpen] = useState(defaultOpen);
 
   return (
     <Card>
@@ -55,6 +57,7 @@ export function CollapsibleInvestorAreas({ areas, tasks, subtitle }: Collapsible
                     key={area.id}
                     area={area}
                     tasksInArea={tasks.filter(t => t.area_id === area.id)}
+                    isAdmin={isAdmin}
                   />
                 ))}
               </Stagger>

--- a/src/components/dashboard/InvestorAreaCard.tsx
+++ b/src/components/dashboard/InvestorAreaCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { StaggerItem, HoverCard } from '@/components/motion';
@@ -10,17 +10,108 @@ import {
   DialogTitle,
   DialogClose,
 } from '@/components/ui/dialog';
-import { MousePointer } from 'lucide-react';
+import { createBrowserClient } from '@supabase/ssr';
+import { toast } from 'sonner';
+import { useHaptics } from '@/components/HapticsProvider';
 import type { Area } from '@/lib/types';
 import type { TaskWithAssignee } from '@/lib/types';
+import type { TaskStatus } from '@/lib/types';
+
+/* ── Constants ──────────────────────────────────────────── */
+
+const AREA_PHASES = ['Alpha', 'Beta', 'Launch'] as const;
+const AREA_STATUSES = ['Active', 'Planned', 'Complete'] as const;
+const TASK_STATUSES: TaskStatus[] = ['In Progress', 'In Review', 'Blocked', 'Complete'];
+
+function statusDotColor(status: string): string {
+  if (status === 'Active') return 'var(--color-seeko-accent)';
+  if (status === 'Complete') return 'var(--color-status-complete)';
+  return 'var(--color-muted-foreground)';
+}
+
+/* ── Props ──────────────────────────────────────────────── */
 
 interface InvestorAreaCardProps {
   area: Area;
   tasksInArea: TaskWithAssignee[];
+  isAdmin?: boolean;
 }
 
-export function InvestorAreaCard({ area, tasksInArea }: InvestorAreaCardProps) {
+export function InvestorAreaCard({ area, tasksInArea, isAdmin = false }: InvestorAreaCardProps) {
   const [open, setOpen] = useState(false);
+  const { trigger } = useHaptics();
+
+  /* ── Admin area editing state ──────────────────────────── */
+  const [editPhase, setEditPhase] = useState(area.phase ?? '');
+  const [editStatus, setEditStatus] = useState(area.status ?? '');
+  const [editDescription, setEditDescription] = useState(area.description ?? '');
+  const [editProgress, setEditProgress] = useState(area.progress);
+  const [saving, setSaving] = useState(false);
+
+  /* ── Admin task status state ───────────────────────────── */
+  const [taskStatuses, setTaskStatuses] = useState<Record<string, string>>(
+    () => Object.fromEntries(tasksInArea.map(t => [t.id, t.status]))
+  );
+
+  const hasAreaChanges =
+    editPhase !== (area.phase ?? '') ||
+    editStatus !== (area.status ?? '') ||
+    editDescription !== (area.description ?? '') ||
+    editProgress !== area.progress;
+
+  const supabase = isAdmin
+    ? createBrowserClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      )
+    : null;
+
+  /* ── Save area changes ─────────────────────────────────── */
+  const handleSaveArea = useCallback(async () => {
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/areas/${area.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          phase: editPhase || null,
+          status: editStatus || null,
+          description: editDescription || null,
+          progress: editProgress,
+        }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        toast.error(err?.error ?? 'Failed to update area');
+        trigger('error');
+        return;
+      }
+      toast.success('Area updated');
+      trigger('success');
+    } catch {
+      toast.error('Failed to update area');
+      trigger('error');
+    } finally {
+      setSaving(false);
+    }
+  }, [area.id, editPhase, editStatus, editDescription, editProgress, trigger]);
+
+  /* ── Update task status ────────────────────────────────── */
+  const handleTaskStatusChange = useCallback(async (taskId: string, newStatus: string) => {
+    if (!supabase) return;
+    setTaskStatuses(prev => ({ ...prev, [taskId]: newStatus }));
+    const { error } = await supabase.from('tasks').update({ status: newStatus }).eq('id', taskId);
+    if (error) {
+      toast.error('Failed to update task');
+      trigger('error');
+    } else {
+      toast.success('Task updated');
+      trigger('success');
+    }
+  }, [supabase, trigger]);
+
+  /* ── Shared select styling ─────────────────────────────── */
+  const selectClass = 'bg-muted/50 border border-border rounded-md px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-seeko-accent/40';
 
   return (
     <>
@@ -31,34 +122,46 @@ export function InvestorAreaCard({ area, tasksInArea }: InvestorAreaCardProps) {
             onClick={() => setOpen(true)}
             className="group relative w-full text-left rounded-xl border border-border bg-card transition-colors hover:bg-card/90 hover:border-border/80 focus:outline-none focus:ring-2 focus:ring-seeko-accent/30 cursor-pointer"
           >
-            <div className="absolute bottom-3 right-3 z-10 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
-              <MousePointer className="size-4 text-muted-foreground" aria-hidden />
-            </div>
             <Card className="border-0 shadow-none">
               <CardContent className="p-4 space-y-3">
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0 flex-1">
                     <p className="text-sm font-medium text-foreground truncate">{area.name}</p>
                     <div className="mt-2">
-                      <span className="text-xs text-muted-foreground">Progress</span>
-                      <div className="mt-1 w-full h-1.5 rounded-full bg-secondary overflow-hidden">
-                        <div
-                          className="h-full rounded-full transition-all"
-                          style={{ width: `${area.progress}%`, backgroundColor: 'var(--color-seeko-accent)' }}
-                        />
+                      <div className="flex items-center justify-between mb-1">
+                        <span className="text-xs text-muted-foreground">Progress</span>
+                        <span className="text-xs text-muted-foreground font-mono">
+                          {tasksInArea.filter(t => t.status === 'Complete').length}/{tasksInArea.length} tasks
+                        </span>
                       </div>
+                      {area.progress === 0 ? (
+                        <div className="flex items-center h-1.5">
+                          <span className="text-[10px] text-muted-foreground/50 font-medium uppercase tracking-wider">Not started</span>
+                        </div>
+                      ) : (
+                        <div className="w-full h-1.5 rounded-full bg-secondary overflow-hidden">
+                          <div
+                            className="h-full rounded-full transition-all"
+                            style={{ width: `${area.progress}%`, backgroundColor: 'var(--color-seeko-accent)' }}
+                          />
+                        </div>
+                      )}
                     </div>
                   </div>
-                  <div className="flex flex-col items-end justify-start gap-1 shrink-0">
+                  <div className="flex flex-col items-end justify-start gap-1.5 shrink-0">
                     {area.phase && (
-                      <span className="rounded border border-border px-1.5 py-0.5 text-xs text-muted-foreground font-mono">
+                      <span className="text-[11px] text-muted-foreground/70 font-mono tracking-wide uppercase">
                         {area.phase}
                       </span>
                     )}
                     {area.status && (
-                      <Badge variant="outline" className="text-[10px] py-0 px-1.5 font-normal rounded-md">
-                        {area.status}
-                      </Badge>
+                      <div className="flex items-center gap-1.5">
+                        <span
+                          className="size-1.5 rounded-full shrink-0"
+                          style={{ backgroundColor: statusDotColor(area.status) }}
+                        />
+                        <span className="text-[11px] text-muted-foreground font-medium">{area.status}</span>
+                      </div>
                     )}
                     <span className="text-xs font-mono text-muted-foreground">{area.progress}%</span>
                   </div>
@@ -78,34 +181,136 @@ export function InvestorAreaCard({ area, tasksInArea }: InvestorAreaCardProps) {
         <DialogClose onClose={() => setOpen(false)} />
         <DialogHeader>
           <DialogTitle>{area.name}</DialogTitle>
-          <div className="flex flex-wrap items-center gap-2 mt-1">
-            {area.phase && (
-              <span className="rounded border border-border px-1.5 py-0.5 text-xs text-muted-foreground font-mono">
-                {area.phase}
-              </span>
-            )}
-            {area.status && (
-              <Badge variant="outline" className="text-xs font-normal">
-                {area.status}
-              </Badge>
-            )}
-          </div>
+
+          {/* ── Phase & status: editable for admins ──────── */}
+          {isAdmin ? (
+            <div className="flex flex-wrap items-center gap-2 mt-1.5">
+              <select
+                value={editPhase}
+                onChange={e => setEditPhase(e.target.value)}
+                className={selectClass}
+              >
+                <option value="">No phase</option>
+                {AREA_PHASES.map(p => (
+                  <option key={p} value={p}>{p}</option>
+                ))}
+              </select>
+              <select
+                value={editStatus}
+                onChange={e => setEditStatus(e.target.value)}
+                className={selectClass}
+              >
+                <option value="">No status</option>
+                {AREA_STATUSES.map(s => (
+                  <option key={s} value={s}>{s}</option>
+                ))}
+              </select>
+            </div>
+          ) : (
+            <div className="flex flex-wrap items-center gap-3 mt-1">
+              {area.phase && (
+                <span className="text-xs text-muted-foreground/70 font-mono tracking-wide uppercase">
+                  {area.phase}
+                </span>
+              )}
+              {area.status && (
+                <div className="flex items-center gap-1.5">
+                  <span
+                    className="size-1.5 rounded-full shrink-0"
+                    style={{ backgroundColor: statusDotColor(area.status) }}
+                  />
+                  <span className="text-xs text-muted-foreground font-medium">{area.status}</span>
+                </div>
+              )}
+            </div>
+          )}
         </DialogHeader>
-        {area.description && (
+
+        {/* ── Description: editable for admins ──────────── */}
+        {isAdmin ? (
+          <div className="mb-4">
+            <label className="text-xs text-muted-foreground font-medium mb-1 block">Description</label>
+            <textarea
+              value={editDescription}
+              onChange={e => setEditDescription(e.target.value)}
+              placeholder="Add a description..."
+              rows={2}
+              className="w-full bg-muted/50 border border-border rounded-md px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-seeko-accent/40 resize-none"
+            />
+          </div>
+        ) : area.description ? (
           <p className="text-sm text-muted-foreground leading-relaxed mb-4">{area.description}</p>
-        )}
+        ) : null}
+
+        {/* ── Progress: editable slider for admins ──────── */}
         <div className="mb-4">
           <div className="flex items-center justify-between mb-1.5">
             <span className="text-sm font-medium text-foreground">Overall progress</span>
-            <span className="text-sm font-mono text-muted-foreground">{area.progress}%</span>
+            {isAdmin ? (
+              <div className="flex items-center gap-0.5">
+                <input
+                  type="number"
+                  min={0}
+                  max={100}
+                  value={editProgress}
+                  onChange={e => {
+                    const n = Math.min(100, Math.max(0, Number(e.target.value) || 0));
+                    setEditProgress(n);
+                  }}
+                  className="w-10 text-right text-sm font-mono text-muted-foreground bg-transparent border-b border-transparent focus:border-seeko-accent focus:outline-none transition-colors [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                />
+                <span className="text-sm text-muted-foreground">%</span>
+              </div>
+            ) : (
+              <span className="text-sm font-mono text-muted-foreground">{area.progress}%</span>
+            )}
           </div>
-          <div className="w-full h-2 rounded-full bg-secondary overflow-hidden">
-            <div
-              className="h-full rounded-full transition-all"
-              style={{ width: `${area.progress}%`, backgroundColor: 'var(--color-seeko-accent)' }}
-            />
-          </div>
+          {isAdmin ? (
+            <>
+              <input
+                type="range"
+                min={0}
+                max={100}
+                value={editProgress}
+                onChange={e => setEditProgress(Number(e.target.value))}
+                className="w-full h-2 rounded-full appearance-none bg-secondary cursor-pointer accent-[#6ee7b7] [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-seeko-accent [&::-webkit-slider-thumb]:shadow-md"
+              />
+              <div className="w-full h-1.5 rounded-full bg-secondary overflow-hidden mt-1">
+                <div
+                  className="h-full rounded-full transition-all duration-200"
+                  style={{ width: `${editProgress}%`, backgroundColor: 'var(--color-seeko-accent)' }}
+                />
+              </div>
+            </>
+          ) : editProgress === 0 ? (
+            <div className="flex items-center h-2">
+              <span className="text-xs text-muted-foreground/50 font-medium uppercase tracking-wider">Not started</span>
+            </div>
+          ) : (
+            <div className="w-full h-2 rounded-full bg-secondary overflow-hidden">
+              <div
+                className="h-full rounded-full transition-all"
+                style={{ width: `${area.progress}%`, backgroundColor: 'var(--color-seeko-accent)' }}
+              />
+            </div>
+          )}
         </div>
+
+        {/* ── Save button for area changes ──────────────── */}
+        {isAdmin && hasAreaChanges && (
+          <div className="mb-4">
+            <button
+              type="button"
+              onClick={handleSaveArea}
+              disabled={saving}
+              className="px-4 py-1.5 text-sm font-medium rounded-lg bg-seeko-accent text-[#1a1a1a] hover:bg-seeko-accent/90 disabled:opacity-50 transition-colors"
+            >
+              {saving ? 'Saving...' : 'Save changes'}
+            </button>
+          </div>
+        )}
+
+        {/* ── Tasks list ─────────────────────────────────── */}
         <div>
           <h3 className="text-sm font-medium text-foreground mb-2">
             Tasks in this area ({tasksInArea.length})
@@ -126,9 +331,21 @@ export function InvestorAreaCard({ area, tasksInArea }: InvestorAreaCardProps) {
                         {task.assignee.display_name}
                       </span>
                     )}
-                    <Badge variant="outline" className="text-[10px] py-0 px-1.5 font-normal">
-                      {task.status}
-                    </Badge>
+                    {isAdmin ? (
+                      <select
+                        value={taskStatuses[task.id] ?? task.status}
+                        onChange={e => handleTaskStatusChange(task.id, e.target.value)}
+                        className={selectClass}
+                      >
+                        {TASK_STATUSES.map(s => (
+                          <option key={s} value={s}>{s}</option>
+                        ))}
+                      </select>
+                    ) : (
+                      <Badge variant="outline" className="text-[10px] py-0 px-1.5 font-normal">
+                        {task.status}
+                      </Badge>
+                    )}
                   </div>
                 </li>
               ))}

--- a/src/components/dashboard/InvestorKPIStrip.tsx
+++ b/src/components/dashboard/InvestorKPIStrip.tsx
@@ -1,0 +1,333 @@
+'use client';
+
+/* ─────────────────────────────────────────────────────────
+ * ANIMATION STORYBOARD — Investor KPI Strip
+ *
+ *    0ms   4 stat cards stagger in (80ms apart)
+ *          progress ring draws in over 700ms
+ *          blocked/overdue cards glow red/amber when > 0
+ *
+ *  on click (admin only):
+ *    0ms   backdrop fades in
+ *   50ms   dialog scales up 0.95 → 1
+ *  150ms   area rows stagger in (60ms apart)
+ * ───────────────────────────────────────────────────────── */
+
+import { useState } from 'react';
+import { TrendingUp, AlertCircle, Map } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader } from '@/components/ui/card';
+import { Dialog, DialogHeader, DialogTitle, DialogClose } from '@/components/ui/dialog';
+import { FadeRise, Stagger, StaggerItem, HoverCard } from '@/components/motion';
+import { toast } from 'sonner';
+import { useHaptics } from '@/components/HapticsProvider';
+
+interface AreaProgress {
+  id: string;
+  name: string;
+  progress: number;
+}
+
+interface InvestorKPIStripProps {
+  overallPct: number;
+  completedThisWeek: number;
+  blocked: number;
+  overdue: number;
+  activeAreas: number;
+  areas?: AreaProgress[];
+  isAdmin?: boolean;
+  delay?: number;
+}
+
+function ProgressRing({ pct }: { pct: number }) {
+  const r = 11;
+  const circumference = 2 * Math.PI * r;
+  const offset = circumference - (pct / 100) * circumference;
+
+  return (
+    <div className="relative flex size-8 items-center justify-center rounded-lg bg-secondary shrink-0">
+      <svg className="size-6 -rotate-90" viewBox="0 0 26 26">
+        <circle cx="13" cy="13" r={r} fill="none" stroke="var(--color-muted-foreground)" opacity="0.3" strokeWidth="2.5" />
+        <circle
+          cx="13" cy="13" r={r}
+          fill="none"
+          stroke="var(--color-seeko-accent)"
+          strokeWidth="2.5"
+          strokeDasharray={circumference}
+          strokeDashoffset={offset}
+          strokeLinecap="round"
+          className="transition-all duration-700"
+        />
+      </svg>
+    </div>
+  );
+}
+
+/* ── Large ring for the dialog ────────────────────────── */
+function LargeProgressRing({ pct }: { pct: number }) {
+  const r = 54;
+  const circumference = 2 * Math.PI * r;
+  const offset = circumference - (pct / 100) * circumference;
+
+  return (
+    <div className="relative size-32 shrink-0 mx-auto">
+      <svg className="size-full -rotate-90" viewBox="0 0 120 120">
+        <circle cx="60" cy="60" r={r} fill="none" stroke="var(--color-muted-foreground)" opacity="0.15" strokeWidth="8" />
+        <circle
+          cx="60" cy="60" r={r}
+          fill="none"
+          stroke="var(--color-seeko-accent)"
+          strokeWidth="8"
+          strokeDasharray={circumference}
+          strokeDashoffset={offset}
+          strokeLinecap="round"
+          className="transition-all duration-500"
+        />
+      </svg>
+      <span className="absolute inset-0 flex items-center justify-center text-2xl font-semibold text-foreground">
+        {pct}%
+      </span>
+    </div>
+  );
+}
+
+export function InvestorKPIStrip({
+  overallPct: initialOverallPct,
+  completedThisWeek,
+  blocked,
+  overdue,
+  activeAreas,
+  areas: initialAreas = [],
+  isAdmin = false,
+  delay: baseDelay = 0,
+}: InvestorKPIStripProps) {
+  const d = (ms: number) => (baseDelay + ms) / 1000;
+  const { trigger } = useHaptics();
+
+  const hasIssues = blocked > 0 || overdue > 0;
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [areaValues, setAreaValues] = useState<Record<string, number>>(() =>
+    Object.fromEntries(initialAreas.map(a => [a.id, a.progress]))
+  );
+  const [saving, setSaving] = useState<string | null>(null);
+
+  // Compute live overall % from area values
+  const liveOverallPct = initialAreas.length > 0
+    ? Math.round(Object.values(areaValues).reduce((sum, v) => sum + v, 0) / initialAreas.length)
+    : initialOverallPct;
+
+  async function handleSave(areaId: string) {
+    const value = areaValues[areaId];
+    if (value === undefined) return;
+
+    setSaving(areaId);
+    try {
+      const res = await fetch(`/api/areas/${areaId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ progress: value }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        toast.error(err?.error ?? 'Failed to update');
+        trigger('error');
+        return;
+      }
+      toast.success('Progress updated');
+      trigger('success');
+    } catch {
+      toast.error('Failed to update');
+      trigger('error');
+    } finally {
+      setSaving(null);
+    }
+  }
+
+  function handleCompletionClick() {
+    if (!isAdmin) return;
+    trigger('selection');
+    setDialogOpen(true);
+  }
+
+  return (
+    <>
+      <FadeRise delay={d(0)}>
+        <Stagger className="grid grid-cols-2 md:grid-cols-4 gap-3" staggerMs={0.08}>
+          {/* Overall Completion — clickable for admins */}
+          <StaggerItem>
+            <HoverCard>
+              {isAdmin ? (
+                <button type="button" onClick={handleCompletionClick} className="w-full text-left">
+                  <Card className="h-full transition-colors hover:border-seeko-accent/30">
+                    <CardHeader className="flex flex-row items-center justify-between pb-2">
+                      <CardDescription className="text-sm font-medium">Completion</CardDescription>
+                      <ProgressRing pct={liveOverallPct} />
+                    </CardHeader>
+                    <CardContent>
+                      <span className="text-2xl font-semibold tracking-tight">{liveOverallPct}%</span>
+                      <p className="text-xs text-muted-foreground mt-0.5">overall progress</p>
+                    </CardContent>
+                  </Card>
+                </button>
+              ) : (
+                <Card className="h-full">
+                  <CardHeader className="flex flex-row items-center justify-between pb-2">
+                    <CardDescription className="text-sm font-medium">Completion</CardDescription>
+                    <ProgressRing pct={liveOverallPct} />
+                  </CardHeader>
+                  <CardContent>
+                    <span className="text-2xl font-semibold tracking-tight">{liveOverallPct}%</span>
+                    <p className="text-xs text-muted-foreground mt-0.5">overall progress</p>
+                  </CardContent>
+                </Card>
+              )}
+            </HoverCard>
+          </StaggerItem>
+
+          {/* Completed This Week */}
+          <StaggerItem>
+            <HoverCard>
+              <Card>
+                <CardHeader className="flex flex-row items-center justify-between pb-2">
+                  <CardDescription className="text-sm font-medium">This Week</CardDescription>
+                  <div className="flex size-8 items-center justify-center rounded-lg bg-secondary">
+                    <TrendingUp className="size-4 text-muted-foreground" />
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <span className="text-2xl font-semibold tracking-tight">{completedThisWeek}</span>
+                  <p className="text-xs text-muted-foreground mt-0.5">tasks completed</p>
+                </CardContent>
+              </Card>
+            </HoverCard>
+          </StaggerItem>
+
+          {/* Blocked / Overdue */}
+          <StaggerItem>
+            <HoverCard>
+              <Card className={hasIssues ? 'border-red-900/40 bg-red-950/10' : ''}>
+                <CardHeader className="flex flex-row items-center justify-between pb-2">
+                  <CardDescription className="text-sm font-medium">Issues</CardDescription>
+                  <div className={`flex size-8 items-center justify-center rounded-lg ${hasIssues ? 'bg-red-950/30' : 'bg-secondary'}`}>
+                    <AlertCircle className={`size-4 ${hasIssues ? 'text-red-400' : 'text-muted-foreground'}`} />
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  {hasIssues ? (
+                    <div className="flex items-baseline gap-2">
+                      {blocked > 0 && (
+                        <span className="text-2xl font-semibold tracking-tight text-red-400">{blocked}</span>
+                      )}
+                      {blocked > 0 && overdue > 0 && (
+                        <span className="text-muted-foreground">/</span>
+                      )}
+                      {overdue > 0 && (
+                        <span className="text-2xl font-semibold tracking-tight text-amber-400">{overdue}</span>
+                      )}
+                    </div>
+                  ) : (
+                    <span className="text-2xl font-semibold tracking-tight">0</span>
+                  )}
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    {blocked > 0 && overdue > 0
+                      ? `${blocked} blocked · ${overdue} overdue`
+                      : blocked > 0
+                        ? 'blocked'
+                        : overdue > 0
+                          ? 'overdue'
+                          : 'all clear'}
+                  </p>
+                </CardContent>
+              </Card>
+            </HoverCard>
+          </StaggerItem>
+
+          {/* Active Areas */}
+          <StaggerItem>
+            <HoverCard>
+              <Card>
+                <CardHeader className="flex flex-row items-center justify-between pb-2">
+                  <CardDescription className="text-sm font-medium">Active Areas</CardDescription>
+                  <div className="flex size-8 items-center justify-center rounded-lg bg-secondary">
+                    <Map className="size-4 text-muted-foreground" />
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <span className="text-2xl font-semibold tracking-tight">{activeAreas}</span>
+                  <p className="text-xs text-muted-foreground mt-0.5">in development</p>
+                </CardContent>
+              </Card>
+            </HoverCard>
+          </StaggerItem>
+        </Stagger>
+      </FadeRise>
+
+      {/* ── Completion Editor Dialog (admin only) ────────── */}
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen} contentClassName="max-w-md">
+        <DialogClose onClose={() => setDialogOpen(false)} />
+        <DialogHeader>
+          <DialogTitle>Update Completion</DialogTitle>
+          <p className="text-sm text-muted-foreground">Adjust progress per area. Changes save individually.</p>
+        </DialogHeader>
+
+        <div className="flex flex-col items-center gap-6">
+          <LargeProgressRing pct={liveOverallPct} />
+
+          <div className="w-full flex flex-col gap-4">
+            {initialAreas.map(area => {
+              const value = areaValues[area.id] ?? area.progress;
+              const changed = value !== area.progress;
+              return (
+                <div key={area.id} className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm font-medium text-foreground">{area.name}</span>
+                    <div className="flex items-center gap-0.5">
+                      <input
+                        type="number"
+                        min={0}
+                        max={100}
+                        value={value}
+                        onChange={e => {
+                          const n = Math.min(100, Math.max(0, Number(e.target.value) || 0));
+                          setAreaValues(prev => ({ ...prev, [area.id]: n }));
+                        }}
+                        className="w-10 text-right text-sm font-mono text-muted-foreground bg-transparent border-b border-transparent focus:border-seeko-accent focus:outline-none transition-colors [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                      />
+                      <span className="text-sm text-muted-foreground">%</span>
+                    </div>
+                  </div>
+                  <input
+                    type="range"
+                    min={0}
+                    max={100}
+                    value={value}
+                    onChange={e => setAreaValues(prev => ({ ...prev, [area.id]: Number(e.target.value) }))}
+                    className="w-full h-2 rounded-full appearance-none bg-secondary cursor-pointer accent-[#6ee7b7] [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-seeko-accent [&::-webkit-slider-thumb]:shadow-md"
+                  />
+                  <div className="flex items-center justify-between">
+                    <div className="w-full h-1.5 rounded-full bg-secondary overflow-hidden">
+                      <div
+                        className="h-full rounded-full transition-all duration-200"
+                        style={{ width: `${value}%`, backgroundColor: 'var(--color-seeko-accent)' }}
+                      />
+                    </div>
+                    {changed && (
+                      <button
+                        type="button"
+                        onClick={() => handleSave(area.id)}
+                        disabled={saving === area.id}
+                        className="ml-3 shrink-0 px-3 py-1 text-xs font-medium rounded-lg bg-seeko-accent text-[#1a1a1a] hover:bg-seeko-accent/90 disabled:opacity-50 transition-colors"
+                      >
+                        {saving === area.id ? 'Saving…' : 'Save'}
+                      </button>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/dashboard/PaymentsInvestor.tsx
+++ b/src/components/dashboard/PaymentsInvestor.tsx
@@ -1,11 +1,25 @@
 'use client';
 
-import { DollarSign, Users, Calendar } from 'lucide-react';
+/* ─────────────────────────────────────────────────────────
+ * ANIMATION STORYBOARD — Investor Payments
+ *
+ *    0ms   stat cards stagger in (80ms apart)
+ *  150ms   monthly breakdown card fades up
+ *  300ms   department + top recipients side-by-side fade up
+ *  450ms   recent payments card fades up
+ * ───────────────────────────────────────────────────────── */
+
+import { useState } from 'react';
+import { DollarSign, Users, Calendar, TrendingUp, ChevronDown, ChevronUp, ArrowUp, ArrowDown } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { FadeRise, Stagger, StaggerItem, HoverCard } from '@/components/motion';
 import { EmptyState } from '@/components/ui/empty-state';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
+import { motion, AnimatePresence } from 'motion/react';
 import type { Payment } from '@/lib/types';
+
+/* ─── Helpers ────────────────────────────────────────────── */
 
 function getInitials(name: string): string {
   return name.split(' ').map(p => p[0]).join('').toUpperCase().slice(0, 2) || '?';
@@ -15,6 +29,26 @@ function formatCurrency(amount: number): string {
   return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(amount);
 }
 
+function formatCompact(amount: number): string {
+  if (amount >= 1000) return `$${(amount / 1000).toFixed(1)}k`;
+  return formatCurrency(amount);
+}
+
+/* ─── Department color map ───────────────────────────────── */
+const DEPT_COLORS: Record<string, string> = {
+  'Coding':          '#6ee7b7',
+  'Visual Art':      '#93c5fd',
+  'UI/UX':           '#c4b5fd',
+  'Animation':       '#fbbf24',
+  'Asset Creation':  '#f9a8d4',
+};
+
+function deptColor(dept: string): string {
+  return DEPT_COLORS[dept] ?? '#6ee7b7';
+}
+
+/* ─── Props ──────────────────────────────────────────────── */
+
 interface PaymentsInvestorProps {
   payments: Payment[];
   stats: {
@@ -22,12 +56,19 @@ interface PaymentsInvestorProps {
     allTime: number;
     peoplePaid: number;
   };
+  lastMonthTotal?: number;
+  monthCount?: number;
   delay?: number;
 }
 
-export function PaymentsInvestor({ payments, stats, delay: baseDelay = 0 }: PaymentsInvestorProps) {
-  const d = (ms: number) => (baseDelay + ms) / 1000;
+const INITIAL_VISIBLE = 10;
 
+export function PaymentsInvestor({ payments, stats, lastMonthTotal, monthCount = 1, delay: baseDelay = 0 }: PaymentsInvestorProps) {
+  const d = (ms: number) => (baseDelay + ms) / 1000;
+  const [showAll, setShowAll] = useState(false);
+  const [expandedPayment, setExpandedPayment] = useState<string | null>(null);
+
+  /* ── Monthly breakdown with bars ─────────────────────── */
   const monthlyBreakdown = payments.reduce<Record<string, { total: number; count: number }>>((acc, p) => {
     const date = new Date(p.paid_at!);
     const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
@@ -40,20 +81,64 @@ export function PaymentsInvestor({ payments, stats, delay: baseDelay = 0 }: Paym
   const months = Object.entries(monthlyBreakdown)
     .sort(([a], [b]) => b.localeCompare(a))
     .map(([key, data]) => ({
+      key,
       label: new Date(key + '-01').toLocaleDateString('en-US', { month: 'long', year: 'numeric' }),
       ...data,
     }));
 
-  const recentPayments = payments.slice(0, 10);
+  const maxMonthTotal = Math.max(...months.map(m => m.total), 1);
+
+  /* ── Department breakdown (proportional) ───────────────── */
+  const deptTotals = payments.reduce<Record<string, number>>((acc, p) => {
+    const dept = p.recipient?.department ?? 'Other';
+    acc[dept] = (acc[dept] ?? 0) + Number(p.amount);
+    return acc;
+  }, {});
+
+  const deptEntries = Object.entries(deptTotals)
+    .sort(([, a], [, b]) => b - a);
+  const deptGrandTotal = deptEntries.reduce((sum, [, v]) => sum + v, 0) || 1;
+
+  /* ── Per-person spend breakdown ────────────────────────── */
+  const personTotals = payments.reduce<Record<string, { name: string; avatar_url?: string; total: number; count: number }>>((acc, p) => {
+    const id = p.recipient_id ?? 'unknown';
+    if (!acc[id]) acc[id] = { name: p.recipient?.display_name ?? 'Unknown', avatar_url: p.recipient?.avatar_url ?? undefined, total: 0, count: 0 };
+    acc[id].total += Number(p.amount);
+    acc[id].count += 1;
+    return acc;
+  }, {});
+
+  const topRecipients = Object.entries(personTotals)
+    .sort(([, a], [, b]) => b.total - a.total)
+    .slice(0, 5);
+
+  /* ── Recent payments ─────────────────────────────────── */
+  const visiblePayments = showAll ? payments : payments.slice(0, INITIAL_VISIBLE);
+  const hasMore = payments.length > INITIAL_VISIBLE;
+
+  /* ── Month-over-month delta (neutral treatment) ────────── */
+  const monthDelta = lastMonthTotal != null && lastMonthTotal > 0
+    ? Math.round(((stats.thisMonth - lastMonthTotal) / lastMonthTotal) * 100)
+    : null;
+
+  /* ── Average monthly spend ─────────────────────────────── */
+  const avgMonthly = monthCount > 0 ? stats.allTime / monthCount : stats.allTime;
 
   const statCards = [
-    { label: 'This Month', value: stats.thisMonth, icon: Calendar, format: true },
-    { label: 'All Time', value: stats.allTime, icon: DollarSign, format: true },
+    {
+      label: 'This Month',
+      value: stats.thisMonth,
+      icon: Calendar,
+      format: true,
+      delta: monthDelta,
+    },
+    { label: 'Avg / Month', value: avgMonthly, icon: TrendingUp, format: true },
     { label: 'People Paid', value: stats.peoplePaid, icon: Users, format: false },
   ];
 
   return (
     <>
+      {/* ── Stat Cards ──────────────────────────────────── */}
       <FadeRise delay={d(0)}>
         <Stagger className="grid grid-cols-1 sm:grid-cols-3 gap-4" staggerMs={0.08}>
           {statCards.map(stat => (
@@ -70,6 +155,15 @@ export function PaymentsInvestor({ payments, stats, delay: baseDelay = 0 }: Paym
                     <span className="text-2xl font-semibold tracking-tight">
                       {stat.format ? formatCurrency(stat.value) : stat.value}
                     </span>
+                    {'delta' in stat && stat.delta != null && (
+                      <p className="text-xs mt-0.5 font-medium text-muted-foreground flex items-center gap-1">
+                        {stat.delta >= 0
+                          ? <ArrowUp className="size-3" />
+                          : <ArrowDown className="size-3" />
+                        }
+                        {Math.abs(stat.delta)}% vs last month
+                      </p>
+                    )}
                   </CardContent>
                 </Card>
               </HoverCard>
@@ -78,6 +172,7 @@ export function PaymentsInvestor({ payments, stats, delay: baseDelay = 0 }: Paym
         </Stagger>
       </FadeRise>
 
+      {/* ── Monthly Breakdown with spend bars ──────────── */}
       <FadeRise delay={d(150)}>
         <Card>
           <CardHeader>
@@ -94,13 +189,24 @@ export function PaymentsInvestor({ payments, stats, delay: baseDelay = 0 }: Paym
             ) : (
               <div className="flex flex-col gap-0">
                 {months.map(month => (
-                  <div key={month.label} className="flex items-center justify-between py-3 border-b border-border last:border-0">
-                    <span className="text-sm text-foreground">{month.label}</span>
-                    <div className="flex items-center gap-3">
-                      <span className="text-sm font-medium text-foreground">{formatCurrency(month.total)}</span>
-                      <span className="text-xs text-muted-foreground">
-                        {month.count} payment{month.count !== 1 ? 's' : ''}
-                      </span>
+                  <div key={month.key} className="py-3 border-b border-border last:border-0">
+                    <div className="flex items-center justify-between mb-1.5">
+                      <span className="text-sm text-foreground">{month.label}</span>
+                      <div className="flex items-center gap-3">
+                        <span className="text-sm font-medium text-foreground">{formatCurrency(month.total)}</span>
+                        <span className="text-xs text-muted-foreground w-20 text-right">
+                          {month.count} payment{month.count !== 1 ? 's' : ''}
+                        </span>
+                      </div>
+                    </div>
+                    <div className="w-full h-2 rounded-full bg-secondary overflow-hidden">
+                      <div
+                        className="h-full rounded-full transition-all duration-500"
+                        style={{
+                          width: `${(month.total / maxMonthTotal) * 100}%`,
+                          backgroundColor: 'var(--color-seeko-accent)',
+                        }}
+                      />
                     </div>
                   </div>
                 ))}
@@ -110,14 +216,114 @@ export function PaymentsInvestor({ payments, stats, delay: baseDelay = 0 }: Paym
         </Card>
       </FadeRise>
 
+      {/* ── Department Breakdown + Top Recipients ────────── */}
       <FadeRise delay={d(300)}>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+
+          {/* Department — stacked proportional bar + legend */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-xl font-semibold text-foreground">By Department</CardTitle>
+              <CardDescription>Allocation across teams.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {deptEntries.length === 0 ? (
+                <EmptyState
+                  icon="Users"
+                  title="No data yet"
+                  description="Department breakdown will appear here."
+                />
+              ) : (
+                <div className="flex flex-col gap-4">
+                  {/* Stacked bar */}
+                  <div className="w-full h-4 rounded-full bg-secondary overflow-hidden flex">
+                    {deptEntries.map(([dept, total]) => (
+                      <div
+                        key={dept}
+                        className="h-full first:rounded-l-full last:rounded-r-full transition-all duration-500"
+                        style={{
+                          width: `${(total / deptGrandTotal) * 100}%`,
+                          backgroundColor: deptColor(dept),
+                        }}
+                      />
+                    ))}
+                  </div>
+                  {/* Legend */}
+                  <div className="flex flex-col gap-2">
+                    {deptEntries.map(([dept, total]) => {
+                      const pct = Math.round((total / deptGrandTotal) * 100);
+                      return (
+                        <div key={dept} className="flex items-center justify-between">
+                          <div className="flex items-center gap-2">
+                            <span
+                              className="size-2.5 rounded-full shrink-0"
+                              style={{ backgroundColor: deptColor(dept) }}
+                            />
+                            <span className="text-sm text-foreground">{dept}</span>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <span className="text-xs text-muted-foreground font-mono">{pct}%</span>
+                            <span className="text-sm text-muted-foreground w-20 text-right">{formatCompact(total)}</span>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Top Recipients */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-xl font-semibold text-foreground">Top Recipients</CardTitle>
+              <CardDescription>Highest paid team members.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {topRecipients.length === 0 ? (
+                <EmptyState
+                  icon="Users"
+                  title="No data yet"
+                  description="Recipient breakdown will appear here."
+                />
+              ) : (
+                <div className="flex flex-col gap-0">
+                  {topRecipients.map(([id, person], idx) => (
+                    <div key={id} className="flex items-center gap-3 py-2.5 border-b border-border last:border-0">
+                      <span className="text-xs text-muted-foreground/60 font-mono w-4 shrink-0">{idx + 1}</span>
+                      <Avatar className="size-7 shrink-0">
+                        <AvatarImage src={person.avatar_url ?? undefined} />
+                        <AvatarFallback className="bg-secondary text-foreground text-[10px]">
+                          {getInitials(person.name)}
+                        </AvatarFallback>
+                      </Avatar>
+                      <div className="min-w-0 flex-1">
+                        <p className="text-sm font-medium text-foreground truncate">{person.name}</p>
+                        <p className="text-xs text-muted-foreground">{person.count} payment{person.count !== 1 ? 's' : ''}</p>
+                      </div>
+                      <span className="text-sm font-medium text-foreground shrink-0">{formatCurrency(person.total)}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+        </div>
+      </FadeRise>
+
+      {/* ── Recent Payments (expandable rows) ──────────── */}
+      <FadeRise delay={d(450)}>
         <Card>
           <CardHeader>
             <CardTitle className="text-xl font-semibold text-foreground">Recent Payments</CardTitle>
-            <CardDescription>Last 10 completed payments.</CardDescription>
+            <CardDescription>
+              {payments.length} completed payment{payments.length !== 1 ? 's' : ''} total.
+            </CardDescription>
           </CardHeader>
           <CardContent>
-            {recentPayments.length === 0 ? (
+            {payments.length === 0 ? (
               <EmptyState
                 icon="CreditCard"
                 title="No payments yet"
@@ -125,27 +331,104 @@ export function PaymentsInvestor({ payments, stats, delay: baseDelay = 0 }: Paym
               />
             ) : (
               <div className="flex flex-col gap-0">
-                {recentPayments.map(payment => (
-                  <div key={payment.id} className="flex items-center justify-between py-3 border-b border-border last:border-0">
-                    <div className="flex items-center gap-3 min-w-0">
-                      <Avatar className="size-8">
-                        <AvatarImage src={payment.recipient?.avatar_url ?? undefined} />
-                        <AvatarFallback className="bg-secondary text-foreground text-[10px]">
-                          {getInitials(payment.recipient?.display_name ?? '?')}
-                        </AvatarFallback>
-                      </Avatar>
-                      <p className="text-sm font-medium text-foreground truncate">
-                        {payment.recipient?.display_name}
-                      </p>
+                {visiblePayments.map(payment => {
+                  const isExpanded = expandedPayment === payment.id;
+                  const hasItems = payment.items && payment.items.length > 0;
+                  const hasDesc = !!payment.description;
+                  const isClickable = hasItems || hasDesc;
+
+                  return (
+                    <div key={payment.id} className="border-b border-border last:border-0">
+                      <button
+                        type="button"
+                        onClick={() => isClickable && setExpandedPayment(isExpanded ? null : payment.id)}
+                        className={`w-full text-left py-3 ${isClickable ? 'cursor-pointer hover:bg-white/[0.02] transition-colors' : 'cursor-default'}`}
+                      >
+                        <div className="flex items-center justify-between">
+                          <div className="flex items-center gap-3 min-w-0">
+                            <Avatar className="size-8 shrink-0">
+                              <AvatarImage src={payment.recipient?.avatar_url ?? undefined} />
+                              <AvatarFallback className="bg-secondary text-foreground text-[10px]">
+                                {getInitials(payment.recipient?.display_name ?? '?')}
+                              </AvatarFallback>
+                            </Avatar>
+                            <div className="min-w-0">
+                              <p className="text-sm font-medium text-foreground truncate">
+                                {payment.recipient?.display_name}
+                              </p>
+                              {hasDesc && (
+                                <p className="text-xs text-muted-foreground truncate mt-0.5">
+                                  {payment.description}
+                                </p>
+                              )}
+                            </div>
+                          </div>
+                          <div className="flex items-center gap-2 shrink-0">
+                            <div className="text-right">
+                              <span className="text-sm font-medium text-foreground">{formatCurrency(Number(payment.amount))}</span>
+                              <p className="text-xs text-muted-foreground">
+                                {new Date(payment.paid_at!).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+                              </p>
+                            </div>
+                            {isClickable && (
+                              isExpanded
+                                ? <ChevronUp className="size-3.5 text-muted-foreground" />
+                                : <ChevronDown className="size-3.5 text-muted-foreground" />
+                            )}
+                          </div>
+                        </div>
+                      </button>
+
+                      {/* Expandable line items */}
+                      <AnimatePresence>
+                        {isExpanded && (
+                          <motion.div
+                            initial={{ height: 0, opacity: 0 }}
+                            animate={{ height: 'auto', opacity: 1 }}
+                            exit={{ height: 0, opacity: 0 }}
+                            transition={{ type: 'spring', stiffness: 300, damping: 28 }}
+                            className="overflow-hidden"
+                          >
+                            <div className="pb-3 pl-11 pr-2">
+                              <div className="rounded-lg bg-muted/40 border border-border/50 p-3 flex flex-col gap-1.5">
+                                {payment.items && payment.items.length > 0 ? (
+                                  payment.items.map(item => (
+                                    <div key={item.id} className="flex items-center justify-between text-xs">
+                                      <span className="text-muted-foreground truncate">{item.label}</span>
+                                      <span className="text-foreground font-medium shrink-0 ml-2">
+                                        {formatCurrency(Number(item.amount))}
+                                      </span>
+                                    </div>
+                                  ))
+                                ) : hasDesc ? (
+                                  <p className="text-xs text-muted-foreground">{payment.description}</p>
+                                ) : null}
+                                {payment.recipient?.department && (
+                                  <div className="mt-1.5 pt-1.5 border-t border-border/50">
+                                    <Badge variant="outline" className="text-[10px] py-0 px-1.5 font-normal">
+                                      {payment.recipient.department}
+                                    </Badge>
+                                  </div>
+                                )}
+                              </div>
+                            </div>
+                          </motion.div>
+                        )}
+                      </AnimatePresence>
                     </div>
-                    <div className="flex items-center gap-3 shrink-0">
-                      <span className="text-sm font-medium text-foreground">{formatCurrency(Number(payment.amount))}</span>
-                      <span className="text-xs text-muted-foreground">
-                        {new Date(payment.paid_at!).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
-                      </span>
-                    </div>
-                  </div>
-                ))}
+                  );
+                })}
+
+                {/* Show all / Show less toggle */}
+                {hasMore && (
+                  <button
+                    type="button"
+                    onClick={() => setShowAll(prev => !prev)}
+                    className="w-full py-3 text-sm font-medium text-seeko-accent hover:text-seeko-accent/80 transition-colors"
+                  >
+                    {showAll ? `Show less` : `Show all ${payments.length} payments`}
+                  </button>
+                )}
               </div>
             )}
           </CardContent>


### PR DESCRIPTION
## Summary
- **Health summary banner** below hero — dynamic one-liner that answers "is the project healthy?" with red-tinted treatment when blocked/overdue issues exist
- **Game Areas open by default** with task counts (X/Y tasks) on each card, 0% bars replaced with "Not Started" label
- **Activity feed grouped by day** (Today/Yesterday/date) with area context prefixes for each entry
- **Phase vs status badge differentiation** — phase shown as mono uppercase text, status as colored dot + label
- **Admin area editing** — admins can edit phase, status, description, and progress via the area detail dialog, plus change task statuses via dropdown
- **Payments: Avg/Month metric** replaces All Time stat for burn rate visibility
- **Payments: Stacked proportional bar** for department breakdown with percentage legend (replaces duplicate bar chart pattern)
- **Payments: Top Recipients card** showing per-person spend concentration
- **Payments: Neutral delta colors** using arrow icons instead of ambiguous color-coding
- **Payments: Smart summary header** — "$X disbursed this month to Y team members" replaces static copy

## Test plan
- [ ] Verify investor dashboard loads with health summary, KPI strip, open game areas, grouped activity
- [ ] Verify admin can edit area phase/status/description/progress and save
- [ ] Verify admin can change task status from area dialog dropdown
- [ ] Verify non-admin sees read-only view (no edit controls)
- [ ] Verify payments page shows Avg/Month, stacked dept bar, top recipients
- [ ] Verify month-over-month delta shows neutral arrow icons
- [ ] Verify page header shows dynamic summary line
- [ ] Verify empty states render correctly when no data exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)