### PR TITLE
Dashboard polish: task improvements, tour fixes, command palette decks

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -68,7 +68,8 @@ export default async function DashboardLayout({
       <ActivityTracker userId={user.id} />
       <CommandPalette
         team={team.map((m) => ({ id: m.id, display_name: m.display_name }))}
-        docs={accessibleDocs.map((d) => ({ id: d.id, title: d.title }))}
+        docs={accessibleDocs.filter((d) => d.type !== 'deck').map((d) => ({ id: d.id, title: d.title }))}
+        decks={accessibleDocs.filter((d) => d.type === 'deck').map((d) => ({ id: d.id, title: d.title }))}
         isContractor={profile?.is_contractor ?? false}
       />
     </DashboardTourWrapper>

--- a/src/components/dashboard/CommandPalette.tsx
+++ b/src/components/dashboard/CommandPalette.tsx
@@ -93,7 +93,7 @@ export function CommandPalette({ team, docs, decks = [], isContractor = false }:
   }, [team, docs, decks, go, setOpen, isContractor]);
 
   const filtered = useMemo(() => {
-    if (!query) return items.slice(0, 12);
+    if (!query) return items;
     const q = query.toLowerCase();
     return items.filter((item) => {
       const haystack = `${item.label} ${item.section} ${item.keywords ?? ''}`.toLowerCase();

--- a/src/components/dashboard/CommandPalette.tsx
+++ b/src/components/dashboard/CommandPalette.tsx
@@ -13,7 +13,7 @@ import { useState, useMemo, useRef, useEffect, useCallback } from 'react';
 import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
 import { useRouter } from 'next/navigation';
 import {
-  LayoutDashboard, Users, FileText, Activity, Settings, Search, PanelLeftClose, DollarSign,
+  LayoutDashboard, Users, FileText, Activity, Settings, Search, PanelLeftClose, DollarSign, Presentation,
 } from 'lucide-react';
 import { useCommandPalette } from '@/lib/hooks/useCommandPalette';
 import type { Profile, Doc } from '@/lib/types';
@@ -25,7 +25,7 @@ const ROW_STAGGER = 0.025;
 type CommandItem = {
   id: string;
   label: string;
-  section: 'Pages' | 'Team' | 'Docs' | 'Actions';
+  section: 'Pages' | 'Team' | 'Docs' | 'Decks' | 'Actions';
   icon: React.ElementType;
   action: () => void;
   keywords?: string;
@@ -34,10 +34,11 @@ type CommandItem = {
 interface CommandPaletteProps {
   team: Pick<Profile, 'id' | 'display_name'>[];
   docs: Pick<Doc, 'id' | 'title'>[];
+  decks?: Pick<Doc, 'id' | 'title'>[];
   isContractor?: boolean;
 }
 
-export function CommandPalette({ team, docs, isContractor = false }: CommandPaletteProps) {
+export function CommandPalette({ team, docs, decks = [], isContractor = false }: CommandPaletteProps) {
   const { open, setOpen } = useCommandPalette();
   const [query, setQuery] = useState('');
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -77,11 +78,19 @@ export function CommandPalette({ team, docs, isContractor = false }: CommandPale
       action: () => go(`/docs?doc=${d.id}`),
       keywords: d.title,
     }));
+    const deckItems: CommandItem[] = decks.map((d) => ({
+      id: `dk-${d.id}`,
+      label: d.title,
+      section: 'Decks',
+      icon: Presentation,
+      action: () => go(`/docs?doc=${d.id}`),
+      keywords: d.title,
+    }));
     const actions: CommandItem[] = [
       { id: 'a-sidebar', label: 'Toggle Sidebar', section: 'Actions', icon: PanelLeftClose, action: () => { setOpen(false); document.dispatchEvent(new CustomEvent('toggle-sidebar')); } },
     ];
-    return [...pages, ...teamItems, ...docItems, ...actions];
-  }, [team, docs, go, setOpen, isContractor]);
+    return [...pages, ...teamItems, ...docItems, ...deckItems, ...actions];
+  }, [team, docs, decks, go, setOpen, isContractor]);
 
   const filtered = useMemo(() => {
     if (!query) return items.slice(0, 12);

--- a/src/components/dashboard/SettingsPanel.tsx
+++ b/src/components/dashboard/SettingsPanel.tsx
@@ -16,7 +16,7 @@ import { Camera, Check, Eye, MousePointer, Monitor, UserX, AlertTriangle, Rotate
 import { toast } from 'sonner';
 import { Profile, UserEvent, Task, Payment } from '@/lib/types';
 import { useHaptics } from '@/components/HapticsProvider';
-import { useTour } from '@/components/ui/tour';
+import { useTourMaybe } from '@/components/ui/tour';
 import { PaymentRequestDialog } from '@/components/dashboard/PaymentRequestDialog';
 import { formatCurrency } from '@/lib/format';
 import { cn } from '@/lib/utils';
@@ -732,7 +732,9 @@ export function SettingsPanel({ profile, isAdmin, team, revalidate, completedTas
 }
 
 function ReplayTourCard({ userId }: { userId: string }) {
-  const { setIsTourCompleted, startTour, isTourCompleted } = useTour();
+  const tour = useTourMaybe();
+  if (!tour) return null;
+  const { setIsTourCompleted, startTour } = tour;
   const [replaying, setReplaying] = useState(false);
 
   const supabase = createBrowserClient(

--- a/src/components/dashboard/SettingsPanel.tsx
+++ b/src/components/dashboard/SettingsPanel.tsx
@@ -12,6 +12,7 @@ import { Select } from '@/components/ui/select';
 import { Separator } from '@/components/ui/separator';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
+import { motion, AnimatePresence } from 'motion/react';
 import { Camera, Check, Eye, MousePointer, Monitor, UserX, AlertTriangle, RotateCcw, DollarSign, Vibrate, Lock, ChevronDown } from 'lucide-react';
 import { toast } from 'sonner';
 import { Profile, UserEvent, Task, Payment } from '@/lib/types';
@@ -21,6 +22,8 @@ import { PaymentRequestDialog } from '@/components/dashboard/PaymentRequestDialo
 import { formatCurrency } from '@/lib/format';
 import { cn } from '@/lib/utils';
 import { Switch } from '@/components/ui/switch';
+
+const COLLAPSE_SPRING = { type: 'spring' as const, stiffness: 360, damping: 39, mass: 2.4 };
 
 const COMMON_TIMEZONES = [
   'America/New_York', 'America/Chicago', 'America/Denver', 'America/Los_Angeles',
@@ -391,55 +394,65 @@ export function SettingsPanel({ profile, isAdmin, team, revalidate, completedTas
             <ChevronDown className={cn("size-4 text-muted-foreground transition-transform duration-200", pwOpen && "rotate-180")} />
           </button>
 
-          {pwOpen && (
-            <div className="flex flex-col gap-4">
-              <div className="space-y-2">
-                <Label htmlFor="current-password">Current Password</Label>
-                <Input
-                  id="current-password"
-                  type="password"
-                  value={currentPassword}
-                  onChange={e => { setCurrentPassword(e.target.value); setPwError(''); }}
-                  placeholder="Enter current password"
-                />
-              </div>
-              <div className="grid gap-4 sm:grid-cols-2">
-                <div className="space-y-2">
-                  <Label htmlFor="new-password">New Password</Label>
-                  <Input
-                    id="new-password"
-                    type="password"
-                    value={newPassword}
-                    onChange={e => { setNewPassword(e.target.value); setPwError(''); }}
-                    placeholder="At least 8 characters"
-                  />
+          <AnimatePresence>
+            {pwOpen && (
+              <motion.div
+                initial={{ height: 0, opacity: 0 }}
+                animate={{ height: 'auto', opacity: 1 }}
+                exit={{ height: 0, opacity: 0 }}
+                transition={COLLAPSE_SPRING}
+                className="overflow-hidden"
+              >
+                <div className="flex flex-col gap-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="current-password">Current Password</Label>
+                    <Input
+                      id="current-password"
+                      type="password"
+                      value={currentPassword}
+                      onChange={e => { setCurrentPassword(e.target.value); setPwError(''); }}
+                      placeholder="Enter current password"
+                    />
+                  </div>
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <div className="space-y-2">
+                      <Label htmlFor="new-password">New Password</Label>
+                      <Input
+                        id="new-password"
+                        type="password"
+                        value={newPassword}
+                        onChange={e => { setNewPassword(e.target.value); setPwError(''); }}
+                        placeholder="At least 8 characters"
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="confirm-password">Confirm New Password</Label>
+                      <Input
+                        id="confirm-password"
+                        type="password"
+                        value={confirmPassword}
+                        onChange={e => { setConfirmPassword(e.target.value); setPwError(''); }}
+                        placeholder="Re-enter new password"
+                        onKeyDown={e => e.key === 'Enter' && handleChangePassword()}
+                      />
+                    </div>
+                  </div>
+                  {pwError && <p className="text-sm text-destructive">{pwError}</p>}
+                  {pwSuccess && <p className="text-sm text-seeko-accent">Password updated successfully.</p>}
+                  <div className="flex justify-end">
+                    <Button
+                      type="button"
+                      onClick={handleChangePassword}
+                      disabled={pwSaving}
+                      className="gap-2 min-w-[7.5rem] min-h-[2.5rem] touch-manipulation"
+                    >
+                      {pwSaving ? 'Updating...' : 'Update Password'}
+                    </Button>
+                  </div>
                 </div>
-                <div className="space-y-2">
-                  <Label htmlFor="confirm-password">Confirm New Password</Label>
-                  <Input
-                    id="confirm-password"
-                    type="password"
-                    value={confirmPassword}
-                    onChange={e => { setConfirmPassword(e.target.value); setPwError(''); }}
-                    placeholder="Re-enter new password"
-                    onKeyDown={e => e.key === 'Enter' && handleChangePassword()}
-                  />
-                </div>
-              </div>
-              {pwError && <p className="text-sm text-destructive">{pwError}</p>}
-              {pwSuccess && <p className="text-sm text-seeko-accent">Password updated successfully.</p>}
-              <div className="flex justify-end">
-                <Button
-                  type="button"
-                  onClick={handleChangePassword}
-                  disabled={pwSaving}
-                  className="gap-2 min-w-[7.5rem] min-h-[2.5rem] touch-manipulation"
-                >
-                  {pwSaving ? 'Updating...' : 'Update Password'}
-                </Button>
-              </div>
-            </div>
-          )}
+              </motion.div>
+            )}
+          </AnimatePresence>
         </CardContent>
       </Card>
 

--- a/src/components/ui/tour.tsx
+++ b/src/components/ui/tour.tsx
@@ -427,6 +427,11 @@ export function useTour() {
   return context;
 }
 
+/** Safe variant — returns null when outside a TourProvider instead of throwing. */
+export function useTourMaybe() {
+  return useContext(TourContext);
+}
+
 export function TourAlertDialog({
   isOpen,
   setIsOpen,


### PR DESCRIPTION
## Summary
- **Task page**: priority dots, summary bar, smart sort (status→priority), stronger filter pills, row animations
- **Tour fixes**: mobile compatibility (separate IDs, viewport clamping), replay tour single-click fix (stale closure → useRef), admin "More" step on mobile, ReplayTourCard crash fix for investor panel
- **Command palette**: decks section with presentation icon, removed 12-item cap so all sections show
- **Agreement form**: engagement type locked based on invite role
- **Settings**: animated change password collapsible (matching invite form spring)
- **Bug fixes**: assignees not populating, task priority layout shift, deck sizing, PDF digital signature

## Test plan
- [ ] Open tasks page — priority dots, summary bar, sort order
- [ ] Run onboarding tour on mobile — highlights clamp to viewport, shows "More" for admins
- [ ] Replay tour from settings — works on first click
- [ ] Open investor settings — no crash (ReplayTourCard hidden gracefully)
- [ ] Open ⌘K — decks appear in their own section below docs
- [ ] Open /agreement — engagement type toggle is locked
- [ ] Expand change password in settings — smooth spring animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)