### PR TITLE
feat: deadline extensions, activity filters, task detail redesign

### DIFF
--- a/docs/plans/2026-03-08-deadline-extensions-design.md
+++ b/docs/plans/2026-03-08-deadline-extensions-design.md
@@ -1,0 +1,69 @@
+# Deadline Extension Requests — Design
+
+**Goal:** Let team members request more time on a task deadline. Admins receive a notification, review in-context inside TaskDetail, and approve or deny.
+
+## Data Model
+
+New `deadline_extensions` table:
+
+| Column | Type | Notes |
+|--------|------|-------|
+| id | uuid (PK) | Auto-generated |
+| task_id | uuid (FK) | → tasks.id |
+| requested_by | uuid (FK) | → profiles.id |
+| extra_hours | integer | Offset in hours (days = n × 24) |
+| original_deadline | date | Snapshot of deadline at request time |
+| new_deadline | date | original + offset |
+| status | text | pending, approved, denied |
+| decided_by | uuid (FK, nullable) | → profiles.id |
+| decided_at | timestamptz (nullable) | When admin acted |
+| denial_reason | text (nullable) | Optional note on denial |
+| created_at | timestamptz | Default now() |
+
+**RLS:**
+- Members can read their own requests + insert for tasks they're assigned to
+- Admins can read all + update status
+
+**Constraint:** Only one pending request per task at a time (enforced in API).
+
+## Notification Kinds
+
+Three new kinds added to `NotificationKind`:
+- `deadline_extension_requested` — sent to all admins
+- `deadline_extension_approved` — sent to requester
+- `deadline_extension_denied` — sent to requester
+
+## Team Member Flow (TaskDetail)
+
+"Request more time" button appears when:
+- User is the assignee
+- Task has a deadline
+- No pending request exists
+
+Clicking reveals an inline form:
+- Segmented toggle: Hours / Days
+- Number input for amount
+- Preview: "New deadline: Mar 15"
+- Submit button
+
+While pending: button replaced by status line "Extension requested — waiting for approval" with amount shown.
+
+## Admin Flow (TaskDetail)
+
+Banner at top of TaskDetail when pending request exists:
+- Shows: requester name, amount, current → proposed deadline
+- Approve button (green accent) — updates deadline immediately
+- Deny button (ghost) — reveals optional reason text input, then confirm
+
+## API Routes
+
+- `POST /api/deadline-extensions` — create request (validates assignee, deadline exists, no pending)
+- `PATCH /api/deadline-extensions/[id]` — approve or deny (admin only, updates task deadline on approve)
+
+Both trigger notifications via existing `/api/notify/*`.
+
+## Activity Log
+
+New action types logged to activity table:
+- "Requested extension" on task
+- "Approved extension" / "Denied extension" on task

--- a/docs/plans/2026-03-08-deadline-extensions.md
+++ b/docs/plans/2026-03-08-deadline-extensions.md
@@ -1,0 +1,923 @@
+# Deadline Extension Requests Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Let team members request deadline extensions on tasks; admins approve/deny from a banner inside TaskDetail.
+
+**Architecture:** New `deadline_extensions` table stores requests with status tracking. Two API routes handle create + decide. TaskDetail renders a request form (assignee) or approval banner (admin). Notifications use the existing `/api/notify/*` infrastructure. Activity log records all extension events.
+
+**Tech Stack:** Next.js 16 App Router, Supabase Postgres, TypeScript, Motion (framer-motion)
+
+---
+
+### Task 1: Database Migration
+
+**Files:**
+- Create: `supabase/migrations/20260308000000_deadline_extensions.sql`
+- Modify: `docs/supabase-schema.sql` (append new table documentation)
+
+**Step 1: Write the migration SQL**
+
+Create `supabase/migrations/20260308000000_deadline_extensions.sql`:
+
+```sql
+-- Deadline extension requests
+create table public.deadline_extensions (
+  id                uuid primary key default gen_random_uuid(),
+  task_id           uuid not null references public.tasks(id) on delete cascade,
+  requested_by      uuid not null references public.profiles(id) on delete cascade,
+  extra_hours       integer not null,
+  original_deadline date not null,
+  new_deadline      date not null,
+  status            text not null default 'pending' check (status in ('pending', 'approved', 'denied')),
+  decided_by        uuid references public.profiles(id),
+  decided_at        timestamptz,
+  denial_reason     text,
+  created_at        timestamptz not null default now()
+);
+
+alter table public.deadline_extensions enable row level security;
+
+-- Members can read their own requests
+create policy "Users can read own extension requests"
+  on public.deadline_extensions for select
+  using (auth.uid() = requested_by);
+
+-- Admins can read all requests
+create policy "Admins can read all extension requests"
+  on public.deadline_extensions for select
+  using (
+    exists (
+      select 1 from public.profiles
+      where id = auth.uid() and is_admin = true
+    )
+  );
+
+-- Members can insert requests for tasks they are assigned to
+create policy "Assignees can request extensions"
+  on public.deadline_extensions for insert
+  with check (
+    auth.uid() = requested_by
+    and exists (
+      select 1 from public.tasks
+      where id = task_id and assignee_id = auth.uid()
+    )
+  );
+
+-- Admins can update (approve/deny)
+create policy "Admins can decide on extensions"
+  on public.deadline_extensions for update
+  using (
+    exists (
+      select 1 from public.profiles
+      where id = auth.uid() and is_admin = true
+    )
+  );
+
+-- Index for fast lookup of pending requests per task
+create index idx_deadline_extensions_task_status
+  on public.deadline_extensions (task_id, status)
+  where status = 'pending';
+```
+
+**Step 2: Apply the migration**
+
+Run:
+```bash
+npx supabase db push
+```
+
+If using Supabase MCP, use `apply_migration` tool instead.
+
+**Step 3: Update schema docs**
+
+Append the new table to `docs/supabase-schema.sql` after the activity_log section:
+
+```sql
+-- ─── Deadline Extensions ──────────────────────────────────────────────────
+
+create table public.deadline_extensions (
+  id                uuid primary key default gen_random_uuid(),
+  task_id           uuid not null references public.tasks(id) on delete cascade,
+  requested_by      uuid not null references public.profiles(id) on delete cascade,
+  extra_hours       integer not null,
+  original_deadline date not null,
+  new_deadline      date not null,
+  status            text not null default 'pending',
+  decided_by        uuid references public.profiles(id),
+  decided_at        timestamptz,
+  denial_reason     text,
+  created_at        timestamptz not null default now()
+);
+```
+
+**Step 4: Commit**
+
+```bash
+git add supabase/migrations/20260308000000_deadline_extensions.sql docs/supabase-schema.sql
+git commit -m "feat: add deadline_extensions table and migration"
+```
+
+---
+
+### Task 2: TypeScript Types & Notification Kinds
+
+**Files:**
+- Modify: `src/lib/types.ts` (lines ~151-160 for NotificationKind, add DeadlineExtension type)
+
+**Step 1: Add DeadlineExtension type**
+
+After the `Notification` type (around line 181), add:
+
+```typescript
+export type DeadlineExtension = {
+  id: string;
+  task_id: string;
+  requested_by: string;
+  extra_hours: number;
+  original_deadline: string;
+  new_deadline: string;
+  status: 'pending' | 'approved' | 'denied';
+  decided_by?: string | null;
+  decided_at?: string | null;
+  denial_reason?: string | null;
+  created_at: string;
+};
+```
+
+**Step 2: Add notification kinds**
+
+Update the `NotificationKind` type (lines 151-160) to add three new values:
+
+```typescript
+export type NotificationKind =
+  | 'task_assigned'
+  | 'mentioned'
+  | 'comment_reply'
+  | 'task_completed'
+  | 'deliverable_uploaded'
+  | 'task_handoff'
+  | 'payment_request'
+  | 'payment_approved'
+  | 'payment_denied'
+  | 'deadline_extension_requested'
+  | 'deadline_extension_approved'
+  | 'deadline_extension_denied';
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/lib/types.ts
+git commit -m "feat: add DeadlineExtension type and notification kinds"
+```
+
+---
+
+### Task 3: Notification Kind Enum Migration
+
+**Files:**
+- Create: `supabase/migrations/20260308000001_deadline_extension_notification_kinds.sql`
+
+**Step 1: Write the migration**
+
+The notification bell component (`NotificationBell.tsx`) uses a `KIND_CONFIG` map. The `notifications.kind` column is `text`, not a Postgres enum, so no SQL enum update is needed. But we need to add the new kinds to the bell's config.
+
+Check if there's an existing enum migration pattern. Looking at `20260305000005_notification_kind_enum_values.sql` — if `kind` is a Postgres enum, we need to add values:
+
+```sql
+-- Add deadline extension notification kinds
+-- (Only needed if kind column uses a Postgres enum — skip if it's text)
+alter type notification_kind add value if not exists 'deadline_extension_requested';
+alter type notification_kind add value if not exists 'deadline_extension_approved';
+alter type notification_kind add value if not exists 'deadline_extension_denied';
+```
+
+**Step 2: Apply migration**
+
+```bash
+npx supabase db push
+```
+
+**Step 3: Commit**
+
+```bash
+git add supabase/migrations/20260308000001_deadline_extension_notification_kinds.sql
+git commit -m "feat: add deadline extension notification kind enum values"
+```
+
+---
+
+### Task 4: API Route — Create Extension Request
+
+**Files:**
+- Create: `src/app/api/deadline-extensions/route.ts`
+
+**Step 1: Implement the POST handler**
+
+Create `src/app/api/deadline-extensions/route.ts`:
+
+```typescript
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { createServiceClient } from '@/lib/supabase/service';
+
+export async function POST(request: Request) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = await request.json();
+  const { taskId, extraHours } = body as { taskId?: string; extraHours?: number };
+
+  if (!taskId || !extraHours || extraHours < 1) {
+    return NextResponse.json({ error: 'taskId and extraHours (>= 1) are required' }, { status: 400 });
+  }
+
+  // Fetch task to validate assignee + deadline
+  const { data: task, error: taskError } = await supabase
+    .from('tasks')
+    .select('id, name, assignee_id, deadline')
+    .eq('id', taskId)
+    .single();
+
+  if (taskError || !task) {
+    return NextResponse.json({ error: 'Task not found' }, { status: 404 });
+  }
+  if (task.assignee_id !== user.id) {
+    return NextResponse.json({ error: 'Only the assignee can request an extension' }, { status: 403 });
+  }
+  if (!task.deadline) {
+    return NextResponse.json({ error: 'Task has no deadline' }, { status: 400 });
+  }
+
+  // Check for existing pending request
+  const { data: existing } = await supabase
+    .from('deadline_extensions')
+    .select('id')
+    .eq('task_id', taskId)
+    .eq('status', 'pending')
+    .limit(1);
+
+  if (existing && existing.length > 0) {
+    return NextResponse.json({ error: 'A pending request already exists for this task' }, { status: 409 });
+  }
+
+  // Compute new deadline
+  const originalDate = new Date(task.deadline + 'T00:00:00');
+  const newDate = new Date(originalDate.getTime() + extraHours * 3600000);
+  const newDeadline = newDate.toISOString().split('T')[0];
+
+  // Insert the request
+  const service = createServiceClient();
+  const { data: extension, error: insertError } = await service
+    .from('deadline_extensions')
+    .insert({
+      task_id: taskId,
+      requested_by: user.id,
+      extra_hours: extraHours,
+      original_deadline: task.deadline,
+      new_deadline: newDeadline,
+      status: 'pending',
+    })
+    .select()
+    .single();
+
+  if (insertError) {
+    return NextResponse.json({ error: insertError.message }, { status: 500 });
+  }
+
+  // Log activity
+  await service.from('activity_log').insert({
+    user_id: user.id,
+    action: 'Requested extension',
+    target: `task: ${task.name}`,
+    task_id: taskId,
+  });
+
+  // Notify admins
+  const daysOrHours = extraHours >= 24
+    ? `${Math.round(extraHours / 24)} day${Math.round(extraHours / 24) !== 1 ? 's' : ''}`
+    : `${extraHours} hour${extraHours !== 1 ? 's' : ''}`;
+
+  await fetch(new URL('/api/notify/admins', request.url), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      cookie: request.headers.get('cookie') ?? '',
+    },
+    body: JSON.stringify({
+      kind: 'deadline_extension_requested',
+      title: `Extension requested on "${task.name}"`,
+      body: `+${daysOrHours} — new deadline would be ${newDeadline}`,
+      link: `/tasks?task=${taskId}`,
+    }),
+  });
+
+  return NextResponse.json({ success: true, extension });
+}
+```
+
+**Step 2: Verify the service client import exists**
+
+Check that `src/lib/supabase/service.ts` exports `createServiceClient`. If it doesn't exist, look for how other API routes (e.g., `/api/notify/admins/route.ts`) create a service role client and use the same pattern.
+
+**Step 3: Test manually**
+
+Start dev server (`npm run dev`), log in as an assignee, and POST via browser console:
+```javascript
+fetch('/api/deadline-extensions', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ taskId: '<some-task-id>', extraHours: 48 }),
+}).then(r => r.json()).then(console.log)
+```
+
+Expected: `{ success: true, extension: { ... } }`
+
+**Step 4: Commit**
+
+```bash
+git add src/app/api/deadline-extensions/route.ts
+git commit -m "feat: add POST /api/deadline-extensions for requesting extensions"
+```
+
+---
+
+### Task 5: API Route — Approve/Deny Extension
+
+**Files:**
+- Create: `src/app/api/deadline-extensions/[id]/route.ts`
+
+**Step 1: Implement the PATCH handler**
+
+Create `src/app/api/deadline-extensions/[id]/route.ts`:
+
+```typescript
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { createServiceClient } from '@/lib/supabase/service';
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  // Verify admin
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('is_admin')
+    .eq('id', user.id)
+    .single();
+
+  if (!profile?.is_admin) {
+    return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
+  }
+
+  const body = await request.json();
+  const { action, reason } = body as { action?: 'approve' | 'deny'; reason?: string };
+
+  if (action !== 'approve' && action !== 'deny') {
+    return NextResponse.json({ error: 'action must be "approve" or "deny"' }, { status: 400 });
+  }
+
+  const service = createServiceClient();
+
+  // Fetch the extension request
+  const { data: ext, error: fetchError } = await service
+    .from('deadline_extensions')
+    .select('*, tasks(name, deadline)')
+    .eq('id', id)
+    .single();
+
+  if (fetchError || !ext) {
+    return NextResponse.json({ error: 'Extension request not found' }, { status: 404 });
+  }
+  if (ext.status !== 'pending') {
+    return NextResponse.json({ error: 'Request already resolved' }, { status: 409 });
+  }
+
+  const newStatus = action === 'approve' ? 'approved' : 'denied';
+
+  // Update the extension request
+  const { error: updateError } = await service
+    .from('deadline_extensions')
+    .update({
+      status: newStatus,
+      decided_by: user.id,
+      decided_at: new Date().toISOString(),
+      denial_reason: action === 'deny' ? (reason ?? null) : null,
+    })
+    .eq('id', id);
+
+  if (updateError) {
+    return NextResponse.json({ error: updateError.message }, { status: 500 });
+  }
+
+  // If approved, update the task's deadline
+  if (action === 'approve') {
+    const { error: taskError } = await service
+      .from('tasks')
+      .update({ deadline: ext.new_deadline })
+      .eq('id', ext.task_id);
+
+    if (taskError) {
+      return NextResponse.json({ error: 'Extension approved but deadline update failed' }, { status: 500 });
+    }
+  }
+
+  // Log activity
+  const taskName = (ext as any).tasks?.name ?? 'a task';
+  await service.from('activity_log').insert({
+    user_id: user.id,
+    action: action === 'approve' ? 'Approved extension' : 'Denied extension',
+    target: `task: ${taskName}`,
+    task_id: ext.task_id,
+  });
+
+  // Notify the requester
+  const notifKind = action === 'approve'
+    ? 'deadline_extension_approved'
+    : 'deadline_extension_denied';
+
+  const notifBody = action === 'approve'
+    ? `New deadline: ${ext.new_deadline}`
+    : reason
+      ? `Reason: ${reason}`
+      : 'No reason provided.';
+
+  await fetch(new URL('/api/notify/user', request.url), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      cookie: request.headers.get('cookie') ?? '',
+    },
+    body: JSON.stringify({
+      userId: ext.requested_by,
+      kind: notifKind,
+      title: `Deadline extension ${newStatus} for "${taskName}"`,
+      body: notifBody,
+      link: `/tasks?task=${ext.task_id}`,
+    }),
+  });
+
+  return NextResponse.json({ success: true, status: newStatus });
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/app/api/deadline-extensions/
+git commit -m "feat: add PATCH /api/deadline-extensions/[id] for approve/deny"
+```
+
+---
+
+### Task 6: Data Fetcher — Pending Extension for a Task
+
+**Files:**
+- Modify: `src/lib/supabase/data.ts`
+
+**Step 1: Add fetchPendingExtension function**
+
+Add after the `fetchActivity` function:
+
+```typescript
+export async function fetchPendingExtension(taskId: string) {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from('deadline_extensions')
+    .select('*, profiles!requested_by(display_name)')
+    .eq('task_id', taskId)
+    .eq('status', 'pending')
+    .limit(1)
+    .maybeSingle();
+
+  if (error) return null;
+  return data;
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/lib/supabase/data.ts
+git commit -m "feat: add fetchPendingExtension data fetcher"
+```
+
+---
+
+### Task 7: NotificationBell — Add New Kind Icons
+
+**Files:**
+- Modify: `src/components/dashboard/NotificationBell.tsx`
+
+**Step 1: Find the KIND_CONFIG map and add three new entries**
+
+Add these to the `KIND_CONFIG` object. Import `Clock` from lucide-react if not already imported:
+
+```typescript
+deadline_extension_requested: { icon: Clock,       className: 'text-amber-400',    bg: 'bg-amber-500/10' },
+deadline_extension_approved:  { icon: CheckCircle2, className: 'text-emerald-500',  bg: 'bg-emerald-500/10' },
+deadline_extension_denied:    { icon: CircleX,      className: 'text-red-400',      bg: 'bg-red-500/10' },
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/components/dashboard/NotificationBell.tsx
+git commit -m "feat: add deadline extension icons to notification bell"
+```
+
+---
+
+### Task 8: TaskDetail — Extension Request Form (Assignee)
+
+**Files:**
+- Modify: `src/components/dashboard/TaskDetail.tsx`
+
+This is the assignee-facing UI. Add it below the deadline callout section (after line ~1123), before the metadata row.
+
+**Step 1: Add state for extension form**
+
+Inside the `TaskDetail` component function, after the existing state declarations, add:
+
+```typescript
+const [showExtForm, setShowExtForm] = useState(false);
+const [extUnit, setExtUnit] = useState<'hours' | 'days'>('days');
+const [extAmount, setExtAmount] = useState(1);
+const [extSubmitting, setExtSubmitting] = useState(false);
+const [pendingExt, setPendingExt] = useState<{
+  id: string;
+  extra_hours: number;
+  new_deadline: string;
+  status: string;
+  profiles?: { display_name?: string };
+} | null>(null);
+```
+
+**Step 2: Add effect to fetch pending extension**
+
+After the state declarations, add an effect:
+
+```typescript
+useEffect(() => {
+  if (!open || !task.id) return;
+  const fetchExt = async () => {
+    const res = await supabase
+      .from('deadline_extensions')
+      .select('id, extra_hours, new_deadline, status, profiles!requested_by(display_name)')
+      .eq('task_id', task.id)
+      .eq('status', 'pending')
+      .limit(1)
+      .maybeSingle();
+    setPendingExt(res.data ?? null);
+  };
+  fetchExt();
+}, [open, task.id, supabase]);
+```
+
+**Step 3: Add the submit handler**
+
+```typescript
+const handleExtensionRequest = async () => {
+  setExtSubmitting(true);
+  const totalHours = extUnit === 'days' ? extAmount * 24 : extAmount;
+  try {
+    const res = await fetch('/api/deadline-extensions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ taskId: task.id, extraHours: totalHours }),
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      toast.error(data.error ?? 'Failed to request extension');
+      return;
+    }
+    toast.success('Extension requested');
+    setPendingExt(data.extension);
+    setShowExtForm(false);
+  } catch {
+    toast.error('Network error');
+  } finally {
+    setExtSubmitting(false);
+  }
+};
+```
+
+**Step 4: Add the UI below the urgent deadline callout**
+
+After the urgent deadline callout block (around line 1123) and before the metadata row, add:
+
+```tsx
+{/* Extension request — assignee only */}
+{task.deadline && !isAdmin && task.assignee_id === currentUserId && (
+  pendingExt ? (
+    <div className="flex items-center gap-2 rounded-lg border border-amber-500/20 bg-amber-500/[0.06] px-3.5 py-2.5 mb-3 text-sm text-amber-400">
+      <Clock className="size-4 shrink-0" />
+      <span>Extension requested — waiting for approval</span>
+    </div>
+  ) : showExtForm ? (
+    <div className="rounded-lg border border-border bg-muted/40 px-3.5 py-3 mb-3 space-y-3">
+      <p className="text-sm font-medium text-foreground">Request more time</p>
+      <div className="flex items-center gap-2">
+        <div className="inline-flex rounded-md border border-border overflow-hidden">
+          <button
+            type="button"
+            onClick={() => setExtUnit('hours')}
+            className={cn(
+              'px-3 py-1 text-xs font-medium transition-colors',
+              extUnit === 'hours' ? 'bg-foreground/10 text-foreground' : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            Hours
+          </button>
+          <button
+            type="button"
+            onClick={() => setExtUnit('days')}
+            className={cn(
+              'px-3 py-1 text-xs font-medium transition-colors',
+              extUnit === 'days' ? 'bg-foreground/10 text-foreground' : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            Days
+          </button>
+        </div>
+        <input
+          type="number"
+          min={1}
+          max={extUnit === 'days' ? 30 : 720}
+          value={extAmount}
+          onChange={e => setExtAmount(Math.max(1, Number(e.target.value) || 1))}
+          className="w-16 rounded-md border border-border bg-transparent px-2 py-1 text-sm text-foreground text-center [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+        />
+        <span className="text-xs text-muted-foreground">{extUnit}</span>
+      </div>
+      {/* Preview */}
+      <p className="text-xs text-muted-foreground">
+        New deadline:{' '}
+        <span className="text-foreground font-medium">
+          {new Date(
+            new Date(task.deadline + 'T00:00:00').getTime() +
+            (extUnit === 'days' ? extAmount * 24 : extAmount) * 3600000
+          ).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+        </span>
+      </p>
+      <div className="flex items-center gap-2">
+        <button
+          onClick={handleExtensionRequest}
+          disabled={extSubmitting}
+          className="rounded-md bg-seeko-accent px-3 py-1.5 text-xs font-medium text-background hover:bg-seeko-accent/90 transition-colors disabled:opacity-50"
+        >
+          {extSubmitting ? 'Requesting…' : 'Submit request'}
+        </button>
+        <button
+          onClick={() => setShowExtForm(false)}
+          className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  ) : (
+    <button
+      onClick={() => setShowExtForm(true)}
+      className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors mb-3"
+    >
+      <Clock className="size-3" />
+      Request more time
+    </button>
+  )
+)}
+```
+
+**Step 5: Verify it renders**
+
+Run: `npm run dev`, open a task you're assigned to that has a deadline. Verify:
+1. "Request more time" link appears
+2. Clicking it shows the inline form with hours/days toggle
+3. Preview updates as you change the amount
+4. Submit sends POST and shows pending status
+
+**Step 6: Commit**
+
+```bash
+git add src/components/dashboard/TaskDetail.tsx
+git commit -m "feat: add deadline extension request form for assignees in TaskDetail"
+```
+
+---
+
+### Task 9: TaskDetail — Admin Approval Banner
+
+**Files:**
+- Modify: `src/components/dashboard/TaskDetail.tsx`
+
+**Step 1: Add admin state for deny reason**
+
+Add alongside the other extension state:
+
+```typescript
+const [denyMode, setDenyMode] = useState(false);
+const [denyReason, setDenyReason] = useState('');
+const [extDeciding, setExtDeciding] = useState(false);
+```
+
+**Step 2: Add the decide handler**
+
+```typescript
+const handleExtensionDecision = async (action: 'approve' | 'deny') => {
+  if (!pendingExt) return;
+  setExtDeciding(true);
+  try {
+    const res = await fetch(`/api/deadline-extensions/${pendingExt.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        action,
+        reason: action === 'deny' ? denyReason.trim() || undefined : undefined,
+      }),
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      toast.error(data.error ?? `Failed to ${action} extension`);
+      return;
+    }
+    toast.success(action === 'approve' ? 'Extension approved — deadline updated' : 'Extension denied');
+    setPendingExt(null);
+    setDenyMode(false);
+    setDenyReason('');
+    // Refresh task data if parent provides a mechanism, otherwise router.refresh()
+  } catch {
+    toast.error('Network error');
+  } finally {
+    setExtDeciding(false);
+  }
+};
+```
+
+**Step 3: Add the admin banner UI**
+
+Place this at the very top of the TaskDetail content area (before the urgent deadline callout), so it's the first thing admins see:
+
+```tsx
+{/* Admin: pending extension banner */}
+{isAdmin && pendingExt && (
+  <div className="rounded-lg border border-amber-500/20 bg-amber-500/[0.06] px-3.5 py-3 mb-3 space-y-2.5">
+    <div className="flex items-start gap-2">
+      <Clock className="size-4 text-amber-400 mt-0.5 shrink-0" />
+      <div className="flex-1 min-w-0">
+        <p className="text-sm text-foreground">
+          <span className="font-medium">
+            {(pendingExt as any).profiles?.display_name ?? 'Someone'}
+          </span>{' '}
+          requested{' '}
+          <span className="font-medium">
+            {pendingExt.extra_hours >= 24
+              ? `${Math.round(pendingExt.extra_hours / 24)} more day${Math.round(pendingExt.extra_hours / 24) !== 1 ? 's' : ''}`
+              : `${pendingExt.extra_hours} more hour${pendingExt.extra_hours !== 1 ? 's' : ''}`}
+          </span>
+        </p>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          {task.deadline} → {pendingExt.new_deadline}
+        </p>
+      </div>
+    </div>
+    {denyMode ? (
+      <div className="space-y-2 pl-6">
+        <textarea
+          value={denyReason}
+          onChange={e => setDenyReason(e.target.value)}
+          placeholder="Reason (optional)"
+          rows={2}
+          className="w-full rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground resize-none focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => handleExtensionDecision('deny')}
+            disabled={extDeciding}
+            className="rounded-md bg-red-500/10 border border-red-500/20 px-3 py-1.5 text-xs font-medium text-red-400 hover:bg-red-500/20 transition-colors disabled:opacity-50"
+          >
+            {extDeciding ? 'Denying…' : 'Confirm deny'}
+          </button>
+          <button
+            onClick={() => { setDenyMode(false); setDenyReason(''); }}
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    ) : (
+      <div className="flex items-center gap-2 pl-6">
+        <button
+          onClick={() => handleExtensionDecision('approve')}
+          disabled={extDeciding}
+          className="rounded-md bg-seeko-accent px-3 py-1.5 text-xs font-medium text-background hover:bg-seeko-accent/90 transition-colors disabled:opacity-50"
+        >
+          {extDeciding ? 'Approving…' : 'Approve'}
+        </button>
+        <button
+          onClick={() => setDenyMode(true)}
+          className="rounded-md border border-border px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+        >
+          Deny
+        </button>
+      </div>
+    )}
+  </div>
+)}
+```
+
+**Step 4: Test the full flow**
+
+1. Log in as assignee → open task with deadline → request +2 days
+2. Log in as admin → open same task → see banner with "Approve" / "Deny"
+3. Test approve: deadline updates, requester gets notification
+4. Test deny: with and without reason, requester gets notification
+
+**Step 5: Commit**
+
+```bash
+git add src/components/dashboard/TaskDetail.tsx
+git commit -m "feat: add admin approval banner for deadline extensions in TaskDetail"
+```
+
+---
+
+### Task 10: Activity Page — New Action Configs
+
+**Files:**
+- Modify: `src/components/dashboard/ActivityFeed.tsx`
+
+**Step 1: Add extension actions to ACTION_CONFIG and actionToSentence**
+
+In `ACTION_CONFIG`, add:
+
+```typescript
+'Requested extension':  { icon: Clock,        className: 'text-amber-400' },
+'Approved extension':   { icon: CheckCircle2,  className: 'text-emerald-400', significant: true },
+'Denied extension':     { icon: AlertCircle,   className: 'text-red-400', significant: true },
+```
+
+Import `Clock` from lucide-react if not already imported.
+
+In `actionToSentence`, add:
+
+```typescript
+'Requested extension': 'requested an extension on',
+'Approved extension': 'approved an extension on',
+'Denied extension': 'denied an extension on',
+```
+
+**Step 2: Do the same in the dashboard overview page**
+
+In `src/app/(dashboard)/page.tsx`, check if the activity feed there also needs these action mappings. The overview uses `ACTIVITY_ICONS` with lowercase keys. No changes needed since it uses a fallback for unknown actions.
+
+**Step 3: Commit**
+
+```bash
+git add src/components/dashboard/ActivityFeed.tsx
+git commit -m "feat: add extension action configs to activity feed"
+```
+
+---
+
+### Task 11: Final Testing & PR
+
+**Step 1: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: No errors
+
+**Step 2: Run dev server and test full flow**
+
+```bash
+npm run dev
+```
+
+Test:
+1. Assignee sees "Request more time" on tasks with deadlines
+2. Hours/days toggle and preview work correctly
+3. Submit creates request, shows pending status
+4. Admin notification appears in bell
+5. Admin sees banner on task, can approve or deny
+6. Approve updates deadline, notify requester
+7. Deny with optional reason, notify requester
+8. Activity feed shows extension events
+9. After resolution, assignee can request again
+
+**Step 3: Commit any fixes**
+
+**Step 4: Create PR**
+
+```bash
+git push -u origin feat/deadline-clarity
+gh pr create --title "feat: deadline extension requests" --body "..."
+```

--- a/docs/supabase-schema.sql
+++ b/docs/supabase-schema.sql
@@ -198,6 +198,22 @@ create policy "Authenticated users can insert activity"
   on public.activity_log for insert
   with check (auth.role() = 'authenticated');
 
+-- ─── Deadline Extensions ──────────────────────────────────────────────────────
+
+create table public.deadline_extensions (
+  id                uuid primary key default gen_random_uuid(),
+  task_id           uuid not null references public.tasks(id) on delete cascade,
+  requested_by      uuid not null references public.profiles(id) on delete cascade,
+  extra_hours       integer not null,
+  original_deadline date not null,
+  new_deadline      date not null,
+  status            text not null default 'pending' check (status in ('pending', 'approved', 'denied')),
+  decided_by        uuid references public.profiles(id),
+  decided_at        timestamptz,
+  denial_reason     text,
+  created_at        timestamptz not null default now()
+);
+
 -- ─── Storage: Avatars Bucket ──────────────────────────────────────────────────
 
 -- insert into storage.buckets (id, name, public) values ('avatars', 'avatars', true);

--- a/src/app/(dashboard)/activity/page.tsx
+++ b/src/app/(dashboard)/activity/page.tsx
@@ -2,156 +2,28 @@
  * ANIMATION STORYBOARD
  *
  *    0ms   heading + subtitle fades up
- *  120ms   first date group label fades in
- *  180ms   activity items stagger in (50ms apart)
+ *  120ms   filter pills + feed fade in
  * ───────────────────────────────────────────────────────── */
 
-import Link from 'next/link';
 import { fetchActivity } from '@/lib/supabase/data';
-import { FadeRise, Stagger, StaggerItem } from '@/components/motion';
+import { FadeRise } from '@/components/motion';
 import { EmptyState } from '@/components/ui/empty-state';
-import { Badge } from '@/components/ui/badge';
-import {
-  CheckCircle2,
-  Timer,
-  AlertCircle,
-  UserPlus,
-  Plus,
-  Trash2,
-  MessageSquare,
-  ArrowRight,
-  RefreshCw,
-  Activity,
-} from 'lucide-react';
+import { ActivityFeed } from '@/components/dashboard/ActivityFeed';
 
 const TIMING = {
   hero:    0,
-  groups: 120,
-  items:  180,
+  feed:  120,
 };
 
 const delay = (ms: number) => ms / 1000;
-
-// ── Helpers ──────────────────────────────────────────────
-
-function timeAgo(dateStr: string): string {
-  const diff = Date.now() - new Date(dateStr).getTime();
-  const mins = Math.floor(diff / 60000);
-  if (mins < 1) return 'just now';
-  if (mins < 60) return `${mins}m ago`;
-  const hours = Math.floor(mins / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  if (days < 7) return `${days}d ago`;
-  return new Date(dateStr).toLocaleDateString();
-}
-
-function timeShort(dateStr: string): string {
-  return new Date(dateStr).toLocaleTimeString(undefined, {
-    hour: 'numeric',
-    minute: '2-digit',
-  });
-}
-
-function dateLabel(dateStr: string): string {
-  const d = new Date(dateStr);
-  const now = new Date();
-  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const itemDay = new Date(d.getFullYear(), d.getMonth(), d.getDate());
-  const diffDays = Math.round((today.getTime() - itemDay.getTime()) / 86_400_000);
-
-  if (diffDays === 0) return 'Today';
-  if (diffDays === 1) return 'Yesterday';
-  if (diffDays < 7) return d.toLocaleDateString('en-US', { weekday: 'long' });
-  return d.toLocaleDateString('en-US', { month: 'long', day: 'numeric' });
-}
-
-function actionToSentence(action: string): string {
-  const map: Record<string, string> = {
-    Created: 'created',
-    Assigned: 'assigned',
-    Completed: 'completed',
-    Started: 'started',
-    'Moved to review': 'moved to review',
-    Blocked: 'blocked',
-    Deleted: 'deleted',
-    'Commented on': 'commented on',
-    'Changed priority': 'changed priority',
-    'Changed department': 'changed department',
-  };
-  return map[action] ?? action.toLowerCase();
-}
-
-function itemHref(parsed: { type: string }, taskId?: string | null, docId?: string | null): string {
-  if (taskId) return `/tasks?task=${encodeURIComponent(taskId)}`;
-  if (docId) return `/docs?doc=${encodeURIComponent(docId)}`;
-  if (parsed.type === 'doc') return '/docs';
-  if (parsed.type === 'task' || parsed.type === 'area') return '/tasks';
-  return '/activity';
-}
-
-// ── Action config ────────────────────────────────────────
-
-/** significant = events that deserve visual emphasis */
-type ActionConfig = {
-  icon: typeof Activity;
-  className: string;
-  significant?: boolean;
-};
-
-const ACTION_CONFIG: Record<string, ActionConfig> = {
-  Created:              { icon: Plus,          className: 'text-seeko-accent' },
-  Assigned:             { icon: UserPlus,      className: 'text-blue-400', significant: true },
-  Completed:            { icon: CheckCircle2,  className: 'text-emerald-400', significant: true },
-  Started:              { icon: Timer,         className: 'text-amber-400' },
-  'Moved to review':    { icon: AlertCircle,   className: 'text-orange-400' },
-  Blocked:              { icon: AlertCircle,   className: 'text-red-400', significant: true },
-  Deleted:              { icon: Trash2,        className: 'text-red-400', significant: true },
-  'Commented on':       { icon: MessageSquare, className: 'text-purple-400' },
-  'Changed priority':   { icon: RefreshCw,     className: 'text-amber-400' },
-  'Changed department': { icon: RefreshCw,     className: 'text-blue-400' },
-};
-
-const FALLBACK_CONFIG: ActionConfig = { icon: Activity, className: 'text-muted-foreground' };
-
-function parseTarget(target: string): { type: string; name: string; detail?: string } {
-  const arrowIdx = target.indexOf(' \u2192 ');
-  if (target.startsWith('task: ')) {
-    const rest = target.slice(6);
-    if (arrowIdx > 0) {
-      const taskPart = rest.slice(0, rest.indexOf(' \u2192 '));
-      const detail = rest.slice(rest.indexOf(' \u2192 ') + 3);
-      return { type: 'task', name: taskPart, detail };
-    }
-    return { type: 'task', name: rest };
-  }
-  if (target.startsWith('doc: ')) return { type: 'doc', name: target.slice(5) };
-  if (target.startsWith('area: ')) return { type: 'area', name: target.slice(6) };
-  return { type: 'other', name: target };
-}
-
-// ── Group by date ────────────────────────────────────────
-
-type ActivityItem = Awaited<ReturnType<typeof fetchActivity>>[number];
-
-function groupByDate(items: ActivityItem[]): { label: string; items: ActivityItem[] }[] {
-  const groups: Map<string, ActivityItem[]> = new Map();
-  for (const item of items) {
-    const label = dateLabel(item.created_at);
-    if (!groups.has(label)) groups.set(label, []);
-    groups.get(label)!.push(item);
-  }
-  return Array.from(groups, ([label, items]) => ({ label, items }));
-}
 
 // ── Page ─────────────────────────────────────────────────
 
 export default async function ActivityPage() {
   const activity = await fetchActivity(50).catch(() => { throw new Error('Failed to load activity.'); });
-  const groups = groupByDate(activity);
 
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex flex-col gap-6 max-w-2xl">
       <FadeRise delay={delay(TIMING.hero)}>
         <h1 className="text-2xl font-semibold tracking-tight text-foreground">Activity</h1>
         <p className="text-sm text-muted-foreground mt-0.5">What the team&apos;s been up to.</p>
@@ -164,67 +36,8 @@ export default async function ActivityPage() {
           description="Task updates, comments, and assignments will show here."
         />
       ) : (
-        <FadeRise delay={delay(TIMING.groups)} y={12}>
-          <div className="flex flex-col gap-8">
-            {groups.map(group => (
-              <section key={group.label}>
-                <h2 className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground mb-3">
-                  {group.label}
-                </h2>
-                <Stagger className="flex flex-col gap-0.5" staggerMs={0.05} delayMs={delay(TIMING.items)}>
-                  {group.items.map(item => {
-                    const prof = item.profiles as unknown as { display_name?: string; avatar_url?: string } | undefined;
-                    const name = prof?.display_name ?? 'Unknown';
-                    const cfg = ACTION_CONFIG[item.action] ?? FALLBACK_CONFIG;
-                    const Icon = cfg.icon;
-                    const parsed = parseTarget(item.target);
-                    const sentence = actionToSentence(item.action);
-                    const href = itemHref(parsed, item.task_id, item.doc_id);
-
-                    return (
-                      <StaggerItem key={item.id}>
-                        <Link
-                          href={href}
-                          className={`group flex items-start gap-3 rounded-lg px-3 py-2.5 -mx-3 transition-colors hover:bg-white/[0.04] ${cfg.significant ? 'bg-white/[0.02]' : ''}`}
-                        >
-                          <div
-                            className="flex size-7 shrink-0 items-center justify-center rounded-full bg-muted mt-0.5"
-                            aria-hidden
-                          >
-                            <Icon className={`size-3.5 ${cfg.className}`} />
-                          </div>
-                          <div className="flex-1 min-w-0">
-                            <span className={`text-sm text-muted-foreground ${cfg.significant ? 'text-foreground/90' : ''}`}>
-                              <span className="font-medium text-foreground">{name}</span>
-                              {' '}
-                              <span>{sentence}</span>
-                              {' '}
-                              <span className={`font-medium ${cfg.significant ? 'text-foreground' : 'text-foreground/80'}`}>{parsed.name}</span>
-                              {parsed.detail && (
-                                <>
-                                  {' '}
-                                  <ArrowRight className="inline size-3 mx-0.5 text-muted-foreground/50 align-middle" />
-                                  {' '}
-                                  <span className="inline-flex items-center">
-                                    <Badge variant="outline" className="text-[10px] py-0 px-1.5 font-normal rounded-md bg-muted/80 text-foreground/80">
-                                      {parsed.detail}
-                                    </Badge>
-                                  </span>
-                                </>
-                              )}
-                            </span>
-                          </div>
-                          <span className="shrink-0 text-[11px] text-muted-foreground/50 mt-0.5 group-hover:text-muted-foreground transition-colors">
-                            {timeShort(item.created_at)}
-                          </span>
-                        </Link>
-                      </StaggerItem>
-                    );
-                  })}
-                </Stagger>
-              </section>
-            ))}
-          </div>
+        <FadeRise delay={delay(TIMING.feed)} y={12}>
+          <ActivityFeed activity={activity} />
         </FadeRise>
       )}
     </div>

--- a/src/app/api/deadline-extensions/[id]/route.ts
+++ b/src/app/api/deadline-extensions/[id]/route.ts
@@ -1,0 +1,147 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createServerClient } from '@supabase/ssr';
+import { createClient as createServiceClient } from '@supabase/supabase-js';
+import { cookies } from 'next/headers';
+
+async function getAuthenticatedUser() {
+  const cookieStore = await cookies();
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll: () => cookieStore.getAll(),
+        setAll: (c) => c.forEach(({ name, value, options }) => cookieStore.set(name, value, options)),
+      },
+    }
+  );
+  const { data: { user } } = await supabase.auth.getUser();
+  return user;
+}
+
+/** PATCH: Approve or deny a deadline extension. Body: { action: 'approve' | 'deny', reason?: string } */
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  const user = await getAuthenticatedUser();
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const service = createServiceClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+
+  // Verify admin
+  const { data: profile } = await service
+    .from('profiles')
+    .select('is_admin')
+    .eq('id', user.id)
+    .single();
+
+  if (!profile?.is_admin) {
+    return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
+  }
+
+  let body: { action: 'approve' | 'deny'; reason?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const { action, reason } = body;
+  if (action !== 'approve' && action !== 'deny') {
+    return NextResponse.json({ error: 'action must be "approve" or "deny"' }, { status: 400 });
+  }
+
+  // Fetch the extension request with task name
+  const { data: ext, error: extError } = await service
+    .from('deadline_extensions')
+    .select('id, task_id, requested_by, extra_hours, new_deadline, status, tasks(name)')
+    .eq('id', id)
+    .single();
+
+  if (extError || !ext) {
+    return NextResponse.json({ error: 'Extension request not found' }, { status: 404 });
+  }
+
+  if (ext.status !== 'pending') {
+    return NextResponse.json({ error: 'Extension request is no longer pending' }, { status: 409 });
+  }
+
+  const taskName = (ext.tasks as unknown as { name: string })?.name ?? 'Unknown task';
+  const newStatus = action === 'approve' ? 'approved' : 'denied';
+
+  // Update the extension request
+  const { error: updateError } = await service
+    .from('deadline_extensions')
+    .update({
+      status: newStatus,
+      decided_by: user.id,
+      decided_at: new Date().toISOString(),
+      ...(action === 'deny' && reason ? { denial_reason: reason } : {}),
+    })
+    .eq('id', id);
+
+  if (updateError) {
+    console.error('[deadline-extensions] update failed:', updateError);
+    return NextResponse.json({ error: 'Failed to update extension request' }, { status: 500 });
+  }
+
+  // If approved, update the task deadline
+  if (action === 'approve') {
+    const { error: taskUpdateError } = await service
+      .from('tasks')
+      .update({ deadline: ext.new_deadline })
+      .eq('id', ext.task_id);
+
+    if (taskUpdateError) {
+      console.error('[deadline-extensions] task deadline update failed:', taskUpdateError);
+      // Roll back extension status since deadline wasn't updated
+      await service.from('deadline_extensions').update({ status: 'pending', decided_by: null, decided_at: null }).eq('id', id);
+      return NextResponse.json({ error: 'Failed to update task deadline' }, { status: 500 });
+    }
+  }
+
+  // Log to activity_log
+  await service.from('activity_log').insert({
+    user_id: user.id,
+    action: action === 'approve' ? 'Approved extension' : 'Denied extension',
+    target: `task: ${taskName}`,
+    task_id: ext.task_id,
+  });
+
+  // Notify the requester
+  const notifKind = action === 'approve' ? 'deadline_extension_approved' : 'deadline_extension_denied';
+  const notifTitle = action === 'approve'
+    ? `Extension approved on "${taskName}"`
+    : `Extension denied on "${taskName}"`;
+  const notifBody = action === 'approve'
+    ? `Deadline updated to ${new Date(ext.new_deadline + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`
+    : reason || 'No reason provided';
+
+  try {
+    const notifyUrl = new URL('/api/notify/user', req.url);
+    await fetch(notifyUrl.toString(), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        cookie: req.headers.get('cookie') ?? '',
+      },
+      body: JSON.stringify({
+        userId: ext.requested_by,
+        kind: notifKind,
+        title: notifTitle,
+        body: notifBody,
+        link: `/tasks?task=${ext.task_id}`,
+      }),
+    });
+  } catch {
+    console.error('[deadline-extensions] failed to notify requester');
+  }
+
+  return NextResponse.json({ success: true, status: newStatus });
+}

--- a/src/app/api/deadline-extensions/route.ts
+++ b/src/app/api/deadline-extensions/route.ts
@@ -1,0 +1,146 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createServerClient } from '@supabase/ssr';
+import { createClient as createServiceClient } from '@supabase/supabase-js';
+import { cookies } from 'next/headers';
+
+async function getAuthenticatedUser() {
+  const cookieStore = await cookies();
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll: () => cookieStore.getAll(),
+        setAll: (c) => c.forEach(({ name, value, options }) => cookieStore.set(name, value, options)),
+      },
+    }
+  );
+  const { data: { user } } = await supabase.auth.getUser();
+  return user;
+}
+
+/** POST: Request a deadline extension. Body: { taskId, extraHours } */
+export async function POST(req: NextRequest) {
+  const user = await getAuthenticatedUser();
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  let body: { taskId: string; extraHours: number };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const { taskId, extraHours } = body;
+  if (!taskId || typeof taskId !== 'string') {
+    return NextResponse.json({ error: 'taskId is required' }, { status: 400 });
+  }
+  if (!Number.isFinite(extraHours) || extraHours < 1 || extraHours > 720) {
+    return NextResponse.json({ error: 'extraHours must be between 1 and 720' }, { status: 400 });
+  }
+
+  const service = createServiceClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+
+  // Fetch the task
+  const { data: task, error: taskError } = await service
+    .from('tasks')
+    .select('id, name, deadline, assignee_id')
+    .eq('id', taskId)
+    .single();
+
+  if (taskError || !task) {
+    return NextResponse.json({ error: 'Task not found' }, { status: 404 });
+  }
+
+  // Verify the user is the assignee
+  if (task.assignee_id !== user.id) {
+    return NextResponse.json({ error: 'Only the assignee can request an extension' }, { status: 403 });
+  }
+
+  // Verify the task has a deadline
+  if (!task.deadline) {
+    return NextResponse.json({ error: 'Task has no deadline' }, { status: 400 });
+  }
+
+  // Check for existing pending request
+  const { data: existing } = await service
+    .from('deadline_extensions')
+    .select('id')
+    .eq('task_id', taskId)
+    .eq('status', 'pending')
+    .limit(1)
+    .maybeSingle();
+
+  if (existing) {
+    return NextResponse.json({ error: 'A pending extension request already exists for this task' }, { status: 409 });
+  }
+
+  // Compute new deadline
+  const originalDeadline = task.deadline; // date string e.g. "2026-03-15"
+  const newDeadlineDate = new Date(originalDeadline + 'T00:00:00');
+  newDeadlineDate.setTime(newDeadlineDate.getTime() + extraHours * 3600000);
+  const newDeadline = newDeadlineDate.toISOString().split('T')[0]; // back to date string
+
+  // Insert the extension request
+  const { data: extension, error: insertError } = await service
+    .from('deadline_extensions')
+    .insert({
+      task_id: taskId,
+      requested_by: user.id,
+      extra_hours: extraHours,
+      original_deadline: originalDeadline,
+      new_deadline: newDeadline,
+      status: 'pending',
+    })
+    .select('id, extra_hours, new_deadline, status')
+    .single();
+
+  if (insertError) {
+    console.error('[deadline-extensions] insert failed:', insertError);
+    return NextResponse.json({ error: 'Failed to create extension request' }, { status: 500 });
+  }
+
+  // Log to activity_log
+  await service.from('activity_log').insert({
+    user_id: user.id,
+    action: 'Requested extension',
+    target: `task: ${task.name}`,
+    task_id: taskId,
+  });
+
+  // Notify admins
+  const amount = extraHours >= 24
+    ? `+${Math.round(extraHours / 24)} day${Math.round(extraHours / 24) !== 1 ? 's' : ''}`
+    : `+${extraHours} hour${extraHours !== 1 ? 's' : ''}`;
+
+  const newDeadlineFormatted = new Date(newDeadline + 'T00:00:00').toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+
+  try {
+    const notifyUrl = new URL('/api/notify/admins', req.url);
+    await fetch(notifyUrl.toString(), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        cookie: req.headers.get('cookie') ?? '',
+      },
+      body: JSON.stringify({
+        kind: 'deadline_extension_requested',
+        title: `Extension requested on "${task.name}"`,
+        body: `${amount} \u2014 new deadline would be ${newDeadlineFormatted}`,
+        link: `/tasks?task=${taskId}`,
+      }),
+    });
+  } catch {
+    // Non-critical: notification failure shouldn't block the request
+    console.error('[deadline-extensions] failed to notify admins');
+  }
+
+  return NextResponse.json({ success: true, extension });
+}

--- a/src/components/dashboard/ActivityFeed.tsx
+++ b/src/components/dashboard/ActivityFeed.tsx
@@ -1,0 +1,253 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Stagger, StaggerItem } from '@/components/motion';
+import { Badge } from '@/components/ui/badge';
+import {
+  CheckCircle2,
+  Timer,
+  AlertCircle,
+  UserPlus,
+  Plus,
+  Trash2,
+  MessageSquare,
+  ArrowRight,
+  RefreshCw,
+  Activity,
+  Clock,
+} from 'lucide-react';
+
+// ── Types ───────────────────────────────────────────────
+
+type ActivityItem = {
+  id: string;
+  action: string;
+  target: string;
+  created_at: string;
+  task_id?: string | null;
+  doc_id?: string | null;
+  profiles?: unknown;
+};
+
+type ActionConfig = {
+  icon: typeof Activity;
+  className: string;
+  significant?: boolean;
+};
+
+// ── Filter definitions ──────────────────────────────────
+
+const FILTERS = [
+  { key: 'all',         label: 'All' },
+  { key: 'assignments', label: 'Assignments' },
+  { key: 'completed',   label: 'Completed' },
+  { key: 'comments',    label: 'Comments' },
+  { key: 'blocked',     label: 'Blocked' },
+] as const;
+
+type FilterKey = (typeof FILTERS)[number]['key'];
+
+const FILTER_ACTIONS: Record<Exclude<FilterKey, 'all'>, string[]> = {
+  assignments: ['Assigned'],
+  completed:   ['Completed'],
+  comments:    ['Commented on'],
+  blocked:     ['Blocked'],
+};
+
+// ── Action config ───────────────────────────────────────
+
+const ACTION_CONFIG: Record<string, ActionConfig> = {
+  Created:              { icon: Plus,          className: 'text-seeko-accent' },
+  Assigned:             { icon: UserPlus,      className: 'text-blue-400', significant: true },
+  Completed:            { icon: CheckCircle2,  className: 'text-emerald-400', significant: true },
+  Started:              { icon: Timer,         className: 'text-amber-400' },
+  'Moved to review':    { icon: AlertCircle,   className: 'text-orange-400' },
+  Blocked:              { icon: AlertCircle,   className: 'text-red-400', significant: true },
+  Deleted:              { icon: Trash2,        className: 'text-red-400', significant: true },
+  'Commented on':       { icon: MessageSquare, className: 'text-purple-400' },
+  'Changed priority':   { icon: RefreshCw,     className: 'text-amber-400' },
+  'Changed department': { icon: RefreshCw,     className: 'text-blue-400' },
+  'Requested extension':  { icon: Clock,        className: 'text-amber-400' },
+  'Approved extension':   { icon: CheckCircle2,  className: 'text-emerald-400', significant: true },
+  'Denied extension':     { icon: AlertCircle,   className: 'text-red-400', significant: true },
+};
+
+const FALLBACK_CONFIG: ActionConfig = { icon: Activity, className: 'text-muted-foreground' };
+
+// ── Helpers ─────────────────────────────────────────────
+
+function timeShort(dateStr: string): string {
+  return new Date(dateStr).toLocaleTimeString(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function dateLabel(dateStr: string): string {
+  const d = new Date(dateStr);
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const itemDay = new Date(d.getFullYear(), d.getMonth(), d.getDate());
+  const diffDays = Math.round((today.getTime() - itemDay.getTime()) / 86_400_000);
+
+  if (diffDays === 0) return 'Today';
+  if (diffDays === 1) return 'Yesterday';
+  if (diffDays < 7) return d.toLocaleDateString('en-US', { weekday: 'long' });
+  return d.toLocaleDateString('en-US', { month: 'long', day: 'numeric' });
+}
+
+function actionToSentence(action: string): string {
+  const map: Record<string, string> = {
+    Created: 'created',
+    Assigned: 'assigned',
+    Completed: 'completed',
+    Started: 'started',
+    'Moved to review': 'moved to review',
+    Blocked: 'blocked',
+    Deleted: 'deleted',
+    'Commented on': 'commented on',
+    'Changed priority': 'changed priority',
+    'Changed department': 'changed department',
+    'Requested extension': 'requested an extension on',
+    'Approved extension': 'approved an extension on',
+    'Denied extension': 'denied an extension on',
+  };
+  return map[action] ?? action.toLowerCase();
+}
+
+function itemHref(parsed: { type: string }, taskId?: string | null, docId?: string | null): string {
+  if (taskId) return `/tasks?task=${encodeURIComponent(taskId)}`;
+  if (docId) return `/docs?doc=${encodeURIComponent(docId)}`;
+  if (parsed.type === 'doc') return '/docs';
+  if (parsed.type === 'task' || parsed.type === 'area') return '/tasks';
+  return '/activity';
+}
+
+function parseTarget(target: string): { type: string; name: string; detail?: string } {
+  const arrowIdx = target.indexOf(' \u2192 ');
+  if (target.startsWith('task: ')) {
+    const rest = target.slice(6);
+    if (arrowIdx > 0) {
+      const taskPart = rest.slice(0, rest.indexOf(' \u2192 '));
+      const detail = rest.slice(rest.indexOf(' \u2192 ') + 3);
+      return { type: 'task', name: taskPart, detail };
+    }
+    return { type: 'task', name: rest };
+  }
+  if (target.startsWith('doc: ')) return { type: 'doc', name: target.slice(5) };
+  if (target.startsWith('area: ')) return { type: 'area', name: target.slice(6) };
+  return { type: 'other', name: target };
+}
+
+function groupByDate(items: ActivityItem[]): { label: string; items: ActivityItem[] }[] {
+  const groups: Map<string, ActivityItem[]> = new Map();
+  for (const item of items) {
+    const label = dateLabel(item.created_at);
+    if (!groups.has(label)) groups.set(label, []);
+    groups.get(label)!.push(item);
+  }
+  return Array.from(groups, ([label, items]) => ({ label, items }));
+}
+
+// ── Component ───────────────────────────────────────────
+
+export function ActivityFeed({ activity }: { activity: ActivityItem[] }) {
+  const [filter, setFilter] = useState<FilterKey>('all');
+
+  const filtered = filter === 'all'
+    ? activity
+    : activity.filter(item => FILTER_ACTIONS[filter].includes(item.action));
+
+  const groups = groupByDate(filtered);
+
+  return (
+    <div className="flex flex-col gap-5">
+      {/* Filter pills */}
+      <div className="flex flex-wrap items-center gap-1.5">
+        {FILTERS.map(f => (
+          <button
+            key={f.key}
+            type="button"
+            onClick={() => setFilter(f.key)}
+            className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+              filter === f.key
+                ? 'bg-foreground/10 text-foreground'
+                : 'text-muted-foreground hover:text-foreground hover:bg-white/[0.04]'
+            }`}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Feed */}
+      {filtered.length === 0 ? (
+        <p className="py-8 text-center text-sm text-muted-foreground">
+          No {filter === 'all' ? '' : filter.toLowerCase() + ' '}activity yet.
+        </p>
+      ) : (
+        <div className="flex flex-col gap-8">
+          {groups.map(group => (
+            <section key={group.label}>
+              <h2 className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground mb-3">
+                {group.label}
+              </h2>
+              <Stagger className="flex flex-col gap-0.5" staggerMs={0.05} delayMs={0.18}>
+                {group.items.map(item => {
+                  const prof = item.profiles as { display_name?: string } | undefined;
+                  const name = prof?.display_name ?? 'Unknown';
+                  const cfg = ACTION_CONFIG[item.action] ?? FALLBACK_CONFIG;
+                  const Icon = cfg.icon;
+                  const parsed = parseTarget(item.target);
+                  const sentence = actionToSentence(item.action);
+                  const href = itemHref(parsed, item.task_id, item.doc_id);
+
+                  return (
+                    <StaggerItem key={item.id}>
+                      <Link
+                        href={href}
+                        className={`group flex items-start gap-3 rounded-lg px-3 py-2.5 -mx-3 transition-colors hover:bg-white/[0.04] ${cfg.significant ? 'bg-white/[0.02]' : ''}`}
+                      >
+                        <div
+                          className="flex size-7 shrink-0 items-center justify-center rounded-full bg-muted mt-0.5"
+                          aria-hidden
+                        >
+                          <Icon className={`size-3.5 ${cfg.className}`} />
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <span className={`text-sm text-muted-foreground ${cfg.significant ? 'text-foreground/90' : ''}`}>
+                            <span className="font-medium text-foreground">{name}</span>
+                            {' '}
+                            <span>{sentence}</span>
+                            {' '}
+                            <span className={`font-medium ${cfg.significant ? 'text-foreground' : 'text-foreground/80'}`}>{parsed.name}</span>
+                            {parsed.detail && (
+                              <>
+                                {' '}
+                                <ArrowRight className="inline size-3 mx-0.5 text-muted-foreground/50 align-middle" />
+                                {' '}
+                                <span className="inline-flex items-center">
+                                  <Badge variant="outline" className="text-[10px] py-0 px-1.5 font-normal rounded-md bg-muted/80 text-foreground/80">
+                                    {parsed.detail}
+                                  </Badge>
+                                </span>
+                              </>
+                            )}
+                          </span>
+                        </div>
+                        <span className="shrink-0 text-[11px] text-muted-foreground/50 mt-0.5 group-hover:text-muted-foreground transition-colors">
+                          {timeShort(item.created_at)}
+                        </span>
+                      </Link>
+                    </StaggerItem>
+                  );
+                })}
+              </Stagger>
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/dashboard/HandoffDialog.tsx
+++ b/src/components/dashboard/HandoffDialog.tsx
@@ -103,7 +103,7 @@ export function HandoffDialog({
   }, [buttonState, onOpenChange]);
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={onOpenChange} className="z-[70]">
       <DialogClose onClose={handleClose} />
       <DialogHeader>
         <DialogTitle className="pr-8 flex items-center gap-2">

--- a/src/components/dashboard/NotificationBell.tsx
+++ b/src/components/dashboard/NotificationBell.tsx
@@ -23,7 +23,7 @@ import { createPortal } from 'react-dom';
 import { useRouter } from 'next/navigation';
 import { createBrowserClient } from '@supabase/ssr';
 import { motion, AnimatePresence, useMotionValue, useTransform, PanInfo } from 'motion/react';
-import { Bell, CheckSquare, AtSign, MessageSquare, CheckCheck, CheckCircle2, Package, ArrowRightLeft, DollarSign, CircleCheck, CircleX, X } from 'lucide-react';
+import { Bell, CheckSquare, AtSign, MessageSquare, CheckCheck, CheckCircle2, Package, ArrowRightLeft, DollarSign, CircleCheck, CircleX, Clock, X } from 'lucide-react';
 import { Notification, NotificationKind } from '@/lib/types';
 import { useIsDesktop } from '@/lib/hooks/useIsDesktop';
 
@@ -43,6 +43,9 @@ const KIND_CONFIG: Record<NotificationKind, { icon: typeof Bell; className: stri
   payment_request:     { icon: DollarSign,    className: 'text-amber-400',    bg: 'bg-amber-500/10' },
   payment_approved:    { icon: CircleCheck,   className: 'text-emerald-500',  bg: 'bg-emerald-500/10' },
   payment_denied:      { icon: CircleX,       className: 'text-red-400',      bg: 'bg-red-500/10' },
+  deadline_extension_requested: { icon: Clock,       className: 'text-amber-400',    bg: 'bg-amber-500/10' },
+  deadline_extension_approved:  { icon: CheckCircle2, className: 'text-emerald-500',  bg: 'bg-emerald-500/10' },
+  deadline_extension_denied:    { icon: CircleX,      className: 'text-red-400',      bg: 'bg-red-500/10' },
 };
 
 /** #6 — Show time-of-day within a date group, "Xd ago" only for Earlier */

--- a/src/components/dashboard/TaskDetail.tsx
+++ b/src/components/dashboard/TaskDetail.tsx
@@ -675,6 +675,20 @@ export function TaskDetail({ task, open, onOpenChange, team, docs, currentUserId
   const [replyTo, setReplyTo] = useState<TaskComment | null>(null);
   const [pendingFiles, setPendingFiles] = useState<File[]>([]);
   const [isDragging, setIsDragging] = useState(false);
+  const [showExtForm, setShowExtForm] = useState(false);
+  const [extUnit, setExtUnit] = useState<'hours' | 'days'>('days');
+  const [extAmount, setExtAmount] = useState(1);
+  const [extSubmitting, setExtSubmitting] = useState(false);
+  const [pendingExt, setPendingExt] = useState<{
+    id: string;
+    extra_hours: number;
+    new_deadline: string;
+    status: string;
+    profiles?: { display_name?: string };
+  } | null>(null);
+  const [denyMode, setDenyMode] = useState(false);
+  const [denyReason, setDenyReason] = useState('');
+  const [extDeciding, setExtDeciding] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const commentsEndRef = useRef<HTMLDivElement>(null);
 
@@ -724,6 +738,76 @@ export function TaskDetail({ task, open, onOpenChange, team, docs, currentUserId
   useEffect(() => {
     if (open && isAdmin) loadDeliverables();
   }, [open, isAdmin, loadDeliverables]);
+
+  // Fetch pending deadline extension when panel opens
+  useEffect(() => {
+    if (!open || !task.id) return;
+    const fetchExt = async () => {
+      const res = await supabase
+        .from('deadline_extensions')
+        .select('id, extra_hours, new_deadline, status, profiles!requested_by(display_name)')
+        .eq('task_id', task.id)
+        .eq('status', 'pending')
+        .limit(1)
+        .maybeSingle();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      setPendingExt(res.data as any ?? null);
+    };
+    fetchExt();
+  }, [open, task.id, supabase]);
+
+  const handleExtensionRequest = async () => {
+    setExtSubmitting(true);
+    const totalHours = extUnit === 'days' ? extAmount * 24 : extAmount;
+    try {
+      const res = await fetch('/api/deadline-extensions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ taskId: task.id, extraHours: totalHours }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        toast.error(data.error ?? 'Failed to request extension');
+        return;
+      }
+      toast.success('Extension requested');
+      setPendingExt(data.extension);
+      setShowExtForm(false);
+    } catch {
+      toast.error('Network error');
+    } finally {
+      setExtSubmitting(false);
+    }
+  };
+
+  const handleExtensionDecision = async (action: 'approve' | 'deny') => {
+    if (!pendingExt) return;
+    setExtDeciding(true);
+    try {
+      const res = await fetch(`/api/deadline-extensions/${pendingExt.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action,
+          reason: action === 'deny' ? denyReason.trim() || undefined : undefined,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        toast.error(data.error ?? `Failed to ${action} extension`);
+        return;
+      }
+      toast.success(action === 'approve' ? 'Extension approved \u2014 deadline updated' : 'Extension denied');
+      setPendingExt(null);
+      setDenyMode(false);
+      setDenyReason('');
+      if (action === 'approve') onOpenChange(false);
+    } catch {
+      toast.error('Network error');
+    } finally {
+      setExtDeciding(false);
+    }
+  };
 
   const handleDeleteDeliverable = useCallback(async (deliverableId: string) => {
     setDeletingDeliverableId(deliverableId);
@@ -1102,109 +1186,273 @@ export function TaskDetail({ task, open, onOpenChange, team, docs, currentUserId
 
   const detailsContent = (
     <>
-      {/* Urgent deadline callout — own row when overdue or due soon */}
-      {task.deadline && (() => {
-        const dl = formatDeadline(task.deadline);
-        const DlIcon = dl.icon;
-        if (!dl.urgent) return null;
-        const bgMap: Record<string, string> = {
-          'text-red-400': 'bg-red-500/10 border-red-500/20',
-          'text-orange-400': 'bg-orange-500/10 border-orange-500/20',
-          'text-amber-400': 'bg-amber-500/10 border-amber-500/20',
-        };
-        return (
-          <div className={cn('flex items-center gap-2 rounded-lg border px-3.5 py-2.5 mb-3', bgMap[dl.className] ?? 'bg-muted/40 border-border')} title={formatDeadlineFull(task.deadline)}>
-            <DlIcon className={cn('size-4', dl.className)} />
-            <span className={cn('text-sm font-medium', dl.className)}>
-              {dl.className === 'text-red-400' ? 'Overdue' : 'Due'} — {dl.label}
-            </span>
+      {/* Admin: pending extension banner */}
+      {isAdmin && pendingExt && (
+        <div className="rounded-lg border border-amber-500/20 bg-amber-500/[0.06] px-3.5 py-3 mb-4 space-y-2.5">
+          <div className="flex items-start gap-2">
+            <Clock className="size-4 text-amber-400 mt-0.5 shrink-0" />
+            <div className="flex-1 min-w-0">
+              <p className="text-sm text-foreground">
+                <span className="font-medium">
+                  {(pendingExt as Record<string, unknown> & { profiles?: { display_name?: string } }).profiles?.display_name ?? 'Someone'}
+                </span>{' '}
+                requested{' '}
+                <span className="font-medium">
+                  {pendingExt.extra_hours >= 24
+                    ? `${Math.round(pendingExt.extra_hours / 24)} more day${Math.round(pendingExt.extra_hours / 24) !== 1 ? 's' : ''}`
+                    : `${pendingExt.extra_hours} more hour${pendingExt.extra_hours !== 1 ? 's' : ''}`}
+                </span>
+              </p>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                {new Date(task.deadline + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} → {new Date(pendingExt.new_deadline + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+              </p>
+            </div>
           </div>
-        );
-      })()}
+          {denyMode ? (
+            <div className="space-y-2 pl-6">
+              <textarea
+                value={denyReason}
+                onChange={e => setDenyReason(e.target.value)}
+                placeholder="Reason (optional)"
+                rows={2}
+                className="w-full rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground resize-none focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() => handleExtensionDecision('deny')}
+                  disabled={extDeciding}
+                  className="rounded-md bg-red-500/10 border border-red-500/20 px-3 py-1.5 text-xs font-medium text-red-400 hover:bg-red-500/20 transition-colors disabled:opacity-50"
+                >
+                  {extDeciding ? 'Denying\u2026' : 'Confirm deny'}
+                </button>
+                <button
+                  onClick={() => { setDenyMode(false); setDenyReason(''); }}
+                  className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="flex items-center gap-2 pl-6">
+              <button
+                onClick={() => handleExtensionDecision('approve')}
+                disabled={extDeciding}
+                className="rounded-md bg-seeko-accent px-3 py-1.5 text-xs font-medium text-background hover:bg-seeko-accent/90 transition-colors disabled:opacity-50"
+              >
+                {extDeciding ? 'Approving\u2026' : 'Approve'}
+              </button>
+              <button
+                onClick={() => setDenyMode(true)}
+                className="rounded-md border border-border px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+              >
+                Deny
+              </button>
+            </div>
+          )}
+        </div>
+      )}
 
-      {/* Metadata row */}
-      <div className="rounded-lg bg-muted/40 px-3.5 py-3 mb-4">
-        <div className="flex flex-col md:flex-row md:flex-wrap items-start md:items-center gap-2 md:gap-4">
-          <div className="flex items-center gap-1.5">
-            <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Priority</span>
-            {isAdmin ? (
-              <select
-                className="appearance-none rounded-md border border-transparent bg-transparent px-2 py-0.5 text-xs font-medium text-foreground cursor-pointer hover:border-border hover:bg-muted/50 transition-colors leading-normal"
-                defaultValue={task.priority}
-                onChange={async (e) => {
-                  const newPriority = e.target.value;
-                  await supabase.from('tasks').update({ priority: newPriority }).eq('id', task.id);
-                  toast.success(`Priority changed to ${newPriority}`);
-                }}
-              >
-                {['High', 'Medium', 'Low'].map(p => (
-                  <option key={p} value={p}>{p}</option>
-                ))}
-              </select>
-            ) : (
-              <Badge variant="secondary" className="text-xs">{task.priority}</Badge>
-            )}
+      {/* ── Deadline + metadata — one cohesive zone ────────── */}
+      <div className="mb-4 space-y-2">
+        {/* Urgent deadline banner */}
+        {task.deadline && (() => {
+          const dl = formatDeadline(task.deadline);
+          const DlIcon = dl.icon;
+          if (!dl.urgent) return null;
+          const bgMap: Record<string, string> = {
+            'text-red-400': 'bg-red-500/10 border-red-500/20',
+            'text-orange-400': 'bg-orange-500/10 border-orange-500/20',
+            'text-amber-400': 'bg-amber-500/10 border-amber-500/20',
+          };
+          return (
+            <div className={cn('flex items-center gap-2 rounded-lg border px-3.5 py-2.5', bgMap[dl.className] ?? 'bg-muted/40 border-border')} title={formatDeadlineFull(task.deadline)}>
+              <DlIcon className={cn('size-4', dl.className)} />
+              <span className={cn('text-sm font-medium', dl.className)}>
+                {dl.className === 'text-red-400' ? 'Overdue' : 'Due'} — {dl.label}
+              </span>
+              {/* Request more time — inline with deadline */}
+              {!isAdmin && task.assignee_id === currentUserId && !pendingExt && !showExtForm && (
+                <button
+                  onClick={() => setShowExtForm(true)}
+                  className="ml-auto text-xs text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  Request more time
+                </button>
+              )}
+            </div>
+          );
+        })()}
+
+        {/* Extension: pending status */}
+        {task.deadline && !isAdmin && task.assignee_id === currentUserId && pendingExt && (
+          <div className="flex items-center gap-2 text-xs text-amber-400">
+            <Clock className="size-3 shrink-0" />
+            <span>Extension requested — waiting for approval</span>
           </div>
-          <div className="hidden md:block w-px h-4 bg-border" />
-          <div className="flex items-center gap-1.5">
-            <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Dept</span>
-            {isAdmin ? (
-              <select
-                className="appearance-none rounded-md border border-transparent bg-transparent px-2 py-0.5 text-xs font-medium text-foreground cursor-pointer hover:border-border hover:bg-muted/50 transition-colors leading-normal"
-                defaultValue={task.department}
-                onChange={async (e) => {
-                  const newDept = e.target.value;
-                  await supabase.from('tasks').update({ department: newDept }).eq('id', task.id);
-                  toast.success(`Department changed to ${newDept}`);
-                }}
+        )}
+
+        {/* Extension: request form — tightly coupled under deadline */}
+        {task.deadline && !isAdmin && task.assignee_id === currentUserId && showExtForm && !pendingExt && (
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-center gap-1.5">
+              {[
+                { label: '+1d', hours: 24 },
+                { label: '+2d', hours: 48 },
+                { label: '+3d', hours: 72 },
+                { label: '+1w', hours: 168 },
+              ].map(preset => {
+                const isActive = extUnit === 'days'
+                  ? extAmount === preset.hours / 24
+                  : extAmount === preset.hours;
+                return (
+                  <button
+                    key={preset.label}
+                    type="button"
+                    onClick={() => { setExtUnit('days'); setExtAmount(preset.hours / 24); }}
+                    className={cn(
+                      'rounded-full px-3 py-1 text-xs font-medium transition-colors',
+                      isActive
+                        ? 'bg-foreground/10 text-foreground'
+                        : 'text-muted-foreground hover:text-foreground hover:bg-white/[0.04]'
+                    )}
+                  >
+                    {preset.label}
+                  </button>
+                );
+              })}
+              <button
+                type="button"
+                onClick={() => { setExtUnit('hours'); setExtAmount(12); }}
+                className={cn(
+                  'rounded-full px-3 py-1 text-xs font-medium transition-colors',
+                  extUnit === 'hours'
+                    ? 'bg-foreground/10 text-foreground'
+                    : 'text-muted-foreground hover:text-foreground hover:bg-white/[0.04]'
+                )}
               >
-                {['Coding', 'Visual Art', 'UI/UX', 'Animation', 'Asset Creation'].map(d => (
-                  <option key={d} value={d}>{d}</option>
-                ))}
-              </select>
-            ) : (
-              <Badge variant="secondary" className="text-xs">{task.department}</Badge>
+                Custom
+              </button>
+            </div>
+            {extUnit === 'hours' && (
+              <div className="flex items-center gap-2">
+                <input
+                  type="number"
+                  min={1}
+                  max={720}
+                  value={extAmount}
+                  onChange={e => setExtAmount(Math.max(1, Number(e.target.value) || 1))}
+                  className="w-14 rounded-md bg-muted/60 px-2 py-1 text-sm text-foreground text-center focus:outline-none focus:ring-1 focus:ring-ring [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                />
+                <span className="text-xs text-muted-foreground">hours</span>
+              </div>
             )}
+            <div className="flex items-center justify-between">
+              <p className="text-xs text-muted-foreground">
+                New deadline:{' '}
+                <span className="text-foreground font-medium">
+                  {new Date(
+                    new Date(task.deadline + 'T00:00:00').getTime() +
+                    (extUnit === 'days' ? extAmount * 24 : extAmount) * 3600000
+                  ).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+                </span>
+              </p>
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() => setShowExtForm(false)}
+                  className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleExtensionRequest}
+                  disabled={extSubmitting}
+                  className="rounded-md border border-border px-3 py-1.5 text-xs font-medium text-foreground hover:bg-muted/50 transition-colors disabled:opacity-50"
+                >
+                  {extSubmitting ? 'Requesting\u2026' : 'Submit'}
+                </button>
+              </div>
+            </div>
           </div>
-          {/* Normal (non-urgent) deadline stays inline */}
-          {task.deadline && (() => {
-            const dl = formatDeadline(task.deadline);
-            const DlIcon = dl.icon;
-            if (dl.urgent) return null;
-            return (
-              <>
-                <div className="hidden md:block w-px h-4 bg-border" />
-                <div className={cn('flex items-center gap-1.5 cursor-default', dl.className)} title={formatDeadlineFull(task.deadline)}>
-                  <DlIcon className="size-3" />
-                  <span className="text-xs font-medium">{dl.label}</span>
-                </div>
-              </>
-            );
-          })()}
+        )}
+
+        {/* Non-urgent deadline — show "Request more time" link for assignees */}
+        {task.deadline && (() => {
+          const dl = formatDeadline(task.deadline);
+          const DlIcon = dl.icon;
+          if (dl.urgent) return null;
+          return (
+            <div className="flex items-center gap-1.5">
+              <DlIcon className={cn('size-3', dl.className)} />
+              <span className={cn('text-xs font-medium', dl.className)} title={formatDeadlineFull(task.deadline)}>{dl.label}</span>
+              {!isAdmin && task.assignee_id === currentUserId && !pendingExt && !showExtForm && (
+                <button
+                  onClick={() => setShowExtForm(true)}
+                  className="ml-2 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  Request more time
+                </button>
+              )}
+            </div>
+          );
+        })()}
+
+        {/* Metadata — compact inline badges, no container */}
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5">
+          {isAdmin ? (
+            <select
+              className="appearance-none rounded-md border border-transparent bg-transparent px-2 py-0.5 text-xs font-medium text-foreground cursor-pointer hover:border-border hover:bg-muted/50 transition-colors leading-normal"
+              defaultValue={task.priority}
+              onChange={async (e) => {
+                const newPriority = e.target.value;
+                await supabase.from('tasks').update({ priority: newPriority }).eq('id', task.id);
+                toast.success(`Priority changed to ${newPriority}`);
+              }}
+            >
+              {['High', 'Medium', 'Low'].map(p => (
+                <option key={p} value={p}>{p}</option>
+              ))}
+            </select>
+          ) : (
+            <span className="text-xs font-medium text-foreground">{task.priority}</span>
+          )}
+          <span className="inline-block w-px h-3 bg-border" />
+          {isAdmin ? (
+            <select
+              className="appearance-none rounded-md border border-transparent bg-transparent px-2 py-0.5 text-xs font-medium text-foreground cursor-pointer hover:border-border hover:bg-muted/50 transition-colors leading-normal"
+              defaultValue={task.department}
+              onChange={async (e) => {
+                const newDept = e.target.value;
+                await supabase.from('tasks').update({ department: newDept }).eq('id', task.id);
+                toast.success(`Department changed to ${newDept}`);
+              }}
+            >
+              {['Coding', 'Visual Art', 'UI/UX', 'Animation', 'Asset Creation'].map(d => (
+                <option key={d} value={d}>{d}</option>
+              ))}
+            </select>
+          ) : (
+            <span className="text-xs font-medium text-foreground">{task.department}</span>
+          )}
+          {/* Hand off — demoted to inline text link */}
+          {canHandOff && (
+            <>
+              <span className="inline-block w-px h-3 bg-border" />
+              <button
+                onClick={() => setShowHandoff(true)}
+                className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <ArrowRightLeft className="size-3" />
+                Hand off
+              </button>
+            </>
+          )}
         </div>
       </div>
 
-      {/* Actions */}
-      {canHandOff && (
-        <button
-          onClick={() => setShowHandoff(true)}
-          className="flex w-full items-center justify-center gap-2 rounded-lg border border-border px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-muted/50 hover:text-foreground transition-colors mb-4"
-        >
-          <ArrowRightLeft className="size-3.5" />
-          Hand Off Task
-        </button>
-      )}
-
-      {/* Description */}
-      {task.description ? (
-        <div className="mb-4">
-          <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/60">Description</span>
-          <p className="text-sm text-muted-foreground mt-1 leading-relaxed">{task.description}</p>
-        </div>
-      ) : (
-        <div className="mb-4 py-4 text-center">
-          <p className="text-xs text-muted-foreground/40">No description added</p>
-        </div>
+      {/* Description — no label, separated by spacing alone */}
+      {task.description && (
+        <p className="text-sm text-muted-foreground mb-4 leading-relaxed">{task.description}</p>
       )}
 
       {handoffs.length > 0 && (
@@ -1728,7 +1976,7 @@ export function TaskDetail({ task, open, onOpenChange, team, docs, currentUserId
         )}
       </AnimatePresence>
 
-      {showHandoff && (
+      {showHandoff && createPortal(
         <HandoffDialog
           task={task}
           team={team}
@@ -1739,7 +1987,8 @@ export function TaskDetail({ task, open, onOpenChange, team, docs, currentUserId
             setLocalAssigneeId(toUserId);
             loadHandoffs();
           }}
-        />
+        />,
+        document.body
       )}
     </>
   );

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -31,9 +31,11 @@ interface DialogProps {
   resizable?: boolean
   /** Optional class name for the panel (e.g. max-w-4xl for a larger dialog). */
   contentClassName?: string
+  /** Optional class name for the outer fixed wrapper (e.g. z-[70] to override stacking). */
+  className?: string
 }
 
-function Dialog({ open, onOpenChange, children, resizable = false, contentClassName }: DialogProps) {
+function Dialog({ open, onOpenChange, children, resizable = false, contentClassName, className }: DialogProps) {
   const [footer, setFooter] = React.useState<React.ReactNode>(null)
   const [size, setSize] = React.useState({ w: DEFAULT_MAX_W, h: 600 });
   const [maximized, setMaximized] = React.useState(false)
@@ -137,7 +139,7 @@ function Dialog({ open, onOpenChange, children, resizable = false, contentClassN
   return (
     <AnimatePresence>
       {open && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center">
+        <div className={cn("fixed inset-0 z-50 flex items-center justify-center", className)}>
           <motion.div
             className="fixed inset-0 bg-black/50 backdrop-blur-sm"
             initial={{ opacity: 0 }}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -157,7 +157,10 @@ export type NotificationKind =
   | 'task_handoff'
   | 'payment_request'
   | 'payment_approved'
-  | 'payment_denied';
+  | 'payment_denied'
+  | 'deadline_extension_requested'
+  | 'deadline_extension_approved'
+  | 'deadline_extension_denied';
 
 export type UserEvent = {
   id: string;
@@ -177,5 +180,19 @@ export type Notification = {
   body?: string;
   link?: string;
   read: boolean;
+  created_at: string;
+};
+
+export type DeadlineExtension = {
+  id: string;
+  task_id: string;
+  requested_by: string;
+  extra_hours: number;
+  original_deadline: string;
+  new_deadline: string;
+  status: 'pending' | 'approved' | 'denied';
+  decided_by?: string | null;
+  decided_at?: string | null;
+  denial_reason?: string | null;
   created_at: string;
 };


### PR DESCRIPTION
## Summary

- **Deadline extension requests**: Team members can request more time on tasks with a preset chip picker (+1d/+2d/+3d/+1w/Custom). Admins see an approval banner in TaskDetail with Approve/Deny actions. Notifications sent both ways via existing notification system. Activity log tracks all extension events.
- **Activity page improvements**: Filter pills (All, Assignments, Completed, Comments, Blocked), max-width constraint for readable line lengths, extracted client component for filtering.
- **TaskDetail redesign**: Merged metadata into compact inline format (High | Animation | ⇄ Hand off), removed card-in-card nesting, demoted hand-off to text link, removed redundant description label, tightly coupled extension form with deadline banner.
- **Bug fixes**: HandoffDialog z-index (now portaled to body with z-[70]), Dialog component accepts className prop for stacking overrides.

## New API Routes

- `POST /api/deadline-extensions` — create extension request (validates assignee, deadline, no pending)
- `PATCH /api/deadline-extensions/[id]` — admin approve/deny (atomic with rollback on failure)

## Database

- New `deadline_extensions` table with RLS policies
- Three new notification kinds: `deadline_extension_requested/approved/denied`

## Test plan

- [ ] As assignee: open task with deadline → see "Request more time" → pick +3d → submit → see pending status
- [ ] As admin: open same task → see approval banner → approve → deadline updates, panel closes
- [ ] As admin: deny with optional reason → requester gets notification
- [ ] Activity page: verify filter pills work, check max-width on wide screens
- [ ] HandoffDialog: verify it renders above TaskDetail panel
- [ ] Mobile: verify activity page and task detail still work on small screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)