### PR TITLE
fix: mobile tour not starting for non-admin users

### DIFF
--- a/src/components/dashboard/DashboardTourWrapper.tsx
+++ b/src/components/dashboard/DashboardTourWrapper.tsx
@@ -15,7 +15,10 @@ function useIsMac() {
 }
 
 function useIsMobile() {
-  const [isMobile, setIsMobile] = useState(false);
+  const [isMobile, setIsMobile] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return window.matchMedia('(max-width: 767px)').matches;
+  });
   useEffect(() => {
     const mq = window.matchMedia('(max-width: 767px)');
     setIsMobile(mq.matches);


### PR DESCRIPTION
## Summary
- `useIsMobile()` hook initialized as `false`, causing the first render to build desktop tour step IDs (`tour-overview`) that don't exist in the mobile DOM
- Changed to a lazy `useState` initializer that reads `window.matchMedia` synchronously, so mobile steps are correct from the first render

## Test plan
- [ ] On mobile (or narrow viewport ≤767px), complete onboarding as a non-admin user
- [ ] Verify the "Welcome" tour dialog appears and clicking "Start tour" highlights the first mobile nav item
- [ ] Verify tour works for admin users on mobile (with "More" overflow step)
- [ ] Verify desktop tour still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)