### PR TITLE
fix: add missing admin/external-signing page

### DIFF
--- a/src/app/(dashboard)/admin/external-signing/client.tsx
+++ b/src/app/(dashboard)/admin/external-signing/client.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useState } from 'react';
+import { motion } from 'motion/react';
+import { FileSignature } from 'lucide-react';
+import { SendInviteForm } from '@/components/external-signing/SendInviteForm';
+import { InviteTable } from '@/components/external-signing/InviteTable';
+
+const SPRING = { type: 'spring' as const, stiffness: 300, damping: 25 };
+
+export function ExternalSigningAdmin() {
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  return (
+    <div className="mx-auto max-w-4xl p-6">
+      <motion.div
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={SPRING}
+        className="space-y-8"
+      >
+        {/* Header */}
+        <div className="flex items-center gap-3">
+          <div className="flex size-10 items-center justify-center rounded-xl bg-seeko-accent/10 ring-1 ring-seeko-accent/20">
+            <FileSignature className="size-5 text-seeko-accent" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-foreground">External Signing</h1>
+            <p className="text-sm text-muted-foreground">Send documents for external parties to sign</p>
+          </div>
+        </div>
+
+        <SendInviteForm onInviteSent={() => setRefreshKey((k) => k + 1)} />
+        <InviteTable refreshKey={refreshKey} />
+      </motion.div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/admin/external-signing/page.tsx
+++ b/src/app/(dashboard)/admin/external-signing/page.tsx
@@ -1,0 +1,19 @@
+import { createClient } from '@/lib/supabase/server';
+import { redirect } from 'next/navigation';
+import { ExternalSigningAdmin } from './client';
+
+export default async function ExternalSigningPage() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect('/login');
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('is_admin')
+    .eq('id', user.id)
+    .single();
+
+  if (!profile?.is_admin) redirect('/');
+
+  return <ExternalSigningAdmin />;
+}


### PR DESCRIPTION
## Summary

- The `/admin/external-signing` page files were created locally but never committed to git, causing a 404 in production
- Adds `page.tsx` (server component with admin auth check) and `client.tsx` (the SendInviteForm + InviteTable UI)

## Test plan

- [ ] Navigate to `/admin/external-signing` — should show the external signing admin panel
- [ ] Verify non-admin users get redirected

🤖 Generated with [Claude Code](https://claude.com/claude-code)