### PR TITLE
fix: mobile/PWA fixes for onboarding, auth & dialogs

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -4,7 +4,7 @@ export default function AuthLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background">
+    <div className="min-h-dvh flex items-center justify-center bg-background pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
       {children}
     </div>
   );

--- a/src/app/agreement/page.tsx
+++ b/src/app/agreement/page.tsx
@@ -23,7 +23,7 @@ export default async function AgreementPage() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background px-4 py-12">
+    <div className="flex min-h-dvh items-center justify-center bg-background px-4 py-12 pt-[max(3rem,env(safe-area-inset-top))] pb-[max(3rem,env(safe-area-inset-bottom))]">
       <div className="w-full max-w-2xl space-y-8">
         <div className="text-center">
           <FadeScale className="mx-auto flex size-16 items-center justify-center">

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -17,7 +17,7 @@ export default async function OnboardingPage() {
   if (profile?.onboarded === 1) redirect('/');
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background px-4">
+    <div className="flex min-h-dvh items-center justify-center bg-background px-4 pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
       <div className="w-full max-w-md space-y-8">
         <div className="text-center">
           <FadeScale className="mx-auto flex size-16 items-center justify-center">

--- a/src/app/set-password/page.tsx
+++ b/src/app/set-password/page.tsx
@@ -9,7 +9,7 @@ export default async function SetPasswordPage() {
   if (!user) redirect('/login');
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background px-4">
+    <div className="min-h-dvh flex items-center justify-center bg-background px-4 pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
       <div className="w-full max-w-sm space-y-8">
         <div className="text-center">
           <FadeScale className="mx-auto flex size-16 items-center justify-center">

--- a/src/app/sign/[token]/page.tsx
+++ b/src/app/sign/[token]/page.tsx
@@ -20,7 +20,7 @@ export default async function ExternalSignPage({ params }: Props) {
 
   if (!invite) {
     return (
-      <div className="flex min-h-dvh items-center justify-center bg-background px-4">
+      <div className="flex min-h-dvh items-center justify-center bg-background px-4 pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
         <div className="text-center">
           <h1 className="text-xl font-semibold text-foreground">Link not found</h1>
           <p className="mt-2 text-sm text-muted-foreground">This signing link is invalid or has been removed.</p>

--- a/src/components/dashboard/PaymentCreateDialog.tsx
+++ b/src/components/dashboard/PaymentCreateDialog.tsx
@@ -146,8 +146,8 @@ export function PaymentCreateDialog({
   const nonInvestorTeam = team.filter(m => !m.is_investor);
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4">
-      <div className="w-full max-w-md rounded-xl border border-border bg-card p-6 shadow-xl">
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/60 sm:px-4">
+      <div className="w-full max-w-md rounded-t-2xl sm:rounded-xl border border-border bg-card p-6 pb-[max(1.5rem,env(safe-area-inset-bottom))] sm:pb-6 shadow-xl max-h-[90dvh] overflow-y-auto">
         {success ? (
           <div className="flex flex-col items-center gap-4 py-8">
             <div className="flex size-14 items-center justify-center rounded-full bg-emerald-500/10">

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -139,7 +139,7 @@ function Dialog({ open, onOpenChange, children, resizable = false, contentClassN
   return (
     <AnimatePresence>
       {open && (
-        <div className={cn("fixed inset-0 z-50 flex items-center justify-center", className)}>
+        <div className={cn("fixed inset-0 z-50 flex items-end sm:items-center justify-center", className)}>
           <motion.div
             className="fixed inset-0 bg-black/50 backdrop-blur-sm"
             initial={{ opacity: 0 }}
@@ -151,7 +151,7 @@ function Dialog({ open, onOpenChange, children, resizable = false, contentClassN
           <motion.div
             ref={panelRef}
             className={cn(
-              "relative z-50 flex flex-col rounded-xl border border-white/[0.08] bg-popover/80 backdrop-blur-xl backdrop-saturate-150 shadow-xl mx-4",
+              "relative z-50 flex flex-col rounded-t-2xl sm:rounded-xl border border-white/[0.08] bg-popover/80 backdrop-blur-xl backdrop-saturate-150 shadow-xl mx-0 sm:mx-4 pb-[env(safe-area-inset-bottom)] sm:pb-0",
               !resizable && "w-full max-w-[900px] max-h-[90vh] sm:max-h-[88vh]",
               !resizable && footer != null && "h-[90vh] sm:h-[88vh]",
               contentClassName


### PR DESCRIPTION
## Summary
Follow-up to #46 — applies the same mobile/PWA treatment to all remaining standalone pages and shared components:

- **Auth layout**: `min-h-screen` → `min-h-dvh` + safe-area insets (affects login page)
- **Onboarding page**: `min-h-screen` → `min-h-dvh` + safe-area insets
- **Set-password page**: `min-h-screen` → `min-h-dvh` + safe-area insets
- **Agreement page**: `min-h-screen` → `min-h-dvh` + safe-area insets
- **Sign/[token] server error state**: Add safe-area insets
- **Dialog component (shared)**: Bottom-sheet on mobile (`items-end`, `rounded-t-2xl`, safe-area bottom padding)
- **PaymentCreateDialog**: Bottom-sheet on mobile + safe-area + scrollable `max-h-[90dvh]`

## Test plan
- [ ] Login page renders correctly on iPhone SE in standalone mode (no content behind home indicator)
- [ ] Onboarding profile setup page has safe-area padding on notched devices
- [ ] Agreement signing page scrollable content area adapts to mobile viewport
- [ ] Any Dialog (docs editor, task detail, etc.) slides up from bottom on mobile
- [ ] PaymentCreateDialog scrollable when content exceeds mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)