### PR TITLE
fix: confirm send dialog hidden behind bottom nav

### DIFF
--- a/src/components/external-signing/SendInviteForm.tsx
+++ b/src/components/external-signing/SendInviteForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
 import { Send, Upload, FileText, Loader2, X, Eye, ChevronDown, ChevronUp, AlertCircle, Calendar } from 'lucide-react';
 import { EXTERNAL_TEMPLATES } from '@/lib/external-agreement-templates';
@@ -112,6 +112,16 @@ export function SendInviteForm({ onInviteSent }: SendInviteFormProps) {
       setSending(false);
     }
   }
+
+  // Hide mobile bottom nav when confirm dialog is open
+  useEffect(() => {
+    if (showConfirm) {
+      document.documentElement.setAttribute('data-modal-open', '');
+    } else {
+      document.documentElement.removeAttribute('data-modal-open');
+    }
+    return () => document.documentElement.removeAttribute('data-modal-open');
+  }, [showConfirm]);
 
   const canSubmit = email && (templateMode === 'preset' ? templateId : customSections);
   const selectedTemplate = EXTERNAL_TEMPLATES.find((t) => t.id === templateId);
@@ -362,7 +372,7 @@ export function SendInviteForm({ onInviteSent }: SendInviteFormProps) {
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
-              className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/60 backdrop-blur-sm"
+              className="fixed inset-0 z-[60] flex items-end sm:items-center justify-center bg-black/60 backdrop-blur-sm"
               onClick={() => setShowConfirm(false)}
             >
               <motion.div


### PR DESCRIPTION
## Summary
- The "Confirm Send" bottom sheet on the external signing invite form was rendering behind the mobile bottom nav — Cancel/Send buttons were completely hidden
- Adds `data-modal-open` attribute on `<html>` when dialog opens (triggers existing CSS rule that hides bottom nav)
- Bumps dialog z-index to `z-[60]` (above nav's `z-50`)

## Test plan
- [ ] Open external signing page on mobile → Send Invite → Confirm dialog should show Cancel/Send buttons fully visible
- [ ] Bottom nav should be hidden while confirm dialog is open
- [ ] Dismissing dialog should restore bottom nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)