### PR TITLE
fix: hide mobile bottom nav behind all modals + notification PWA padding

### DIFF
--- a/src/components/agreement/AgreementForm.tsx
+++ b/src/components/agreement/AgreementForm.tsx
@@ -96,6 +96,15 @@ export function AgreementForm({
   const [signed, setSigned] = useState(false);
   const [showConfirmation, setShowConfirmation] = useState(false);
 
+  useEffect(() => {
+    if (showConfirmation) {
+      document.documentElement.setAttribute('data-modal-open', '');
+    } else {
+      document.documentElement.removeAttribute('data-modal-open');
+    }
+    return () => { document.documentElement.removeAttribute('data-modal-open'); };
+  }, [showConfirmation]);
+
   // Signature animation timing
   const [sigKey, setSigKey] = useState(0);
   const SIG = { charDelay: 0.08, charDuration: 0.18, initialDelay: 0.3, fontSize: 27 };

--- a/src/components/dashboard/CommandPalette.tsx
+++ b/src/components/dashboard/CommandPalette.tsx
@@ -124,9 +124,13 @@ export function CommandPalette({ team, docs, decks = [], isContractor = false, i
 
   useEffect(() => {
     if (open) {
+      document.documentElement.setAttribute('data-modal-open', '');
       setQuery('');
       setTimeout(() => inputRef.current?.focus(), 50);
+    } else {
+      document.documentElement.removeAttribute('data-modal-open');
     }
+    return () => { document.documentElement.removeAttribute('data-modal-open'); };
   }, [open]);
 
   useEffect(() => {

--- a/src/components/dashboard/ContractorToggle.tsx
+++ b/src/components/dashboard/ContractorToggle.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
 import { toast } from 'sonner';
 import { X } from 'lucide-react';
@@ -8,6 +8,15 @@ import { X } from 'lucide-react';
 export function ContractorToggle({ userId, isContractor }: { userId: string; isContractor: boolean }) {
   const [confirming, setConfirming] = useState(false);
   const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (confirming) {
+      document.documentElement.setAttribute('data-modal-open', '');
+    } else {
+      document.documentElement.removeAttribute('data-modal-open');
+    }
+    return () => { document.documentElement.removeAttribute('data-modal-open'); };
+  }, [confirming]);
 
   const next = !isContractor;
   const actionLabel = isContractor ? 'Make Member' : 'Make Contractor';

--- a/src/components/dashboard/DeckViewer.tsx
+++ b/src/components/dashboard/DeckViewer.tsx
@@ -68,6 +68,15 @@ export function DeckViewer({ slides, title }: DeckViewerProps) {
     setShowEndCard(false);
   }, []);
 
+  useEffect(() => {
+    if (fullscreen) {
+      document.documentElement.setAttribute('data-modal-open', '');
+    } else {
+      document.documentElement.removeAttribute('data-modal-open');
+    }
+    return () => { document.documentElement.removeAttribute('data-modal-open'); };
+  }, [fullscreen]);
+
   // Keyboard navigation in fullscreen
   useEffect(() => {
     if (!fullscreen) return;

--- a/src/components/dashboard/NotificationBell.tsx
+++ b/src/components/dashboard/NotificationBell.tsx
@@ -203,11 +203,15 @@ export function NotificationBell({ userId, initialCount, initialNotifications, c
 
   useEffect(() => { setMounted(true); }, []);
 
-  // #1 — Lock body scroll when mobile sheet is open
+  // #1 — Lock body scroll + hide bottom nav when mobile sheet is open
   useEffect(() => {
     if (!isDesktop && open) {
+      document.documentElement.setAttribute('data-modal-open', '');
       document.body.style.overflow = 'hidden';
-      return () => { document.body.style.overflow = ''; };
+      return () => {
+        document.documentElement.removeAttribute('data-modal-open');
+        document.body.style.overflow = '';
+      };
     }
   }, [isDesktop, open]);
 
@@ -477,6 +481,7 @@ export function NotificationBell({ userId, initialCount, initialNotifications, c
             style={{
               backgroundColor: '#1a1a1a',
               maxHeight: '85dvh',
+              paddingTop: 'env(safe-area-inset-top)',
               paddingBottom: 'env(safe-area-inset-bottom)',
             }}
           >

--- a/src/components/dashboard/PaymentCreateDialog.tsx
+++ b/src/components/dashboard/PaymentCreateDialog.tsx
@@ -53,11 +53,15 @@ export function PaymentCreateDialog({
 
   useEffect(() => {
     if (open) {
+      document.documentElement.setAttribute('data-modal-open', '');
       setItems([{ id: uuid(), label: '', amount: '' }]);
       setSaving(false);
       setSuccess(false);
       setCopied(false);
+    } else {
+      document.documentElement.removeAttribute('data-modal-open');
     }
+    return () => { document.documentElement.removeAttribute('data-modal-open'); };
   }, [open]);
 
   const total = items.reduce((sum, i) => sum + (parseFloat(i.amount) || 0), 0);

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -14,16 +14,19 @@ interface AlertDialogProps {
 function AlertDialog({ open, onOpenChange, children }: AlertDialogProps) {
   React.useEffect(() => {
     if (open) {
+      document.documentElement.setAttribute('data-modal-open', '');
       document.body.style.overflow = 'hidden';
       const handler = (e: KeyboardEvent) => {
         if (e.key === 'Escape') onOpenChange(false);
       }
       document.addEventListener('keydown', handler);
       return () => {
+        document.documentElement.removeAttribute('data-modal-open');
         document.body.style.overflow = '';
         document.removeEventListener('keydown', handler);
       };
     }
+    document.documentElement.removeAttribute('data-modal-open');
     document.body.style.overflow = '';
   }, [open, onOpenChange]);
 

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -44,6 +44,16 @@ function Dialog({ open, onOpenChange, children, resizable = false, contentClassN
   const sizeBeforeMax = React.useRef(size)
   const panelRef = React.useRef<HTMLDivElement>(null)
 
+  // Hide mobile bottom nav when dialog is open
+  React.useEffect(() => {
+    if (open) {
+      document.documentElement.setAttribute('data-modal-open', '')
+    } else {
+      document.documentElement.removeAttribute('data-modal-open')
+    }
+    return () => { document.documentElement.removeAttribute('data-modal-open') }
+  }, [open])
+
   React.useEffect(() => {
     if (!open) return
 


### PR DESCRIPTION
## Summary
- Add `data-modal-open` attribute to all 8 overlay components so the mobile bottom nav hides when any modal is open
- Components fixed: Dialog, AlertDialog, AgreementForm, PaymentCreateDialog, CommandPalette, ContractorToggle, DeckViewer, NotificationBell
- Add `paddingTop: env(safe-area-inset-top)` to notification mobile sheet for PWA standalone mode

## Test plan
- [ ] Open any document on mobile — bottom nav should hide
- [ ] Open payment create dialog — bottom nav should hide
- [ ] Open command palette — bottom nav should hide
- [ ] Open notification sheet on mobile — bottom nav should hide, content not behind status bar in PWA
- [ ] Dismiss any modal — bottom nav should reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)