### PR TITLE
fix: mobile bug fixes for signing, payments, dialogs, and PWA

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -4,7 +4,7 @@ export default function AuthLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-dvh flex items-center justify-center bg-background pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
+    <div className="min-h-dvh flex items-center justify-center bg-background px-4 pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
       {children}
     </div>
   );

--- a/src/components/agreement/AgreementForm.tsx
+++ b/src/components/agreement/AgreementForm.tsx
@@ -197,7 +197,7 @@ export function AgreementForm({
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 0.3 }}
-            className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/60 backdrop-blur-sm"
+            className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 backdrop-blur-sm px-4"
           >
             <motion.div
               initial={{ opacity: 0, y: 40 }}
@@ -464,7 +464,7 @@ export function AgreementForm({
                         animate={{ opacity: 1 }}
                         transition={SPRING}
                       >
-                        <div className="rounded-lg border border-border bg-muted/20 px-6 py-5 text-center">
+                        <div className="rounded-lg border border-border bg-muted/20 px-4 sm:px-6 py-5 text-center">
                           <p className="text-[10px] uppercase tracking-widest text-muted-foreground mb-3">Digital Signature</p>
                           <SignatureDrawing
                             text={fullName.trim()}

--- a/src/components/dashboard/PaymentCreateDialog.tsx
+++ b/src/components/dashboard/PaymentCreateDialog.tsx
@@ -284,8 +284,7 @@ export function PaymentCreateDialog({
               <div className="flex items-center justify-between pt-2 border-t border-border">
                 <span className="text-sm font-medium text-muted-foreground">Total</span>
                 <span
-                  className="text-lg font-semibold"
-                  style={{ color: total > 0 ? 'var(--color-seeko-accent)' : undefined }}
+                  className={`text-lg font-semibold ${total > 0 ? 'text-seeko-accent' : ''}`}
                 >
                   {new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(total)}
                 </span>

--- a/src/components/external-signing/InviteTable.tsx
+++ b/src/components/external-signing/InviteTable.tsx
@@ -29,7 +29,7 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
     const supabase = createClient();
     const { data } = await supabase
       .from('external_signing_invites')
-      .select('id, token, recipient_email, recipient_name, status, template_type, template_id, custom_title, personal_note, expires_at, signed_at, created_at, verification_attempts, created_by')
+      .select('id, token, recipient_email, status, template_type, template_id, custom_title, personal_note, expires_at, signed_at, created_at, verification_attempts, created_by, signer_name')
       .order('created_at', { ascending: false });
     setInvites((data as ExternalSigningInvite[]) || []);
     setLoading(false);

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -167,14 +167,24 @@ function Dialog({ open, onOpenChange, children, resizable = false, contentClassN
               contentClassName
             )}
             style={panelStyle}
-            initial={{ opacity: 0, scale: 0.95, y: 8 }}
-            animate={{ opacity: 1, scale: 1, y: 0 }}
-            exit={{ opacity: 0, scale: 0.95, y: 8 }}
+            initial={{ opacity: 0, y: 40 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 40 }}
             transition={{ type: "spring", stiffness: 400, damping: 30 }}
+            drag="y"
+            dragConstraints={{ top: 0, bottom: 0 }}
+            dragElastic={{ top: 0, bottom: 0.6 }}
+            onDragEnd={(_e, info) => {
+              if (info.offset.y > 100 || info.velocity.y > 300) onOpenChange(false)
+            }}
           >
+            {/* Mobile drag handle */}
+            <div className="sm:hidden flex justify-center pt-2 pb-1 shrink-0 cursor-grab active:cursor-grabbing">
+              <div className="w-9 h-1 rounded-full bg-white/20" />
+            </div>
             <DialogFooterContext.Provider value={{ setFooter }}>
               <div className="flex min-h-0 flex-1 flex-col">
-                <div className="flex-1 min-h-0 overflow-y-auto p-6 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                <div className="flex-1 min-h-0 overflow-y-auto p-6 pt-2 sm:pt-6 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
                   {children}
                 </div>
                 {footer != null ? (


### PR DESCRIPTION
## Summary
- **InviteTable query fix**: Removed non-existent `recipient_name` column, added `signer_name` — fixes invite table not loading
- **Payment total color**: Replaced inline CSS variable style with `text-seeko-accent` Tailwind class so total shows green
- **Auth layout PWA padding**: Added `px-4` horizontal padding so invite code doesn't leak to edges in Safari PWA
- **Dialog swipe-to-dismiss**: Added drag handle + `drag="y"` with velocity/offset threshold for mobile dismiss gesture
- **Dialog animation**: Changed from scale to slide-up (`y: 40`) for more natural mobile feel
- **Success card overlay**: Centered (`items-center`) instead of bottom-sheet (`items-end`) so it's not hidden under the search bar
- **Signature box padding**: Made responsive (`px-4 sm:px-6`) so signature aligns properly on mobile

## Test plan
- [ ] Open external signing invite table — verify it loads without errors
- [ ] Create a payment request — verify total turns green when > $0
- [ ] Open app from Safari home screen — verify invite code has proper padding
- [ ] Open any dialog on mobile — verify drag handle visible and swipe-to-dismiss works
- [ ] Complete agreement signing — verify success card is centered on screen
- [ ] View signature box on mobile — verify padding is not too wide

🤖 Generated with [Claude Code](https://claude.com/claude-code)