### PR TITLE
fix: darken agreement signed success overlay

### DIFF
--- a/src/components/agreement/AgreementForm.tsx
+++ b/src/components/agreement/AgreementForm.tsx
@@ -197,7 +197,7 @@ export function AgreementForm({
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 0.3 }}
-            className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 backdrop-blur-sm px-4"
+            className="fixed inset-0 z-[60] flex items-center justify-center bg-black/80 backdrop-blur-md px-4"
           >
             <motion.div
               initial={{ opacity: 0, y: 40 }}


### PR DESCRIPTION
## Summary
- Increased backdrop opacity from `bg-black/60` to `bg-black/80` and blur from `backdrop-blur-sm` to `backdrop-blur-md`
- Form content behind the "Agreement Signed" card was showing through and looking messy

## Test plan
- [ ] Complete an external signing flow — verify the success card overlay fully obscures the form behind it

🤖 Generated with [Claude Code](https://claude.com/claude-code)