### PR TITLE
fix: dialog renders above mobile nav bar

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -149,7 +149,7 @@ function Dialog({ open, onOpenChange, children, resizable = false, contentClassN
   return (
     <AnimatePresence>
       {open && (
-        <div className={cn("fixed inset-0 z-50 flex items-end sm:items-center justify-center", className)}>
+        <div className={cn("fixed inset-0 z-[60] flex items-end sm:items-center justify-center", className)}>
           <motion.div
             className="fixed inset-0 bg-black/50 backdrop-blur-sm"
             initial={{ opacity: 0 }}


### PR DESCRIPTION
## Summary
- Bumped Dialog z-index from `z-50` to `z-[60]` so it always renders above the mobile bottom nav (`z-50`)
- Fixes the bug report "Send Report" button being hidden behind the nav bar on mobile

## Test plan
- [ ] Open any dialog on mobile (bug report, add task, etc.)
- [ ] Verify the dialog fully covers the bottom nav
- [ ] Verify the "Send Report" button is visible and tappable

🤖 Generated with [Claude Code](https://claude.com/claude-code)