### PR TITLE
fix: payments mobile layout and deck viewer polish

### DIFF
--- a/src/components/dashboard/PaymentsAdmin.tsx
+++ b/src/components/dashboard/PaymentsAdmin.tsx
@@ -210,22 +210,24 @@ export function PaymentsAdmin({ team }: PaymentsAdminProps) {
     <div className="flex flex-col gap-8">
       {/* ── Hero ── */}
       <FadeRise delay={d(TIMING.hero)}>
-        <div className="flex items-start justify-between">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div>
             <h1 className="text-2xl font-semibold tracking-tight text-foreground">Payments</h1>
-            <p className="text-sm text-muted-foreground mt-1">Track and manage team payments.</p>
+            <p className="hidden sm:block text-sm text-muted-foreground mt-1">Track and manage team payments.</p>
           </div>
           <div className="flex items-center gap-2">
             <Button variant="outline" size="sm" className="gap-1.5" onClick={() => setInvoiceFormOpen(true)}>
               <FileText className="size-3.5" />
-              Request Invoice
+              <span className="hidden sm:inline">Request Invoice</span>
+              <span className="sm:hidden">Invoice</span>
             </Button>
             <Button
               onClick={() => { setSelectedRecipient(null); setCreateDialogOpen(true); }}
               className="gap-1.5 bg-seeko-accent text-black hover:bg-seeko-accent/90"
             >
               <Plus className="size-4" />
-              New Payment
+              <span className="hidden sm:inline">New Payment</span>
+              <span className="sm:hidden">Payment</span>
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- **Payments mobile layout** — header stacks vertically on mobile with shorter button labels ("Invoice" / "Payment"), description hidden on small screens
- **Deck viewer: Present button** — overlay bar z-index raised above nav click zones so Present is clickable
- **Deck viewer: fullscreen z-index** — bumped to z-[70] so present mode renders above the dialog
- **Deck viewer: notes section** — renders deck content field below filmstrip with link support
- **Invoice requests collapsible** — shows first 3 items with "Show all N" toggle when 4+
- **Invoice page SSR fix** — query Supabase directly instead of self-fetching API route

## Test plan
- [ ] Payments page on mobile: title and buttons should not overlap or clip
- [ ] Open a deck, hover and click Present — should enter fullscreen (not advance slide)
- [ ] Fullscreen presentation renders above the dialog
- [ ] Deck with content shows notes section below filmstrip
- [ ] Invoice requests list collapses at 4+ items
- [ ] Invoice link in production loads without server error

🤖 Generated with [Claude Code](https://claude.com/claude-code)