### PR TITLE
fix: correct hooks format in .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,14 +2,24 @@
   "hooks": {
     "SessionStart": [
       {
-        "type": "command",
-        "command": "echo '=== SEEKO AGENT PROTOCOL ===' && cat CLAUDE.md"
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo '=== SEEKO AGENT PROTOCOL ===' && cat CLAUDE.md"
+          }
+        ]
       }
     ],
     "PreToolUse": [
       {
-        "type": "command",
-        "command": "python3 -c \"\nimport sys, json\ndata = json.load(sys.stdin)\ninp = str(data.get('tool_input', {}))\nif '.env' in inp:\n    print('.env files are protected and cannot be accessed.', file=sys.stderr)\n    sys.exit(2)\n\""
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 -c \"\nimport sys, json\ndata = json.load(sys.stdin)\ninp = str(data.get('tool_input', {}))\nif '.env' in inp:\n    print('.env files are protected and cannot be accessed.', file=sys.stderr)\n    sys.exit(2)\n\""
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Summary
- Fixes `.claude/settings.json` hook entries to use the required `matcher` + `hooks` array format
- Without this, every new worktree fails with "Expected array, but received undefined"

## Test plan
- [ ] Open a new Claude Code workspace/worktree — no settings error on launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)