### PR TITLE
feat: vertical orientation for deck viewer

### DIFF
--- a/src/app/api/doc-share/view/route.ts
+++ b/src/app/api/doc-share/view/route.ts
@@ -47,11 +47,11 @@ export async function POST(request: NextRequest) {
   }
 
   // Fetch doc content
-  const { data: doc } = await service
-    .from('docs')
-    .select('id, title, content, type, slides')
+  const { data: doc } = await (service
+    .from('docs') as any)
+    .select('id, title, content, type, slides, deck_orientation')
     .eq('id', invite.shared_doc_id)
-    .single();
+    .single() as { data: { id: string; title: string; content?: string; type?: string; slides?: any; deck_orientation?: string } | null };
 
   if (!doc) {
     return NextResponse.json({ error: 'Document not found' }, { status: 404 });
@@ -68,5 +68,6 @@ export async function POST(request: NextRequest) {
     content: doc.content,
     type: doc.type || 'doc',
     slides: doc.slides || null,
+    deck_orientation: doc.deck_orientation || 'horizontal',
   });
 }

--- a/src/app/api/docs/[id]/route.ts
+++ b/src/app/api/docs/[id]/route.ts
@@ -50,6 +50,7 @@ export async function PATCH(
   if ('restricted_department' in body) updates.restricted_department = restricted_department ?? null;
   if ('granted_user_ids' in body) updates.granted_user_ids = Array.isArray(granted_user_ids) && granted_user_ids.length ? granted_user_ids : null;
   if ('slides' in body) updates.slides = body.slides;
+  if ('deck_orientation' in body) updates.deck_orientation = body.deck_orientation;
   updates.updated_at = new Date().toISOString();
 
   const service = createServiceClient(

--- a/src/app/api/docs/route.ts
+++ b/src/app/api/docs/route.ts
@@ -38,7 +38,7 @@ export async function POST(req: NextRequest) {
   } catch {
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
   }
-  const { title, content, sort_order, restricted_department, granted_user_ids, type, slides } = body;
+  const { title, content, sort_order, restricted_department, granted_user_ids, type, slides, deck_orientation } = body;
 
   const service = createServiceClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -55,6 +55,7 @@ export async function POST(req: NextRequest) {
       granted_user_ids: Array.isArray(granted_user_ids) && granted_user_ids.length ? granted_user_ids : null,
       ...(type === 'deck' ? { type: 'deck' } : {}),
       ...(slides ? { slides } : {}),
+      ...(deck_orientation ? { deck_orientation } : {}),
     })
     .select()
     .single();

--- a/src/app/shared/[token]/client.tsx
+++ b/src/app/shared/[token]/client.tsx
@@ -71,7 +71,7 @@ function formatExpiry(expiresAt: string): string {
 export function SharedDocClient({ token, initialData }: SharedDocClientProps) {
   const alreadyVerified = initialData.status === 'verified';
   const [phase, setPhase] = useState<Phase>(alreadyVerified ? 'viewing' : 'verify');
-  const [docData, setDocData] = useState<{ title: string; content?: string; type: string; slides?: { url: string; sort_order: number }[] } | null>(null);
+  const [docData, setDocData] = useState<{ title: string; content?: string; type: string; deck_orientation?: 'horizontal' | 'vertical'; slides?: { url: string; sort_order: number }[] } | null>(null);
   const [loading, setLoading] = useState(false);
 
   const fetchContent = async () => {
@@ -205,7 +205,7 @@ export function SharedDocClient({ token, initialData }: SharedDocClientProps) {
       {/* Content */}
       <motion.div variants={contentReveal} className="mx-auto max-w-5xl px-5 py-8">
         {docData.type === 'deck' && docData.slides ? (
-          <DeckViewer slides={docData.slides} title={docData.title} notes={docData.content} />
+          <DeckViewer slides={docData.slides} title={docData.title} notes={docData.content} orientation={docData.deck_orientation} />
         ) : docData.content ? (
           <DocContent html={docData.content} />
         ) : (

--- a/src/components/dashboard/DeckEditor.tsx
+++ b/src/components/dashboard/DeckEditor.tsx
@@ -27,6 +27,7 @@ export function DeckEditor({ doc, onSave, onCancel, team = [] }: DeckEditorProps
   const [departments, setDepartments] = useState<string[]>(doc?.restricted_department ?? []);
   const [grantedIds, setGrantedIds] = useState<string[]>(doc?.granted_user_ids ?? []);
   const [slides, setSlides] = useState<{ url: string; sort_order: number }[]>(doc?.slides ?? []);
+  const [orientation, setOrientation] = useState<'horizontal' | 'vertical'>(doc?.deck_orientation ?? 'horizontal');
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const [addUserValue, setAddUserValue] = useState('');
@@ -51,6 +52,7 @@ export function DeckEditor({ doc, onSave, onCancel, team = [] }: DeckEditorProps
           restricted_department: departments.length > 0 ? departments : null,
           granted_user_ids: grantedIds.length > 0 ? grantedIds : null,
           slides: slides.length > 0 ? slides : null,
+          deck_orientation: orientation,
         };
         const res = await fetch(`/api/docs/${doc.id}`, {
           method: 'PATCH',
@@ -74,6 +76,7 @@ export function DeckEditor({ doc, onSave, onCancel, team = [] }: DeckEditorProps
           restricted_department: departments.length > 0 ? departments : null,
           granted_user_ids: grantedIds.length > 0 ? grantedIds : null,
           slides: slides.length > 0 ? slides : null,
+          deck_orientation: orientation,
         };
         const res = await fetch(`/api/docs/${deckId}`, {
           method: 'PATCH',
@@ -97,6 +100,7 @@ export function DeckEditor({ doc, onSave, onCancel, team = [] }: DeckEditorProps
           type: 'deck',
           restricted_department: departments.length > 0 ? departments : null,
           granted_user_ids: grantedIds.length > 0 ? grantedIds : null,
+          deck_orientation: orientation,
         };
         const res = await fetch('/api/docs', {
           method: 'POST',
@@ -268,6 +272,37 @@ export function DeckEditor({ doc, onSave, onCancel, team = [] }: DeckEditorProps
           })}
         </div>
       )}
+
+      {/* Orientation toggle */}
+      <div className="flex items-center gap-3">
+        <span className="text-xs text-muted-foreground whitespace-nowrap">Layout:</span>
+        <div className="flex rounded-lg border border-border overflow-hidden">
+          <button
+            type="button"
+            onClick={() => setOrientation('horizontal')}
+            className={cn(
+              'px-3 py-1.5 text-xs font-medium transition-colors',
+              orientation === 'horizontal'
+                ? 'bg-seeko-accent/10 text-seeko-accent'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            Slides
+          </button>
+          <button
+            type="button"
+            onClick={() => setOrientation('vertical')}
+            className={cn(
+              'px-3 py-1.5 text-xs font-medium transition-colors border-l border-border',
+              orientation === 'vertical'
+                ? 'bg-seeko-accent/10 text-seeko-accent'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            Document
+          </button>
+        </div>
+      </div>
 
       {/* PDF Upload */}
       <DeckUploader

--- a/src/components/dashboard/DeckViewer.tsx
+++ b/src/components/dashboard/DeckViewer.tsx
@@ -1,17 +1,21 @@
 /* ─────────────────────────────────────────────────────────
  * ANIMATION STORYBOARD — Deck Viewer
  *
- *   Inline
+ *   Horizontal (slides)
  *     Nav    instant slide swap (no transition — content first)
  *     Nav    slide counter digit slides vertically (150ms)
  *     Nav    filmstrip active ring slides via layoutId (snappy spring)
  *     Hover  inactive thumbnails scale 1.04 on hover
  *     Notes  fade+rise entrance (150ms delay after mount)
  *
- *   Fullscreen
+ *   Vertical (scrolling document)
+ *     Inline  all pages stacked, scroll container
+ *     Hover   fullscreen button appears top-right
+ *     Full    scrollable fullscreen with all pages
+ *
+ *   Fullscreen (both orientations)
  *     Enter  fullscreen fades in (200ms)
- *     Nav    instant slide swap (no transition)
- *     Nav    dot indicators: active dot widens via layoutId
+ *     Nav    (horizontal) instant slide swap, dot indicators
  *     Exit   fullscreen fades out (200ms)
  * ───────────────────────────────────────────────────────── */
 
@@ -31,12 +35,13 @@ interface DeckViewerProps {
   slides: Slide[];
   title: string;
   notes?: string | null;
+  orientation?: 'horizontal' | 'vertical';
 }
 
 const SNAPPY = { type: 'spring' as const, stiffness: 500, damping: 30 };
 const SMOOTH = { type: 'spring' as const, stiffness: 300, damping: 25 };
 
-export function DeckViewer({ slides, title, notes }: DeckViewerProps) {
+export function DeckViewer({ slides, title, notes, orientation = 'horizontal' }: DeckViewerProps) {
   const sorted = [...slides].sort((a, b) => a.sort_order - b.sort_order);
   const [fullscreen, setFullscreen] = useState(false);
   const [currentSlide, setCurrentSlide] = useState(0);
@@ -65,33 +70,141 @@ export function DeckViewer({ slides, title, notes }: DeckViewerProps) {
   useEffect(() => {
     if (fullscreen) {
       document.documentElement.setAttribute('data-modal-open', '');
+      // In vertical fullscreen, we need scroll — override any parent dialog's overflow lock
+      if (orientation === 'vertical') {
+        document.documentElement.style.overflow = 'auto';
+        document.body.style.overflow = 'auto';
+      }
     } else {
       document.documentElement.removeAttribute('data-modal-open');
     }
-    return () => { document.documentElement.removeAttribute('data-modal-open'); };
-  }, [fullscreen]);
+    return () => {
+      document.documentElement.removeAttribute('data-modal-open');
+      if (orientation === 'vertical') {
+        document.documentElement.style.overflow = '';
+        document.body.style.overflow = '';
+      }
+    };
+  }, [fullscreen, orientation]);
 
   // Keyboard navigation — works in both inline and fullscreen
   useEffect(() => {
     function handleKey(e: KeyboardEvent) {
-      if (e.key === 'ArrowRight') goNext();
-      else if (e.key === 'ArrowLeft') goPrev();
-      else if (e.key === 'Escape' && fullscreen) exitFullscreen();
-      else if (e.key === ' ' && fullscreen) { e.preventDefault(); goNext(); }
+      if (orientation === 'horizontal') {
+        if (e.key === 'ArrowRight') goNext();
+        else if (e.key === 'ArrowLeft') goPrev();
+        else if (e.key === ' ' && fullscreen) { e.preventDefault(); goNext(); }
+      }
+      if (e.key === 'Escape' && fullscreen) exitFullscreen();
     }
     window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
-  }, [fullscreen, goNext, goPrev, exitFullscreen]);
+  }, [fullscreen, goNext, goPrev, exitFullscreen, orientation]);
 
   // Scroll filmstrip to keep active thumbnail visible
   useEffect(() => {
-    if (!filmstripRef.current) return;
+    if (orientation !== 'horizontal' || !filmstripRef.current) return;
     const active = filmstripRef.current.children[currentSlide] as HTMLElement | undefined;
     active?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
-  }, [currentSlide]);
+  }, [currentSlide, orientation]);
 
   if (sorted.length === 0) return null;
 
+  /* ── Vertical mode: scrollable stack ─────────────────── */
+  if (orientation === 'vertical') {
+    return (
+      <>
+        <div className="flex flex-col gap-0">
+          {/* Scrollable page stack */}
+          <div className="relative group rounded-xl overflow-hidden border border-border/50" style={{ backgroundColor: 'oklch(0.13 0 0)' }}>
+            {/* Fullscreen button overlay */}
+            <button
+              type="button"
+              onClick={() => setFullscreen(true)}
+              className="absolute top-3 right-3 z-10 flex items-center gap-1.5 text-[11px] font-medium text-white/70 hover:text-white bg-black/50 backdrop-blur-sm rounded-md px-2 py-1.5 transition-all opacity-0 group-hover:opacity-100"
+            >
+              <Maximize2 className="size-3" />
+              Expand
+            </button>
+
+            <div className="max-h-[70vh] overflow-y-auto scrollbar-thin">
+              {sorted.map((slide, i) => (
+                <img
+                  key={i}
+                  src={slide.url}
+                  alt={`Page ${i + 1}`}
+                  className="w-full"
+                  draggable={false}
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* Page count */}
+          {sorted.length > 1 && (
+            <div className="flex items-center justify-center mt-3">
+              <span className="text-xs font-medium tabular-nums text-muted-foreground/60">
+                {sorted.length} {sorted.length === 1 ? 'page' : 'pages'}
+              </span>
+            </div>
+          )}
+
+          {/* Notes section */}
+          {notes && (
+            <motion.div
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ ...SMOOTH, delay: 0.15 }}
+              className="mt-4 rounded-xl border border-border/50 bg-card/50 p-4"
+            >
+              <p className="mb-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground/60">Notes</p>
+              <div className="prose-sm text-sm leading-relaxed text-foreground/70" dangerouslySetInnerHTML={{ __html: notes }} />
+            </motion.div>
+          )}
+        </div>
+
+        {/* Fullscreen — scrollable vertical view */}
+        {createPortal(<AnimatePresence>
+          {fullscreen && (
+            <motion.div
+              initial={false}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.2 }}
+              data-fullscreen-overlay
+              className="fixed inset-0 z-[70] overflow-y-auto"
+              style={{ backgroundColor: '#000' }}
+            >
+              {/* Top bar — fixed overlay */}
+              <div className="fixed top-0 inset-x-0 z-10 pointer-events-none" style={{ background: 'linear-gradient(to bottom, rgba(0,0,0,0.8) 0%, rgba(0,0,0,0.4) 70%, transparent 100%)' }}>
+                <div className="flex items-center justify-between px-5 py-3.5 pointer-events-auto">
+                  <span className="text-xs font-medium tracking-widest uppercase text-white/50 truncate">{title}</span>
+                  <button type="button" onClick={exitFullscreen} className="text-white/40 hover:text-white transition-colors">
+                    <X className="size-4" />
+                  </button>
+                </div>
+              </div>
+
+              {/* Scrollable pages */}
+              <div className="mx-auto max-w-3xl pt-14 pb-8">
+                {sorted.map((slide, i) => (
+                  <img
+                    key={i}
+                    src={slide.url}
+                    alt={`Page ${i + 1}`}
+                    className="w-full select-none"
+                    draggable={false}
+                  />
+                ))}
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>, document.body)}
+      </>
+    );
+  }
+
+  /* ── Horizontal mode: slideshow (original behavior) ──── */
   return (
     <>
       {/* ── Inline view: main slide + filmstrip ───────────── */}

--- a/src/components/dashboard/DocList.tsx
+++ b/src/components/dashboard/DocList.tsx
@@ -660,7 +660,7 @@ export function DocList({ docs: initialDocs, userDepartment, isAdmin = false, cu
             </DialogHeader>
             <div className="doc-read-body min-w-0 overflow-x-auto px-2 pt-4 pb-8 max-w-3xl mx-auto">
               {selected.type === 'deck' && selected.slides ? (
-                <DeckViewer slides={selected.slides} title={selected.title} notes={selected.content} />
+                <DeckViewer slides={selected.slides} title={selected.title} notes={selected.content} orientation={selected.deck_orientation} />
               ) : selected.content ? (
                 <DocContent html={selected.content} />
               ) : (

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -89,6 +89,8 @@ function Dialog({ open, onOpenChange, children, resizable = false, contentClassN
     // Block wheel + touch scroll outside the dialog panel (non-passive so preventDefault works)
     const blockScroll = (e: WheelEvent | TouchEvent) => {
       if (panelRef.current?.contains(e.target as Node)) return
+      // Allow scroll inside portalled fullscreen overlays (e.g. DeckViewer)
+      if ((e.target as Element)?.closest?.('[data-fullscreen-overlay]')) return
       e.preventDefault()
     }
     document.addEventListener('wheel', blockScroll, { passive: false })

--- a/src/lib/supabase/data.ts
+++ b/src/lib/supabase/data.ts
@@ -60,7 +60,7 @@ export async function fetchDocs(parentId?: string): Promise<Doc[]> {
 
   let query = supabase
     .from('docs')
-    .select('id, title, content, parent_id, sort_order, restricted_department, granted_user_ids, type, slides, created_at, updated_at')
+    .select('id, title, content, parent_id, sort_order, restricted_department, granted_user_ids, type, slides, deck_orientation, created_at, updated_at')
     .order('sort_order', { ascending: true });
 
   if (parentId) {
@@ -78,7 +78,7 @@ export async function fetchAllDocs(): Promise<Doc[]> {
   const supabase = await createClient();
   const { data, error } = await supabase
     .from('docs')
-    .select('id, title, content, parent_id, sort_order, restricted_department, granted_user_ids, type, slides, created_at, updated_at')
+    .select('id, title, content, parent_id, sort_order, restricted_department, granted_user_ids, type, slides, deck_orientation, created_at, updated_at')
     .order('sort_order', { ascending: true });
   if (error) throw error;
   return (data ?? []) as Doc[];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -64,6 +64,7 @@ export type Doc = {
   restricted_department?: string[];
   granted_user_ids?: string[];
   type?: 'doc' | 'deck';
+  deck_orientation?: 'horizontal' | 'vertical';
   slides?: { url: string; sort_order: number }[];
 };
 


### PR DESCRIPTION
## Summary
- Decks can now be set to **Document** (vertical scroll) or **Slides** (horizontal slideshow) layout
- Vertical mode stacks all pages in a scrollable container with fullscreen scroll support
- Admin toggle in DeckEditor to switch between layouts
- Dialog scroll blocker updated to respect fullscreen overlay escape hatch

## Changes
- `DeckViewer.tsx` — new vertical rendering mode with scrollable fullscreen
- `DeckEditor.tsx` — Slides/Document toggle for setting orientation
- `types.ts` — added `deck_orientation` to Doc type
- `data.ts` — fetchDocs now selects `deck_orientation`
- `dialog.tsx` — `data-fullscreen-overlay` escape hatch for scroll blocking
- API routes (`docs`, `docs/[id]`, `doc-share/view`) — accept and return `deck_orientation`
- Supabase migration — `deck_orientation` column on `docs` table

## Test plan
- [ ] Upload a portrait PDF, set layout to "Document", verify vertical scroll
- [ ] Click "Expand" in vertical mode, verify fullscreen scrolls vertically
- [ ] Switch to "Slides" layout, verify horizontal slideshow still works
- [ ] Refresh page, verify orientation persists
- [ ] Shared doc view respects deck orientation

🤖 Generated with [Claude Code](https://claude.com/claude-code)