### PR TITLE
feat: polish overview page — motion, surfaces, hierarchy

### DIFF
--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -1,18 +1,18 @@
 /* ─────────────────────────────────────────────────────────
  * ANIMATION STORYBOARD — Overview page entrance
  *
- *    0ms   hero (greeting + stat pills) fades in, y 20 → 0
- *  150ms   tasks card fades in (3-col on md+), y 20 → 0
- *  300ms   activity feed fades in (2-col on md+), y 20 → 0
+ *    0ms   hero greeting fades in, y 20 → 0
+ *   80ms   stat pills stagger in (40ms between each)
+ *  200ms   tasks card fades in (3-col on md+), y 16 → 0
+ *  350ms   activity feed fades in (2-col on md+), y 16 → 0
  *   50ms   activity items stagger in (60ms between each)
- *  400ms   game areas card fades in, y 20 → 0
+ *  500ms   game areas card fades in, y 16 → 0
  *   50ms   area tiles stagger in
  * ───────────────────────────────────────────────────────── */
 
 import { createClient } from '@/lib/supabase/server';
 import { fetchTasks, fetchAllTasksWithAssignees, fetchAreas, fetchTeam, fetchDocs, fetchActivity, fetchProfile } from '@/lib/supabase/data';
 import { Task, Area } from '@/lib/types';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { FadeRise, Stagger, StaggerItem } from '@/components/motion';
 import { EmptyState } from '@/components/ui/empty-state';
 import { UpcomingTasks } from '@/components/dashboard/UpcomingTasks';
@@ -22,33 +22,38 @@ import {
   CheckSquare,
   Activity,
   Map,
-  ArrowRight,
   UserPlus,
   MessageSquare,
   Pencil,
   Trash2,
   FileText,
+  Sparkles,
 } from 'lucide-react';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
+import { StatPills } from '@/components/dashboard/StatPills';
+import { ActivityFeedItem } from '@/components/dashboard/ActivityFeedItem';
+import { ViewAllLink } from '@/components/dashboard/ViewAllLink';
 
 export const dynamic = 'force-dynamic';
 
 // ── Animation timing (ms) — single source of truth ────────────────
 const TIMING = {
   hero:     0,
-  tasks:  150,
-  activity: 300,
+  pills:    80,
+  pillStagger: 40,
+  tasks:  200,
+  activity: 350,
   activityStagger: 60,
   activityDelay: 50,
-  areas:  400,
+  areas:  500,
   areasInner: 50,
 };
 
 /** FadeRise/Stagger delay in seconds */
 const delay = (ms: number) => ms / 1000;
 
-const SECTION_Y = 20;
+const SECTION_Y = 16;
 
 // ── Activity kind → icon + color ────────────────────────────────
 const ACTIVITY_ICONS: Record<string, { icon: typeof Activity; className: string; bg: string }> = {
@@ -58,6 +63,8 @@ const ACTIVITY_ICONS: Record<string, { icon: typeof Activity; className: string;
   updated:     { icon: Pencil,         className: 'text-amber-400',     bg: 'bg-amber-500/10' },
   commented:   { icon: MessageSquare,  className: 'text-violet-400',    bg: 'bg-violet-500/10' },
   deleted:     { icon: Trash2,         className: 'text-red-400',       bg: 'bg-red-500/10' },
+  started:     { icon: Activity,       className: 'text-amber-400',     bg: 'bg-amber-500/10' },
+  'moved to review': { icon: Activity, className: 'text-blue-400',      bg: 'bg-blue-500/10' },
 };
 const ACTIVITY_DEFAULT = { icon: Activity, className: 'text-muted-foreground', bg: 'bg-secondary' };
 
@@ -124,18 +131,42 @@ export default async function OverviewPage() {
     .filter(t => t.deadline)
     .sort((a, b) => a.deadline!.localeCompare(b.deadline!))[0]?.deadline;
 
-  // Derive Game Areas subtitle from real data
+  // Aggregate area progress for subtitle
+  const avgProgress = areas.length > 0
+    ? Math.round(areas.reduce((sum, a) => sum + a.progress, 0) / areas.length)
+    : 0;
   const areasSubtitle = areas.length > 0
-    ? areas.map(a => a.name).join(' · ')
+    ? `${avgProgress}% average progress`
     : 'No active areas';
 
   const greeting = buildGreeting(tasks);
   const firstName = profile?.display_name?.split(' ')[0];
 
-  return (
-    <div className="flex flex-col gap-5 overflow-hidden">
+  // Build stat pills data
+  const pills: { label: string; count: number; variant: 'danger' | 'accent' | 'muted'; href?: string }[] = [];
+  if (overdue > 0) pills.push({ label: 'overdue', count: overdue, variant: 'danger' });
+  pills.push({ label: 'open', count: openTasks, variant: 'accent', href: '/tasks' });
+  if (inProgress > 0) pills.push({ label: 'in progress', count: inProgress, variant: 'muted' });
+  if (blocked > 0) pills.push({ label: 'blocked', count: blocked, variant: 'danger' });
+  pills.push({ label: 'done', count: completed, variant: 'muted' });
 
-      {/* ── Hero — greeting + inline stats ──────────────── */}
+  // Prepare activity items — resolve to plain data (no React components across server→client boundary)
+  const activityItems = activity.map(item => {
+    const prof = item.profiles as unknown as { display_name?: string; avatar_url?: string } | undefined;
+    const name = prof?.display_name ?? 'Unknown';
+    const actionWord = item.action?.toLowerCase() ?? '';
+    const kindCfg = ACTIVITY_ICONS[actionWord] ?? ACTIVITY_DEFAULT;
+    return { id: item.id, name, action: actionWord, target: item.target, time: timeAgo(item.created_at), iconClassName: kindCfg.className, iconBg: kindCfg.bg, actionKey: actionWord };
+  });
+
+  // Shared surface style matching the task screen rehaul
+  const surface = 'rounded-2xl bg-[#222222] border-0';
+  const surfaceShadow = { boxShadow: '0 0 0 1px rgba(255,255,255,0.03), 0 4px 16px rgba(0,0,0,0.1)' };
+
+  return (
+    <div className="flex flex-col gap-4 overflow-hidden">
+
+      {/* ── Hero — greeting + stat pills ──────────────── */}
       <FadeRise delay={delay(TIMING.hero)} y={SECTION_Y}>
         <div className="flex flex-col gap-3">
           <div>
@@ -145,64 +176,36 @@ export default async function OverviewPage() {
             <p className="text-sm text-muted-foreground mt-0.5">{greeting}</p>
           </div>
 
-          {/* Inline stat pills */}
-          <div className="flex flex-wrap items-center gap-2">
-            {overdue > 0 && (
-              <span className="inline-flex items-center gap-1.5 rounded-full border border-red-500/20 bg-red-500/[0.06] px-3 py-1 text-xs font-medium text-red-400">
-                {overdue} overdue
-              </span>
-            )}
-            <Link
-              href="/tasks"
-              className="inline-flex items-center gap-1.5 rounded-full border border-seeko-accent/20 bg-seeko-accent/[0.06] px-3 py-1 text-xs font-medium text-seeko-accent transition-colors hover:bg-seeko-accent/[0.12]"
-            >
-              <CheckSquare className="size-3" />
-              {openTasks} open
-            </Link>
-            {inProgress > 0 && (
-              <span className="inline-flex items-center gap-1.5 rounded-full border border-border px-3 py-1 text-xs text-muted-foreground">
-                {inProgress} in progress
-              </span>
-            )}
-            {blocked > 0 && (
-              <span className="inline-flex items-center gap-1.5 rounded-full border border-red-500/20 bg-red-500/[0.06] px-3 py-1 text-xs font-medium text-red-400">
-                {blocked} blocked
-              </span>
-            )}
-            {completed > 0 && (
-              <span className="inline-flex items-center gap-1.5 rounded-full border border-border px-3 py-1 text-xs text-muted-foreground">
-                {completed} completed
-              </span>
-            )}
-          </div>
+          {/* Staggered stat pills */}
+          <StatPills pills={pills} delayMs={delay(TIMING.pills)} staggerMs={delay(TIMING.pillStagger)} />
         </div>
       </FadeRise>
 
       {/* ── Tasks + Activity — two-column on desktop ──── */}
-      <div className="grid grid-cols-1 gap-5 md:grid-cols-5">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-5">
 
-        {/* Tasks — primary, in a card */}
+        {/* Tasks — primary card */}
         <FadeRise delay={delay(TIMING.tasks)} y={SECTION_Y} className="md:col-span-3">
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-xl font-semibold text-foreground">Your Tasks</CardTitle>
+          <div className={surface} style={surfaceShadow}>
+            <div className="flex flex-col space-y-1.5 p-6">
+              <h3 className="text-lg font-semibold text-foreground">Your Tasks</h3>
               {earliestDeadline && upcoming.length > 0 && (
-                <CardDescription className={new Date(earliestDeadline + 'T23:59:59') < new Date() ? 'text-red-400' : undefined}>
+                <p className={cn('text-xs', new Date(earliestDeadline + 'T23:59:59') < new Date() ? 'text-red-400' : 'text-muted-foreground')}>
                   {new Date(earliestDeadline + 'T23:59:59') < new Date()
                     ? `Overdue since ${new Date(earliestDeadline + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}`
                     : `Next deadline: ${new Date(earliestDeadline + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}`
                   }
-                </CardDescription>
+                </p>
               )}
-            </CardHeader>
-            <CardContent>
-              <UpcomingTasks
-                tasks={upcoming}
-                team={team}
-                docs={docs}
-                currentUserId={user?.id ?? ''}
-                isAdmin={isAdmin}
-                emptyAction={
+            </div>
+            <div className="p-6 pt-0">
+              {upcoming.length === 0 ? (
+                <div className="flex flex-col items-center gap-3 py-10 text-center">
+                  <Sparkles className="size-8 text-seeko-accent/40" />
+                  <div>
+                    <p className="text-sm font-medium text-foreground">You're all caught up</p>
+                    <p className="text-xs text-muted-foreground mt-1">No open tasks right now.</p>
+                  </div>
                   <Link
                     href="/docs"
                     className="inline-flex items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-white/[0.04] transition-colors"
@@ -210,71 +213,56 @@ export default async function OverviewPage() {
                     <FileText className="size-3" />
                     Browse docs
                   </Link>
-                }
-              />
-              {upcoming.length > 0 && (
-                <Link
-                  href="/tasks"
-                  className="mt-3 flex items-center justify-center gap-1.5 rounded-lg border border-transparent py-2 text-sm text-foreground/50 hover:text-foreground hover:border-border transition-colors"
-                >
-                  View all tasks
-                  <ArrowRight className="size-3.5" />
-                </Link>
+                </div>
+              ) : (
+                <>
+                  <UpcomingTasks
+                    tasks={upcoming}
+                    team={team}
+                    docs={docs}
+                    currentUserId={user?.id ?? ''}
+                    isAdmin={isAdmin}
+                  />
+                  <ViewAllLink href="/tasks" label="View all tasks" />
+                </>
               )}
-            </CardContent>
-          </Card>
+            </div>
+          </div>
         </FadeRise>
 
-        {/* Activity — card, visually lighter than tasks */}
+        {/* Activity */}
         <FadeRise delay={delay(TIMING.activity)} y={SECTION_Y} className="md:col-span-2 flex">
-          <Card className="border-border/50 flex flex-col flex-1">
-            <CardHeader className="pb-3">
-              <CardTitle className="text-sm font-medium text-muted-foreground">Activity</CardTitle>
-            </CardHeader>
-            <CardContent className="flex-1 flex flex-col">
-              {activity.length === 0 ? (
+          <div className={cn(surface, 'flex flex-col flex-1')} style={surfaceShadow}>
+            <div className="flex flex-col space-y-1.5 p-6 pb-3">
+              <h3 className="text-base font-semibold text-foreground">Activity</h3>
+            </div>
+            <div className="p-6 pt-0 flex-1 flex flex-col">
+              {activityItems.length === 0 ? (
                 <p className="py-8 text-center text-xs text-muted-foreground flex-1 flex items-center justify-center">No recent activity.</p>
               ) : (
                 <>
-                  <Stagger className="flex flex-col gap-2.5 flex-1" staggerMs={delay(TIMING.activityStagger)} delayMs={delay(TIMING.activityDelay)}>
-                    {activity.map(item => {
-                      const prof = item.profiles as unknown as { display_name?: string; avatar_url?: string } | undefined;
-                      const name = prof?.display_name ?? 'Unknown';
-                      const actionWord = item.action?.toLowerCase() ?? '';
-                      const kindCfg = ACTIVITY_ICONS[actionWord] ?? ACTIVITY_DEFAULT;
-                      const KindIcon = kindCfg.icon;
-                      return (
-                        <StaggerItem key={item.id}>
-                          <div className="flex items-start gap-2.5">
-                            <div className={cn('mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full', kindCfg.bg, kindCfg.className)}>
-                              <KindIcon className="size-3" />
-                            </div>
-                            <div className="flex-1 min-w-0">
-                              <p className="text-sm text-foreground leading-snug">
-                                <span className="font-medium">{name}</span>{' '}
-                                <span className="text-muted-foreground">{actionWord}</span>
-                              </p>
-                              <p className="text-xs text-muted-foreground font-mono truncate">{item.target}</p>
-                            </div>
-                            <span className="shrink-0 text-xs text-muted-foreground mt-0.5">{timeAgo(item.created_at)}</span>
-                          </div>
-                        </StaggerItem>
-                      );
-                    })}
+                  <Stagger className="flex flex-col gap-1 flex-1" staggerMs={delay(TIMING.activityStagger)} delayMs={delay(TIMING.activityDelay)}>
+                    {activityItems.map(item => (
+                      <StaggerItem key={item.id}>
+                        <ActivityFeedItem
+                          name={item.name}
+                          action={item.action}
+                          target={item.target}
+                          time={item.time}
+                          actionKey={item.actionKey}
+                          iconClassName={item.iconClassName}
+                          iconBg={item.iconBg}
+                        />
+                      </StaggerItem>
+                    ))}
                   </Stagger>
                   {!isContractor && (
-                    <Link
-                      href="/activity"
-                      className="mt-auto pt-3 flex items-center justify-center gap-1.5 rounded-lg border border-transparent py-2 text-sm text-foreground/50 hover:text-foreground hover:border-border transition-colors"
-                    >
-                      View all activity
-                      <ArrowRight className="size-3.5" />
-                    </Link>
+                    <ViewAllLink href="/activity" label="View all activity" className="mt-auto pt-3" />
                   )}
                 </>
               )}
-            </CardContent>
-          </Card>
+            </div>
+          </div>
         </FadeRise>
 
       </div>
@@ -284,22 +272,22 @@ export default async function OverviewPage() {
         <FadeRise delay={delay(TIMING.areas)} y={SECTION_Y}>
           {/* Desktop: always expanded */}
           <div className="hidden md:block">
-            <Card>
-              <CardHeader>
+            <div className={surface} style={surfaceShadow}>
+              <div className="flex flex-col space-y-1.5 p-6">
                 <div className="flex items-center gap-2">
                   <Map className="size-4 text-muted-foreground" />
-                  <CardTitle className="text-lg font-semibold text-foreground">Game Areas</CardTitle>
+                  <h3 className="text-base font-semibold text-foreground">Game Areas</h3>
                 </div>
-                <CardDescription className="line-clamp-1">{areasSubtitle}</CardDescription>
-              </CardHeader>
-              <CardContent>
+                <p className="text-xs text-muted-foreground">{areasSubtitle}</p>
+              </div>
+              <div className="p-6 pt-0">
                 <Stagger className="grid grid-cols-1 md:grid-cols-3 gap-4" delayMs={delay(TIMING.areasInner)}>
                   {areas.map(area => (
                     <DashboardAreaCard key={area.id} area={area} isAdmin={isAdmin} />
                   ))}
                 </Stagger>
-              </CardContent>
-            </Card>
+              </div>
+            </div>
           </div>
           {/* Mobile: collapsible */}
           <div className="md:hidden">

--- a/src/components/dashboard/ActivityFeedItem.tsx
+++ b/src/components/dashboard/ActivityFeedItem.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { motion, useReducedMotion } from 'motion/react';
+import { Activity, UserPlus, CheckSquare, FileText, Pencil, MessageSquare, Trash2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+const ICON_MAP: Record<string, typeof Activity> = {
+  assigned: UserPlus,
+  completed: CheckSquare,
+  created: FileText,
+  updated: Pencil,
+  commented: MessageSquare,
+  deleted: Trash2,
+  started: Activity,
+  'moved to review': Activity,
+};
+
+interface ActivityFeedItemProps {
+  name: string;
+  action: string;
+  target: string;
+  time: string;
+  actionKey: string;
+  iconClassName: string;
+  iconBg: string;
+}
+
+const SPRING = { type: 'spring' as const, stiffness: 500, damping: 30 };
+
+export function ActivityFeedItem({ name, action, target, time, actionKey, iconClassName, iconBg }: ActivityFeedItemProps) {
+  const shouldReduce = useReducedMotion();
+  const Icon = ICON_MAP[actionKey] ?? Activity;
+
+  return (
+    <motion.div
+      whileHover={shouldReduce ? undefined : { backgroundColor: 'rgba(255,255,255,0.03)' }}
+      transition={SPRING}
+      className="flex items-start gap-2.5 rounded-lg px-2 py-2 -mx-2 cursor-default"
+    >
+      <div className={cn('mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full', iconBg, iconClassName)}>
+        <Icon className="size-3" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm text-foreground leading-snug">
+          <span className="font-medium">{name}</span>{' '}
+          <span className="text-muted-foreground">{action}</span>
+        </p>
+        <p className="text-xs text-muted-foreground/70 truncate">{target}</p>
+      </div>
+      <span className="shrink-0 text-[11px] text-muted-foreground/50 mt-0.5 tabular-nums">{time}</span>
+    </motion.div>
+  );
+}

--- a/src/components/dashboard/DashboardAreaCard.tsx
+++ b/src/components/dashboard/DashboardAreaCard.tsx
@@ -94,7 +94,7 @@ export function DashboardAreaCard({ area, isAdmin }: DashboardAreaCardProps) {
             {area.progress}%
           </span>
         </div>
-        <div className="w-full h-2 rounded-full bg-secondary overflow-hidden">
+        <div className="w-full h-2.5 rounded-full bg-secondary overflow-hidden">
           <motion.div
             initial={{ width: 0 }}
             animate={{ width: `${area.progress}%` }}
@@ -115,12 +115,12 @@ export function DashboardAreaCard({ area, isAdmin }: DashboardAreaCardProps) {
             <button
               type="button"
               onClick={handleOpen}
-              className="w-full text-left rounded-lg bg-white/[0.03] transition-colors hover:bg-white/[0.06] focus:outline-none focus:ring-2 focus:ring-seeko-accent/30"
+              className="w-full text-left rounded-lg bg-white/[0.03] border border-transparent transition-all hover:bg-white/[0.06] hover:border-seeko-accent/10 hover:shadow-[0_0_12px_rgba(110,231,183,0.04)] focus:outline-none focus:ring-2 focus:ring-seeko-accent/30"
             >
               {cardContent}
             </button>
           ) : (
-            <div className="rounded-lg bg-white/[0.03]">
+            <div className="rounded-lg bg-white/[0.03] border border-transparent transition-all hover:border-white/[0.06]">
               {cardContent}
             </div>
           )}

--- a/src/components/dashboard/StatPills.tsx
+++ b/src/components/dashboard/StatPills.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { motion, useReducedMotion } from 'motion/react';
+import { CheckSquare } from 'lucide-react';
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+
+interface Pill {
+  label: string;
+  count: number;
+  variant: 'danger' | 'accent' | 'muted';
+  href?: string;
+}
+
+const VARIANT_STYLES = {
+  danger: 'border-red-500/20 bg-red-500/[0.06] text-red-400',
+  accent: 'border-seeko-accent/20 bg-seeko-accent/[0.06] text-seeko-accent',
+  muted: 'border-border text-muted-foreground',
+} as const;
+
+const SPRING = { type: 'spring' as const, stiffness: 500, damping: 30 };
+
+export function StatPills({
+  pills,
+  delayMs = 0.08,
+  staggerMs = 0.04,
+}: {
+  pills: Pill[];
+  delayMs?: number;
+  staggerMs?: number;
+}) {
+  const shouldReduce = useReducedMotion();
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {pills.map((pill, i) => {
+        const style = VARIANT_STYLES[pill.variant];
+        const inner = (
+          <>
+            {pill.variant === 'accent' && <CheckSquare className="size-3" />}
+            {pill.count} {pill.label}
+          </>
+        );
+        const className = cn(
+          'inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium',
+          style,
+          pill.href && 'transition-colors hover:bg-seeko-accent/[0.12]',
+        );
+
+        const motionProps = shouldReduce ? {} : {
+          initial: { opacity: 0, scale: 0.8, y: 8 },
+          animate: { opacity: 1, scale: 1, y: 0 },
+          transition: { ...SPRING, delay: delayMs + i * staggerMs },
+        };
+
+        if (pill.href) {
+          return (
+            <motion.div key={pill.label} {...motionProps}>
+              <Link href={pill.href} className={className}>
+                {inner}
+              </Link>
+            </motion.div>
+          );
+        }
+
+        return (
+          <motion.span key={pill.label} className={className} {...motionProps}>
+            {inner}
+          </motion.span>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/dashboard/UpcomingTasks.tsx
+++ b/src/components/dashboard/UpcomingTasks.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { motion, useReducedMotion } from 'motion/react';
 import { Circle, CheckCircle2, Timer, AlertCircle } from 'lucide-react';
 import { Task, Profile, Doc } from '@/lib/types';
 import { cn } from '@/lib/utils';
@@ -23,6 +24,7 @@ const PRIORITY_COLOR: Record<string, string> = {
   Low:    'text-muted-foreground/60',
 };
 
+const SPRING = { type: 'spring' as const, stiffness: 500, damping: 30 };
 
 interface UpcomingTasksProps {
   tasks: Task[];
@@ -35,6 +37,7 @@ interface UpcomingTasksProps {
 
 export function UpcomingTasks({ tasks, team, docs, currentUserId, emptyAction, isAdmin = false }: UpcomingTasksProps) {
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
+  const shouldReduce = useReducedMotion();
 
   if (tasks.length === 0) {
     return (
@@ -57,9 +60,12 @@ export function UpcomingTasks({ tasks, team, docs, currentUserId, emptyAction, i
           const DlIcon = dl?.icon;
           return (
             <StaggerItem key={task.id}>
-              <button
+              <motion.button
                 onClick={() => setSelectedTask(task)}
-                className="flex w-full cursor-pointer items-center justify-between rounded-lg p-3 text-left transition-colors hover:bg-white/[0.04]"
+                whileHover={shouldReduce ? undefined : { y: -1, backgroundColor: 'rgba(255,255,255,0.04)' }}
+                whileTap={shouldReduce ? undefined : { scale: 0.995 }}
+                transition={SPRING}
+                className="flex w-full cursor-pointer items-center justify-between rounded-lg p-3 text-left"
               >
                 <div className="flex items-center gap-3 min-w-0 flex-1">
                   <div className={`flex size-8 shrink-0 items-center justify-center rounded-lg ${cfg.bg}`} title={task.status}>
@@ -83,7 +89,7 @@ export function UpcomingTasks({ tasks, team, docs, currentUserId, emptyAction, i
                     </span>
                   )}
                 </div>
-              </button>
+              </motion.button>
             </StaggerItem>
           );
         })}

--- a/src/components/dashboard/ViewAllLink.tsx
+++ b/src/components/dashboard/ViewAllLink.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { motion, useReducedMotion } from 'motion/react';
+import { ArrowRight } from 'lucide-react';
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+
+interface ViewAllLinkProps {
+  href: string;
+  label: string;
+  className?: string;
+}
+
+export function ViewAllLink({ href, label, className }: ViewAllLinkProps) {
+  const shouldReduce = useReducedMotion();
+
+  return (
+    <Link
+      href={href}
+      className={cn(
+        'group mt-3 flex items-center justify-center gap-1.5 rounded-lg border border-transparent py-2 text-sm font-medium text-foreground/40 hover:text-foreground/70 hover:border-border/50 transition-colors',
+        className,
+      )}
+    >
+      {label}
+      <motion.span
+        className="inline-flex"
+        whileHover={shouldReduce ? undefined : { x: 3 }}
+        transition={{ type: 'spring', stiffness: 500, damping: 30 }}
+      >
+        <ArrowRight className="size-3.5 transition-transform group-hover:translate-x-0.5" />
+      </motion.span>
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary
- Staggered stat pills with scale+fade entrance animation
- Task row hover micro-interactions (lift + tap feedback)
- Activity feed items with hover highlight
- Animated "View all" links (arrow slides on hover)
- Consistent `rounded-2xl bg-[#222222]` surface treatment matching the task screen rehaul
- Activity header visual weight balanced with Tasks card
- Tighter layout gaps reducing dead space
- "Done" pill always shown for full progress narrative
- Area cards: hover glow border, thicker progress bars, no placeholder description noise

## New components
- `StatPills` — staggered entrance, color-coded by variant
- `ActivityFeedItem` — resolves icons client-side, hover highlight
- `ViewAllLink` — animated arrow, hover border

## Test plan
- [ ] Overview loads with staggered pill entrance animation
- [ ] Hover task rows — subtle lift + bg highlight
- [ ] Hover activity items — bg highlight appears
- [ ] "View all" links — arrow animates right on hover
- [ ] All cards match task screen surface (dark bg, soft shadow)
- [ ] Stat pills show "0 done" when nothing completed
- [ ] Area cards without description show no placeholder text
- [ ] Reduced motion: all animations gracefully disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)