### PR TITLE
fix: use timingSafeEqual for doc-share session token

### DIFF
--- a/src/app/api/doc-share/view/route.ts
+++ b/src/app/api/doc-share/view/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { timingSafeEqual } from 'crypto';
 import { getServiceClient } from '@/lib/supabase/service';
 
 export async function POST(request: NextRequest) {
@@ -32,8 +33,12 @@ export async function POST(request: NextRequest) {
 
   if (!invite) return NextResponse.json({ error: 'Invite not found' }, { status: 404 });
 
-  // Validate session
-  if (invite.session_token !== sessionCookie) {
+  // Validate session (constant-time comparison to prevent timing side-channel)
+  const tokenValid =
+    invite.session_token !== null &&
+    invite.session_token.length === sessionCookie.length &&
+    timingSafeEqual(Buffer.from(invite.session_token), Buffer.from(sessionCookie));
+  if (!tokenValid) {
     return NextResponse.json({ error: 'session_expired' }, { status: 401 });
   }
 


### PR DESCRIPTION
## Summary
- Replaces plain `!==` string comparison with `crypto.timingSafeEqual` for session token validation in `/api/doc-share/view`
- Defense-in-depth against theoretical timing side-channel attacks

Closes #70

## Context
Flagged by automated daily commit review (#70). While not practically exploitable over HTTPS with network jitter, constant-time comparison is best practice for secret comparison.

## Test plan
- [ ] Verify doc sharing flow still works (share → verify → view)
- [ ] Confirm invalid session tokens are rejected with 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)