### PR TITLE
fix: deck PDF replacement + chat motion polish

### DIFF
--- a/src/app/api/docs/[id]/route.ts
+++ b/src/app/api/docs/[id]/route.ts
@@ -58,6 +58,20 @@ export async function PATCH(
     process.env.SUPABASE_SERVICE_ROLE_KEY!
   );
 
+  // If slides are being replaced, clean up orphaned slide files in storage
+  if ('slides' in body) {
+    const { data: existing } = await service.from('docs').select('slides').eq('id', id).single();
+    const oldSlides = (existing?.slides as { sort_order: number }[] | null) ?? [];
+    const newSlides = (body.slides as { sort_order: number }[] | null) ?? [];
+    if (oldSlides.length > newSlides.length) {
+      const orphanPaths = Array.from(
+        { length: oldSlides.length - newSlides.length },
+        (_, i) => `${id}/${newSlides.length + i}.webp`
+      );
+      await service.storage.from('deck-slides').remove(orphanPaths);
+    }
+  }
+
   const { data, error } = await service
     .from('docs')
     .update(updates)

--- a/src/app/api/docs/upload-deck/route.ts
+++ b/src/app/api/docs/upload-deck/route.ts
@@ -71,5 +71,8 @@ export async function POST(req: NextRequest) {
     .from('deck-slides')
     .getPublicUrl(path);
 
-  return NextResponse.json({ url: urlData.publicUrl, sort_order: Number(slideIndex) }, { status: 201 });
+  // Append cache-buster so browsers fetch the new file after a PDF replacement
+  const bustUrl = `${urlData.publicUrl}?v=${Date.now()}`;
+
+  return NextResponse.json({ url: bustUrl, sort_order: Number(slideIndex) }, { status: 201 });
 }

--- a/src/components/dashboard/TaskDetail.tsx
+++ b/src/components/dashboard/TaskDetail.tsx
@@ -178,6 +178,7 @@ function CommentItem({
   onReply,
   allComments,
   currentUserId,
+  staggerIndex = 0,
 }: {
   comment: TaskComment;
   isOwn: boolean;
@@ -191,6 +192,7 @@ function CommentItem({
   onReply: (comment: TaskComment) => void;
   allComments: TaskComment[];
   currentUserId: string;
+  staggerIndex?: number;
 }) {
   const highlightRef = useRef<HTMLDivElement>(null);
   const [editing, setEditing] = useState(false);
@@ -248,14 +250,20 @@ function CommentItem({
     <motion.div
       ref={highlightRef}
       key={comment.id}
-      initial={{ opacity: 0, y: 8 }}
+      initial={{ opacity: 0, y: 12 }}
       animate={{
         opacity: 1,
         y: 0,
         backgroundColor: isHighlighted ? ['rgba(59,130,246,0.25)', 'rgba(59,130,246,0)'] : 'rgba(59,130,246,0)',
       }}
-      exit={{ opacity: 0, height: 0, marginBottom: 0 }}
-      transition={{ duration: isHighlighted ? 2 : 0.15, backgroundColor: { duration: 2, delay: 0.5 } }}
+      exit={{ opacity: 0, height: 0, marginBottom: 0, transition: { duration: 0.15 } }}
+      transition={{
+        type: 'spring',
+        stiffness: 380,
+        damping: 28,
+        delay: Math.min(staggerIndex * 0.04, 0.5),
+        backgroundColor: { duration: 2, delay: 0.5 },
+      }}
       className={cn('group relative flex gap-3 rounded-md px-2 -mx-2 md:select-auto select-none [&_*]:select-none md:[&_*]:select-auto', isGrouped ? 'py-0 mt-0.5 pl-[44px]' : 'py-1 mt-3 first:mt-0')}
       style={{ WebkitTouchCallout: 'none', WebkitUserSelect: 'none' } as React.CSSProperties}
       {...longPress}
@@ -658,6 +666,7 @@ export function TaskDetail({ task, open, onOpenChange, team, docs, currentUserId
   }, [open, isDesktop]);
 
   const [activeTab, setActiveTab] = useState<'details' | 'chat'>('details');
+  const [tabDirection, setTabDirection] = useState(1); // 1 = right, -1 = left
   const [comments, setComments] = useState<TaskComment[]>([]);
   const [loading, setLoading] = useState(false);
   const [deliverables, setDeliverables] = useState<TaskDeliverable[]>([]);
@@ -1835,6 +1844,7 @@ export function TaskDetail({ task, open, onOpenChange, team, docs, currentUserId
               onReply={setReplyTo}
               allComments={comments}
               currentUserId={currentUserId}
+              staggerIndex={idx}
             />
           );
         })}
@@ -1981,7 +1991,7 @@ export function TaskDetail({ task, open, onOpenChange, team, docs, currentUserId
             'relative rounded-lg px-4 py-1.5 text-sm font-medium transition-colors',
             activeTab === 'details' ? 'text-seeko-accent' : 'text-muted-foreground hover:text-foreground'
           )}
-          onClick={() => setActiveTab('details')}
+          onClick={() => { setTabDirection(-1); setActiveTab('details'); }}
         >
           {activeTab === 'details' && (
             <motion.div
@@ -1997,7 +2007,7 @@ export function TaskDetail({ task, open, onOpenChange, team, docs, currentUserId
             'relative rounded-lg px-4 py-1.5 text-sm font-medium transition-colors',
             activeTab === 'chat' ? 'text-seeko-accent' : 'text-muted-foreground hover:text-foreground'
           )}
-          onClick={() => setActiveTab('chat')}
+          onClick={() => { setTabDirection(1); setActiveTab('chat'); }}
         >
           {activeTab === 'chat' && (
             <motion.div
@@ -2093,8 +2103,11 @@ export function TaskDetail({ task, open, onOpenChange, team, docs, currentUserId
                     {detailsContent}
                   </div>
                   {/* Right — Chat */}
-                  <div
+                  <motion.div
                     className={cn('flex flex-1 flex-col min-h-0 min-w-0', isDragging && 'ring-2 ring-inset ring-seeko-accent/50')}
+                    initial={{ opacity: 0, x: 16 }}
+                    animate={{ opacity: 1, x: 0 }}
+                    transition={{ type: 'spring', stiffness: 300, damping: 28, delay: 0.1 }}
                     onDragOver={e => { e.preventDefault(); setIsDragging(true); }}
                     onDragLeave={e => {
                       if (!e.currentTarget.contains(e.relatedTarget as Node)) setIsDragging(false);
@@ -2120,13 +2133,26 @@ export function TaskDetail({ task, open, onOpenChange, team, docs, currentUserId
                     <div className="shrink-0 border-t border-white/[0.06] bg-muted/[0.04] px-5 py-3">
                       {chatCompose}
                     </div>
-                  </div>
+                  </motion.div>
                 </div>
               ) : (
                 /* Mobile: tabbed layout */
-                <AnimatePresence mode="wait" initial={false}>
+                <AnimatePresence mode="wait" initial={false} custom={tabDirection}>
                   {activeTab === 'details' && (
-                    <motion.div key="details" className="flex-1 overflow-y-auto px-5 py-5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden" initial={{ opacity: 0, y: 6 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -6 }} transition={{ type: 'spring', stiffness: 500, damping: 35, opacity: { duration: 0.12 } }}>
+                    <motion.div
+                      key="details"
+                      className="flex-1 overflow-y-auto px-5 py-5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+                      custom={tabDirection}
+                      initial="enter"
+                      animate="active"
+                      exit="exit"
+                      variants={{
+                        enter: (d: number) => ({ opacity: 0, x: d * 40 }),
+                        active: { opacity: 1, x: 0 },
+                        exit: (d: number) => ({ opacity: 0, x: d * -40 }),
+                      }}
+                      transition={{ type: 'spring', stiffness: 400, damping: 32, opacity: { duration: 0.15 } }}
+                    >
                       {detailsContent}
                     </motion.div>
                   )}
@@ -2134,10 +2160,16 @@ export function TaskDetail({ task, open, onOpenChange, team, docs, currentUserId
                     <motion.div
                       key="chat"
                       className={cn('flex flex-1 flex-col min-h-0', isDragging && 'ring-2 ring-inset ring-seeko-accent/50')}
-                      initial={{ opacity: 0, y: 6 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      exit={{ opacity: 0, y: -6 }}
-                      transition={{ type: 'spring', stiffness: 500, damping: 35, opacity: { duration: 0.12 } }}
+                      custom={tabDirection}
+                      initial="enter"
+                      animate="active"
+                      exit="exit"
+                      variants={{
+                        enter: (d: number) => ({ opacity: 0, x: d * 40 }),
+                        active: { opacity: 1, x: 0 },
+                        exit: (d: number) => ({ opacity: 0, x: d * -40 }),
+                      }}
+                      transition={{ type: 'spring', stiffness: 400, damping: 32, opacity: { duration: 0.15 } }}
                       onDragOver={e => { e.preventDefault(); setIsDragging(true); }}
                       onDragLeave={e => {
                         if (!e.currentTarget.contains(e.relatedTarget as Node)) setIsDragging(false);


### PR DESCRIPTION
## Summary
- **Deck PDF replace bug:** Replacing a deck's PDF showed stale cached slides because Supabase storage URLs didn't change. Now appends `?v=timestamp` cache-buster to slide URLs after upload. Also cleans up orphaned slide files when new PDF has fewer pages.
- **Chat motion polish:** Directional tab transitions (slide left/right), staggered comment cascade with spring physics, desktop chat panel delayed entrance, snappy comment exit animations.

## Test plan
- [ ] Upload a deck PDF, then replace it with a different PDF — new slides should appear immediately
- [ ] Replace a 10-slide deck with a 3-slide deck — verify no orphan files in `deck-slides` storage
- [ ] Open a task detail on mobile — tap between Details/Chat tabs, verify directional slide animation
- [ ] Open a task with multiple comments on desktop — verify staggered cascade entrance
- [ ] Delete a comment — verify it exits quickly without spring delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)