### PR TITLE
polish: site-wide motion improvements

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -19,6 +19,7 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import { motion, AnimatePresence } from 'motion/react';
+import { Loader2 } from 'lucide-react';
 import { createClient } from '@/lib/supabase/client';
 import { InviteCodeForm } from '@/components/auth/InviteCodeForm';
 import { useHaptics } from '@/components/HapticsProvider';
@@ -229,14 +230,21 @@ export default function LoginPage() {
               <motion.button
                 type="submit"
                 disabled={loading}
-                className="w-full py-2 px-4 rounded-lg bg-seeko-accent text-[#1a1a1a] font-semibold text-sm hover:bg-seeko-accent/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                className="w-full py-2 px-4 rounded-lg bg-seeko-accent text-[#1a1a1a] font-semibold text-sm hover:bg-seeko-accent/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors inline-flex items-center justify-center gap-2"
                 initial={{ opacity: 0, y: FIELD.offsetY }}
                 animate={{ opacity: stage >= 7 ? 1 : 0, y: stage >= 7 ? 0 : FIELD.offsetY }}
                 transition={FIELD.spring}
-                whileHover={{ scale: 1.015 }}
-                whileTap={{ scale: 0.985 }}
+                whileHover={{ scale: 1.02 }}
+                whileTap={{ scale: 0.98 }}
               >
-                {loading ? 'Signing in…' : 'Sign in'}
+                {loading ? (
+                  <>
+                    <Loader2 className="size-4 shrink-0 animate-spin" />
+                    Signing in…
+                  </>
+                ) : (
+                  'Sign in'
+                )}
               </motion.button>
             </motion.form>
           ) : (

--- a/src/app/(dashboard)/notifications/page.tsx
+++ b/src/app/(dashboard)/notifications/page.tsx
@@ -1,5 +1,10 @@
 import { NotificationsPanel } from '@/components/dashboard/NotificationsPanel';
+import { FadeRise } from '@/components/motion';
 
 export default function NotificationsPage() {
-  return <NotificationsPanel />;
+  return (
+    <FadeRise delay={0} y={16}>
+      <NotificationsPanel />
+    </FadeRise>
+  );
 }

--- a/src/app/(dashboard)/payments/page.tsx
+++ b/src/app/(dashboard)/payments/page.tsx
@@ -2,6 +2,7 @@ import { createClient } from '@/lib/supabase/server';
 import { fetchProfile, fetchTeamWithPaypalEmails } from '@/lib/supabase/data';
 import { redirect } from 'next/navigation';
 import { PaymentsAdmin } from '@/components/dashboard/PaymentsAdmin';
+import { FadeRise } from '@/components/motion';
 
 export const dynamic = 'force-dynamic';
 
@@ -15,5 +16,9 @@ export default async function PaymentsPage() {
 
   const team = await fetchTeamWithPaypalEmails();
 
-  return <PaymentsAdmin team={team} />;
+  return (
+    <FadeRise delay={0} y={16}>
+      <PaymentsAdmin team={team} />
+    </FadeRise>
+  );
 }

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from 'next/navigation';
 import { createClient } from '@/lib/supabase/server';
 import { fetchProfile, fetchTeam } from '@/lib/supabase/data';
 import { SettingsPanel } from '@/components/dashboard/SettingsPanel';
+import { FadeRise } from '@/components/motion';
 
 export default async function SettingsPage() {
   const supabase = await createClient();
@@ -23,11 +24,13 @@ export default async function SettingsPage() {
     .order('updated_at', { ascending: false });
 
   return (
-    <SettingsPanel
-      profile={profile}
-      isAdmin={isAdmin}
-      team={team}
-      completedTasks={completedTasks ?? []}
-    />
+    <FadeRise delay={0} y={16}>
+      <SettingsPanel
+        profile={profile}
+        isAdmin={isAdmin}
+        team={team}
+        completedTasks={completedTasks ?? []}
+      />
+    </FadeRise>
   );
 }

--- a/src/app/(dashboard)/team/page.tsx
+++ b/src/app/(dashboard)/team/page.tsx
@@ -11,7 +11,7 @@
 import { fetchTeam } from '@/lib/supabase/data';
 import { createClient } from '@/lib/supabase/server';
 import { Profile } from '@/lib/types';
-import { FadeRise, Stagger, StaggerItem } from '@/components/motion';
+import { FadeRise, Stagger, StaggerItem, InteractiveRow } from '@/components/motion';
 import { Card, CardContent } from '@/components/ui/card';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
@@ -118,7 +118,7 @@ function MemberRow({ member, isAdmin }: { member: Profile; isAdmin: boolean }) {
   const offset = tzAbbrev(member.timezone);
 
   return (
-    <div className="flex items-center gap-3 rounded-lg px-3 py-2.5 -mx-3 hover:bg-white/[0.02] transition-colors">
+    <InteractiveRow className="flex items-center gap-3 rounded-lg px-3 py-2.5 -mx-3 transition-colors">
       {/* Avatar */}
       <div className="relative shrink-0">
         <Avatar className="size-10">
@@ -192,7 +192,7 @@ function MemberRow({ member, isAdmin }: { member: Profile; isAdmin: boolean }) {
           {lastSeenLabel(member.last_seen_at, member.must_set_password)}
         </span>
       </div>
-    </div>
+    </InteractiveRow>
   );
 }
 

--- a/src/components/dashboard/DocList.tsx
+++ b/src/components/dashboard/DocList.tsx
@@ -18,6 +18,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
 } from '@/components/ui/dropdown-menu';
+import { motion, AnimatePresence } from 'motion/react';
 import { Stagger, StaggerItem, HoverCard } from '@/components/motion';
 import { EmptyState } from '@/components/ui/empty-state';
 import { DocEditor } from './DocEditor';
@@ -63,6 +64,21 @@ function isRecentlyUpdated(doc: Doc): boolean {
 const LIST = {
   staggerMs: 70,   // ms between each card
   delayMs:   0,    // ms before first card
+};
+
+const TAB_ORDER: Record<string, number> = { docs: 0, decks: 1, shared: 2 };
+
+const tabSlideVariants = {
+  enter: (d: number) => ({ opacity: 0, x: d * 40 }),
+  active: { opacity: 1, x: 0 },
+  exit: (d: number) => ({ opacity: 0, x: d * -40 }),
+};
+
+const tabSlideTransition = {
+  type: 'spring' as const,
+  stiffness: 400,
+  damping: 32,
+  opacity: { duration: 0.15 },
 };
 
 const SHARE_STATUS_COLORS: Record<string, string> = {
@@ -141,8 +157,10 @@ export function DocList({ docs: initialDocs, userDepartment, isAdmin = false, cu
   type ViewMode = typeof VALID_TABS[number];
   const tabParam = searchParams.get('tab');
   const viewMode: ViewMode = VALID_TABS.includes(tabParam as ViewMode) ? (tabParam as ViewMode) : 'docs';
+  const [tabDirection, setTabDirection] = useState(1);
 
   const setViewMode = (mode: ViewMode) => {
+    setTabDirection(TAB_ORDER[mode] > TAB_ORDER[viewMode] ? 1 : -1);
     const params = new URLSearchParams(searchParams.toString());
     if (mode === 'docs') {
       params.delete('tab');
@@ -456,9 +474,19 @@ export function DocList({ docs: initialDocs, userDepartment, isAdmin = false, cu
         )}
       </div>
 
-      {/* ── Shared tab content ─────────────────────────────── */}
+      {/* ── Tab content with directional slide ────────────── */}
+      <AnimatePresence mode="wait" custom={tabDirection}>
       {viewMode === 'shared' && isAdmin && (
-        <div className="flex flex-col gap-2">
+        <motion.div
+          key="shared"
+          custom={tabDirection}
+          variants={tabSlideVariants}
+          initial="enter"
+          animate="active"
+          exit="exit"
+          transition={tabSlideTransition}
+          className="flex flex-col gap-2"
+        >
           {sharedLoading ? (
             <div className="flex items-center justify-center py-12">
               <div className="size-5 animate-spin rounded-full border-2 border-muted-foreground/30 border-t-foreground" />
@@ -529,10 +557,19 @@ export function DocList({ docs: initialDocs, userDepartment, isAdmin = false, cu
               )}
             </>
           )}
-        </div>
+        </motion.div>
       )}
 
       {viewMode !== 'shared' && (sortedDocs.length === 0 && docs.filter(d => viewMode === 'decks' ? d.type === 'deck' : d.type !== 'deck').length === 0 ? (
+        <motion.div
+          key={viewMode}
+          custom={tabDirection}
+          variants={tabSlideVariants}
+          initial="enter"
+          animate="active"
+          exit="exit"
+          transition={tabSlideTransition}
+        >
         <EmptyState
           icon="FileText"
           title={viewMode === 'decks' ? 'No decks yet' : 'No documents yet'}
@@ -553,8 +590,17 @@ export function DocList({ docs: initialDocs, userDepartment, isAdmin = false, cu
             </Button>
           ) : undefined}
         />
+        </motion.div>
       ) : (
-        <>
+        <motion.div
+          key={viewMode}
+          custom={tabDirection}
+          variants={tabSlideVariants}
+          initial="enter"
+          animate="active"
+          exit="exit"
+          transition={tabSlideTransition}
+        >
           {/* Search + filter row */}
           <div className="flex flex-wrap items-center gap-2 mb-4">
             <div className="relative flex-1 min-w-[200px]">
@@ -628,8 +674,9 @@ export function DocList({ docs: initialDocs, userDepartment, isAdmin = false, cu
               )}
             </div>
           )}
-        </>
+        </motion.div>
       ))}
+      </AnimatePresence>
 
       {/* Read dialog */}
       <Dialog

--- a/src/components/motion.tsx
+++ b/src/components/motion.tsx
@@ -132,6 +132,28 @@ export function StaggerItem({
   );
 }
 
+// ── Interactive row (hover lift + tap feedback) ─────────────────
+export function InteractiveRow({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  const shouldReduce = useReducedMotion();
+  if (shouldReduce) return <div className={className}>{children}</div>;
+  return (
+    <motion.div
+      whileHover={{ y: -1, backgroundColor: 'rgba(255,255,255,0.04)' }}
+      whileTap={{ scale: 0.995 }}
+      transition={springs.snappy}
+      className={className}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
 // ── Hover-lift card ─────────────────────────────────────────────
 export function HoverCard({
   children,

--- a/src/components/onboarding/OnboardingForm.tsx
+++ b/src/components/onboarding/OnboardingForm.tsx
@@ -240,10 +240,13 @@ export function OnboardingForm({
             <p className="text-sm text-destructive">{error}</p>
           )}
 
-          <button
+          <motion.button
             type="submit"
             disabled={saving || uploading}
             className="inline-flex w-full items-center justify-center gap-2 whitespace-nowrap rounded-md bg-primary text-primary-foreground text-sm font-medium h-9 px-4 py-2 transition-colors transition-[box-shadow_var(--focus-ring-duration)_ease-out] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
+            whileHover={{ scale: 1.02 }}
+            whileTap={{ scale: 0.98 }}
+            transition={{ type: 'spring', stiffness: 500, damping: 30 }}
           >
             <AnimatePresence mode="wait">
               <motion.span
@@ -267,7 +270,7 @@ export function OnboardingForm({
                 )}
               </motion.span>
             </AnimatePresence>
-          </button>
+          </motion.button>
         </form>
       </CardContent>
     </Card>

--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import { motion } from 'motion/react';
 import { cn } from '@/lib/utils';
 import {
   Activity,
@@ -46,18 +47,26 @@ export interface EmptyStateProps {
 export function EmptyState({ icon: iconName, title, description, action, className }: EmptyStateProps) {
   const Icon = EMPTY_STATE_ICONS[iconName];
   return (
-    <div
+    <motion.div
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ type: 'spring', stiffness: 300, damping: 25 }}
       className={cn(
         'flex flex-col items-center justify-center py-14 text-center',
         className
       )}
     >
-      <Icon className="size-12 text-muted-foreground/40" aria-hidden />
+      <motion.div
+        animate={{ y: [0, -4, 0] }}
+        transition={{ duration: 3, repeat: Infinity, ease: 'easeInOut' }}
+      >
+        <Icon className="size-12 text-muted-foreground/40" aria-hidden />
+      </motion.div>
       <p className="mt-4 text-sm font-medium text-foreground">{title}</p>
       {description && (
         <p className="mt-1.5 text-xs text-muted-foreground max-w-sm">{description}</p>
       )}
       {action && <div className="mt-4">{action}</div>}
-    </div>
+    </motion.div>
   );
 }

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -144,7 +144,13 @@ const Select = React.forwardRef<
         )}
       >
         <span className="truncate">{selected?.label || 'Select...'}</span>
-        <ChevronDown className={cn('ml-2 size-3.5 shrink-0 text-muted-foreground transition-transform', open && 'rotate-180')} />
+        <motion.span
+          animate={{ rotate: open ? 180 : 0 }}
+          transition={SELECT_SPRING}
+          className="ml-2 flex shrink-0 items-center"
+        >
+          <ChevronDown className="size-3.5 text-muted-foreground" />
+        </motion.span>
       </button>
 
       {typeof document !== 'undefined' &&


### PR DESCRIPTION
## Summary
- **Empty states:** FadeRise entrance with spring physics + floating icon pulse
- **Team member rows:** New `InteractiveRow` component with hover lift + tap feedback (reduced-motion safe)
- **DocList tabs:** Directional slide transitions between docs/decks/shared views
- **Page entrances:** Settings, Payments, Notifications pages now have FadeRise wrappers
- **Login button:** Spinning Loader2 icon during sign-in, enhanced spring scales
- **Onboarding form:** Submit button with motion hover/tap springs
- **Select chevron:** Spring rotation animation on dropdown open/close

10 files changed across components and pages.

## Test plan
- [ ] Visit each page (settings, payments, notifications, team) — verify entrance animations
- [ ] Toggle empty states (e.g. no tasks) — verify fade+rise + floating icon
- [ ] Switch DocList tabs (docs/decks/shared) — verify directional slide
- [ ] Hover/tap team member rows — verify lift and press feedback
- [ ] Open a select dropdown — verify chevron rotates with spring
- [ ] Submit login form — verify spinner appears on button
- [ ] Test with reduced motion enabled — verify graceful fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)