### PR TITLE
Login polish, investor NDA skip, panel refresh + docs

### DIFF
--- a/src/app/(investor)/investor/docs/page.tsx
+++ b/src/app/(investor)/investor/docs/page.tsx
@@ -1,0 +1,56 @@
+/* ─────────────────────────────────────────────────────────
+ * ANIMATION STORYBOARD — Investor Documents
+ *
+ *    0ms   heading fades up
+ *   80ms   subtitle fades up
+ *  160ms   doc list rises in
+ * ───────────────────────────────────────────────────────── */
+
+import { fetchDocs, fetchProfile, fetchTeam } from '@/lib/supabase/data';
+import { createClient } from '@/lib/supabase/server';
+import { DocList } from '@/components/dashboard/DocList';
+import { FadeRise } from '@/components/motion';
+
+const TIMING = {
+  heading:  0,
+  subtitle: 80,
+  list:     160,
+};
+
+const delay = (ms: number) => ms / 1000;
+
+export default async function InvestorDocsPage() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  const [docs, profile, team] = await Promise.all([
+    fetchDocs().catch(() => []),
+    user ? fetchProfile(user.id).catch(() => null) : null,
+    fetchTeam().catch(() => []),
+  ]);
+  const userDepartment = profile?.department ?? null;
+  const isAdmin = profile?.is_admin ?? false;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <FadeRise delay={delay(TIMING.heading)}>
+          <h1 className="text-3xl font-bold tracking-tight text-foreground text-balance">Documents</h1>
+        </FadeRise>
+        <FadeRise delay={delay(TIMING.subtitle)}>
+          <p className="text-sm text-muted-foreground mt-1">Documents, decks, and shared resources.</p>
+        </FadeRise>
+      </div>
+
+      <FadeRise delay={delay(TIMING.list)} y={12}>
+        <DocList
+          docs={docs}
+          userDepartment={userDepartment}
+          isAdmin={isAdmin}
+          isInvestor
+          currentUserId={user?.id ?? ''}
+          team={team}
+        />
+      </FadeRise>
+    </div>
+  );
+}

--- a/src/app/(investor)/investor/page.tsx
+++ b/src/app/(investor)/investor/page.tsx
@@ -13,7 +13,6 @@ import { createClient } from '@/lib/supabase/server';
 import { fetchProfile, fetchAreas, fetchActivity, fetchAllTasksWithAssignees } from '@/lib/supabase/data';
 import { Area } from '@/lib/types';
 import type { TaskWithAssignee } from '@/lib/types';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { FadeRise } from '@/components/motion';
 import { EmptyState } from '@/components/ui/empty-state';
 import { InvestorKPIStrip } from '@/components/dashboard/InvestorKPIStrip';
@@ -149,6 +148,10 @@ export default async function InvestorPage() {
   );
   const hasIssues = blocked > 0 || overdueCount > 0;
 
+  // Shared surface style matching the main dashboard
+  const surface = 'rounded-2xl bg-[#222222] border-0';
+  const surfaceShadow = { boxShadow: '0 0 0 1px rgba(255,255,255,0.03), 0 4px 16px rgba(0,0,0,0.1)' };
+
   // Build task-to-area lookup for activity context
   const taskAreaLookup: Record<string, string> = {};
   for (const task of tasks) {
@@ -167,10 +170,7 @@ export default async function InvestorPage() {
       <FadeRise delay={delay(TIMING.hero)} className="pb-2">
         <div className="flex items-start justify-between gap-4">
           <div>
-            <h1
-              className="text-2xl font-semibold tracking-tight"
-              style={{ color: 'var(--color-seeko-accent)' }}
-            >
+            <h1 className="text-3xl font-bold tracking-tight text-seeko-accent text-balance">
               Investor Panel
             </h1>
             <p className="text-sm text-muted-foreground mt-1">
@@ -178,7 +178,15 @@ export default async function InvestorPage() {
             </p>
           </div>
         </div>
-        <div className={`mt-3 rounded-lg px-3.5 py-2.5 text-sm ${hasIssues ? 'bg-red-950/15 border border-red-900/30 text-red-300' : 'bg-muted/50 border border-border/50 text-muted-foreground'}`}>
+        <div
+          className={`mt-3 rounded-xl px-3.5 py-2.5 text-sm ${hasIssues ? 'text-red-300' : 'text-muted-foreground'}`}
+          style={{
+            backgroundColor: hasIssues ? 'rgba(127, 29, 29, 0.15)' : '#222222',
+            boxShadow: hasIssues
+              ? '0 0 0 1px rgba(185, 28, 28, 0.3), 0 4px 16px rgba(0,0,0,0.1)'
+              : '0 0 0 1px rgba(255,255,255,0.03), 0 4px 16px rgba(0,0,0,0.1)',
+          }}
+        >
           {healthSummary}
         </div>
       </FadeRise>
@@ -198,22 +206,22 @@ export default async function InvestorPage() {
       {/* ── Game Areas (open by default) ─────────────────── */}
       <FadeRise delay={delay(TIMING.areas)}>
         {areas.length === 0 ? (
-          <Card>
-            <CardHeader>
+          <div className={surface} style={surfaceShadow}>
+            <div className="flex flex-col space-y-1.5 p-6">
               <div className="flex items-center gap-2">
                 <Map className="size-4 text-muted-foreground" />
-                <CardTitle className="text-xl font-semibold text-foreground">Game Areas</CardTitle>
+                <h3 className="text-lg font-semibold text-foreground">Game Areas</h3>
               </div>
-              <CardDescription>Progress by area.</CardDescription>
-            </CardHeader>
-            <CardContent>
+              <p className="text-sm text-muted-foreground">Progress by area.</p>
+            </div>
+            <div className="p-6 pt-0">
               <EmptyState
                 icon="Map"
                 title="No game areas yet"
                 description="Areas will appear here when the team adds them."
               />
-            </CardContent>
-          </Card>
+            </div>
+          </div>
         ) : (
           <CollapsibleInvestorAreas
             areas={areas}
@@ -227,15 +235,15 @@ export default async function InvestorPage() {
 
       {/* ── Recent Activity (grouped by day) ──────────────── */}
       <FadeRise delay={delay(TIMING.summary)}>
-        <Card>
-          <CardHeader>
+        <div className={surface} style={surfaceShadow}>
+          <div className="flex flex-col space-y-1.5 p-6">
             <div className="flex items-center gap-2">
               <Activity className="size-4 text-muted-foreground" />
-              <CardTitle className="text-xl font-semibold text-foreground">Recent Activity</CardTitle>
+              <h3 className="text-lg font-semibold text-foreground">Recent Activity</h3>
             </div>
-            <CardDescription>Latest updates from the team.</CardDescription>
-          </CardHeader>
-          <CardContent>
+            <p className="text-sm text-muted-foreground">Latest updates from the team.</p>
+          </div>
+          <div className="p-6 pt-0">
             {recentActivity.length === 0 ? (
               <EmptyState
                 icon="Activity"
@@ -252,7 +260,7 @@ export default async function InvestorPage() {
                     {group.items.map((entry, i) => {
                       const areaName = taskAreaLookup[(entry as typeof recentActivity[number]).target];
                       return (
-                        <div key={i} className="flex items-start gap-3 py-2.5 border-b border-border last:border-0">
+                        <div key={i} className="flex items-start gap-3 py-2.5 border-b border-white/[0.04] last:border-0">
                           <span
                             className="mt-1.5 h-2 w-2 rounded-full shrink-0"
                             style={{ backgroundColor: actionColor((entry as typeof recentActivity[number]).action) }}
@@ -267,7 +275,7 @@ export default async function InvestorPage() {
                               {' '}
                               <span className="text-muted-foreground">{(entry as typeof recentActivity[number]).target}</span>
                             </p>
-                            <p className="text-xs text-muted-foreground/70 mt-0.5">
+                            <p className="text-xs text-muted-foreground/70 tabular-nums mt-0.5">
                               {timeAgo(entry.created_at)}
                             </p>
                           </div>
@@ -278,8 +286,8 @@ export default async function InvestorPage() {
                 ))}
               </div>
             )}
-          </CardContent>
-        </Card>
+          </div>
+        </div>
       </FadeRise>
 
     </div>

--- a/src/components/dashboard/CollapsibleInvestorAreas.tsx
+++ b/src/components/dashboard/CollapsibleInvestorAreas.tsx
@@ -3,10 +3,12 @@
 import { useState } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
 import { ChevronDown, Map } from 'lucide-react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { InvestorAreaCard } from '@/components/dashboard/InvestorAreaCard';
 import { Stagger } from '@/components/motion';
 import type { Area, TaskWithAssignee } from '@/lib/types';
+
+const surface = 'rounded-2xl bg-[#222222] border-0';
+const surfaceShadow = { boxShadow: '0 0 0 1px rgba(255,255,255,0.03), 0 4px 16px rgba(0,0,0,0.1)' };
 
 interface CollapsibleInvestorAreasProps {
   areas: Area[];
@@ -20,16 +22,16 @@ export function CollapsibleInvestorAreas({ areas, tasks, subtitle, defaultOpen =
   const [open, setOpen] = useState(defaultOpen);
 
   return (
-    <Card>
+    <div className={surface} style={surfaceShadow}>
       <button
         onClick={() => setOpen(prev => !prev)}
         className="w-full text-left"
       >
-        <CardHeader>
+        <div className="flex flex-col space-y-1.5 p-6">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <Map className="size-4 text-muted-foreground" />
-              <CardTitle className="text-xl font-semibold text-foreground">Game Areas</CardTitle>
+              <h3 className="text-lg font-semibold text-foreground">Game Areas</h3>
             </div>
             <motion.div
               animate={{ rotate: open ? 180 : 0 }}
@@ -38,8 +40,8 @@ export function CollapsibleInvestorAreas({ areas, tasks, subtitle, defaultOpen =
               <ChevronDown className="size-4 text-muted-foreground" />
             </motion.div>
           </div>
-          <CardDescription className="line-clamp-1">{subtitle}</CardDescription>
-        </CardHeader>
+          <p className="text-sm text-muted-foreground line-clamp-1">{subtitle}</p>
+        </div>
       </button>
       <AnimatePresence>
         {open && (
@@ -50,7 +52,7 @@ export function CollapsibleInvestorAreas({ areas, tasks, subtitle, defaultOpen =
             transition={{ type: 'spring', stiffness: 300, damping: 28 }}
             className="overflow-hidden"
           >
-            <CardContent>
+            <div className="p-6 pt-0">
               <Stagger className="grid grid-cols-1 gap-4" delayMs={0.05}>
                 {areas.map(area => (
                   <InvestorAreaCard
@@ -61,10 +63,10 @@ export function CollapsibleInvestorAreas({ areas, tasks, subtitle, defaultOpen =
                   />
                 ))}
               </Stagger>
-            </CardContent>
+            </div>
           </motion.div>
         )}
       </AnimatePresence>
-    </Card>
+    </div>
   );
 }

--- a/src/components/dashboard/DocList.tsx
+++ b/src/components/dashboard/DocList.tsx
@@ -150,11 +150,12 @@ interface DocListProps {
   docs: Doc[];
   userDepartment?: string | null;
   isAdmin?: boolean;
+  isInvestor?: boolean;
   currentUserId?: string;
   team?: Pick<Profile, 'id' | 'display_name'>[];
 }
 
-export function DocList({ docs: initialDocs, userDepartment, isAdmin = false, currentUserId = '', team = [] }: DocListProps) {
+export function DocList({ docs: initialDocs, userDepartment, isAdmin = false, isInvestor = false, currentUserId = '', team = [] }: DocListProps) {
   const [docs, setDocs] = useState<Doc[]>(initialDocs);
   const { trigger } = useHaptics();
   const searchParams = useSearchParams();
@@ -191,7 +192,7 @@ export function DocList({ docs: initialDocs, userDepartment, isAdmin = false, cu
   const [sharedExpanded, setSharedExpanded] = useState(false);
 
   const isLocked = (d: Doc) => {
-    if (isAdmin) return false;
+    if (isAdmin || isInvestor) return false;
     const hasDeptRestriction = !!d.restricted_department?.length;
     const inDept = hasDeptRestriction && d.restricted_department!.includes(userDepartment ?? '');
     const granted = !!d.granted_user_ids?.length && d.granted_user_ids.includes(currentUserId);

--- a/src/components/dashboard/InvestorAreaCard.tsx
+++ b/src/components/dashboard/InvestorAreaCard.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState, useCallback } from 'react';
-import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { StaggerItem, HoverCard } from '@/components/motion';
 import {
@@ -120,17 +119,20 @@ export function InvestorAreaCard({ area, tasksInArea, isAdmin = false }: Investo
           <button
             type="button"
             onClick={() => setOpen(true)}
-            className="group relative w-full text-left rounded-xl border border-border bg-card transition-colors hover:bg-card/90 hover:border-border/80 focus:outline-none focus:ring-2 focus:ring-seeko-accent/30 cursor-pointer"
+            className="group relative w-full text-left rounded-xl transition-colors hover:bg-white/[0.02] focus:outline-none focus:ring-2 focus:ring-seeko-accent/30 cursor-pointer"
+            style={{
+              backgroundColor: '#2a2a2a',
+              boxShadow: '0 0 0 1px rgba(255,255,255,0.04), 0 2px 8px rgba(0,0,0,0.08)',
+            }}
           >
-            <Card className="border-0 shadow-none">
-              <CardContent className="p-4 space-y-3">
+            <div className="p-4 space-y-3">
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0 flex-1">
                     <p className="text-sm font-medium text-foreground truncate">{area.name}</p>
                     <div className="mt-2">
                       <div className="flex items-center justify-between mb-1">
                         <span className="text-xs text-muted-foreground">Progress</span>
-                        <span className="text-xs text-muted-foreground font-mono">
+                        <span className="text-xs text-muted-foreground font-mono tabular-nums">
                           {tasksInArea.filter(t => t.status === 'Complete').length}/{tasksInArea.length} tasks
                         </span>
                       </div>
@@ -163,7 +165,7 @@ export function InvestorAreaCard({ area, tasksInArea, isAdmin = false }: Investo
                         <span className="text-[11px] text-muted-foreground font-medium">{area.status}</span>
                       </div>
                     )}
-                    <span className="text-xs font-mono text-muted-foreground">{area.progress}%</span>
+                    <span className="text-xs font-mono tabular-nums text-muted-foreground">{area.progress}%</span>
                   </div>
                 </div>
                 {area.description && (
@@ -171,8 +173,7 @@ export function InvestorAreaCard({ area, tasksInArea, isAdmin = false }: Investo
                     {area.description}
                   </p>
                 )}
-              </CardContent>
-            </Card>
+            </div>
           </button>
         </HoverCard>
       </StaggerItem>

--- a/src/components/dashboard/InvestorKPIStrip.tsx
+++ b/src/components/dashboard/InvestorKPIStrip.tsx
@@ -15,9 +15,11 @@
 
 import { useState } from 'react';
 import { TrendingUp, AlertCircle, Map } from 'lucide-react';
-import { Card, CardContent, CardDescription, CardHeader } from '@/components/ui/card';
 import { Dialog, DialogHeader, DialogTitle, DialogClose } from '@/components/ui/dialog';
 import { FadeRise, Stagger, StaggerItem, HoverCard } from '@/components/motion';
+
+const kpiSurface = 'rounded-2xl bg-[#222222] border-0 h-full';
+const kpiShadow = { boxShadow: '0 0 0 1px rgba(255,255,255,0.03), 0 4px 16px rgba(0,0,0,0.1)' };
 import { toast } from 'sonner';
 import { useHaptics } from '@/components/HapticsProvider';
 
@@ -158,28 +160,28 @@ export function InvestorKPIStrip({
             <HoverCard>
               {isAdmin ? (
                 <button type="button" onClick={handleCompletionClick} className="w-full text-left">
-                  <Card className="h-full transition-colors hover:border-seeko-accent/30">
-                    <CardHeader className="flex flex-row items-center justify-between pb-2">
-                      <CardDescription className="text-sm font-medium">Completion</CardDescription>
+                  <div className={kpiSurface} style={kpiShadow}>
+                    <div className="flex flex-row items-center justify-between p-6 pb-2">
+                      <p className="text-sm font-medium text-muted-foreground">Completion</p>
                       <ProgressRing pct={liveOverallPct} />
-                    </CardHeader>
-                    <CardContent>
+                    </div>
+                    <div className="p-6 pt-0">
                       <span className="text-2xl font-semibold tracking-tight tabular-nums">{liveOverallPct}%</span>
                       <p className="text-xs text-muted-foreground mt-0.5">overall progress</p>
-                    </CardContent>
-                  </Card>
+                    </div>
+                  </div>
                 </button>
               ) : (
-                <Card className="h-full">
-                  <CardHeader className="flex flex-row items-center justify-between pb-2">
-                    <CardDescription className="text-sm font-medium">Completion</CardDescription>
+                <div className={kpiSurface} style={kpiShadow}>
+                  <div className="flex flex-row items-center justify-between p-6 pb-2">
+                    <p className="text-sm font-medium text-muted-foreground">Completion</p>
                     <ProgressRing pct={liveOverallPct} />
-                  </CardHeader>
-                  <CardContent>
+                  </div>
+                  <div className="p-6 pt-0">
                     <span className="text-2xl font-semibold tracking-tight tabular-nums">{liveOverallPct}%</span>
                     <p className="text-xs text-muted-foreground mt-0.5">overall progress</p>
-                  </CardContent>
-                </Card>
+                  </div>
+                </div>
               )}
             </HoverCard>
           </StaggerItem>
@@ -187,42 +189,50 @@ export function InvestorKPIStrip({
           {/* Completed This Week */}
           <StaggerItem>
             <HoverCard>
-              <Card>
-                <CardHeader className="flex flex-row items-center justify-between pb-2">
-                  <CardDescription className="text-sm font-medium">This Week</CardDescription>
+              <div className={kpiSurface} style={kpiShadow}>
+                <div className="flex flex-row items-center justify-between p-6 pb-2">
+                  <p className="text-sm font-medium text-muted-foreground">This Week</p>
                   <div className="flex size-8 items-center justify-center rounded-lg bg-secondary">
                     <TrendingUp className="size-4 text-muted-foreground" />
                   </div>
-                </CardHeader>
-                <CardContent>
+                </div>
+                <div className="p-6 pt-0">
                   <span className="text-2xl font-semibold tracking-tight tabular-nums">{completedThisWeek}</span>
                   <p className="text-xs text-muted-foreground mt-0.5">tasks completed</p>
-                </CardContent>
-              </Card>
+                </div>
+              </div>
             </HoverCard>
           </StaggerItem>
 
           {/* Blocked / Overdue */}
           <StaggerItem>
             <HoverCard>
-              <Card className={hasIssues ? 'border-red-900/40 bg-red-950/10' : ''}>
-                <CardHeader className="flex flex-row items-center justify-between pb-2">
-                  <CardDescription className="text-sm font-medium">Issues</CardDescription>
+              <div
+                className="rounded-2xl border-0 h-full"
+                style={{
+                  backgroundColor: hasIssues ? 'rgba(127, 29, 29, 0.1)' : '#222222',
+                  boxShadow: hasIssues
+                    ? '0 0 0 1px rgba(185, 28, 28, 0.3), 0 4px 16px rgba(0,0,0,0.1)'
+                    : '0 0 0 1px rgba(255,255,255,0.03), 0 4px 16px rgba(0,0,0,0.1)',
+                }}
+              >
+                <div className="flex flex-row items-center justify-between p-6 pb-2">
+                  <p className="text-sm font-medium text-muted-foreground">Issues</p>
                   <div className={`flex size-8 items-center justify-center rounded-lg ${hasIssues ? 'bg-red-950/30' : 'bg-secondary'}`}>
                     <AlertCircle className={`size-4 ${hasIssues ? 'text-red-400' : 'text-muted-foreground'}`} />
                   </div>
-                </CardHeader>
-                <CardContent>
+                </div>
+                <div className="p-6 pt-0">
                   {hasIssues ? (
                     <div className="flex items-baseline gap-2">
                       {blocked > 0 && (
-                        <span className="text-2xl font-semibold tracking-tight text-red-400">{blocked}</span>
+                        <span className="text-2xl font-semibold tracking-tight tabular-nums text-red-400">{blocked}</span>
                       )}
                       {blocked > 0 && overdue > 0 && (
                         <span className="text-muted-foreground">/</span>
                       )}
                       {overdue > 0 && (
-                        <span className="text-2xl font-semibold tracking-tight text-amber-400">{overdue}</span>
+                        <span className="text-2xl font-semibold tracking-tight tabular-nums text-amber-400">{overdue}</span>
                       )}
                     </div>
                   ) : (
@@ -237,26 +247,26 @@ export function InvestorKPIStrip({
                           ? 'overdue'
                           : 'all clear'}
                   </p>
-                </CardContent>
-              </Card>
+                </div>
+              </div>
             </HoverCard>
           </StaggerItem>
 
           {/* Active Areas */}
           <StaggerItem>
             <HoverCard>
-              <Card>
-                <CardHeader className="flex flex-row items-center justify-between pb-2">
-                  <CardDescription className="text-sm font-medium">Active Areas</CardDescription>
+              <div className={kpiSurface} style={kpiShadow}>
+                <div className="flex flex-row items-center justify-between p-6 pb-2">
+                  <p className="text-sm font-medium text-muted-foreground">Active Areas</p>
                   <div className="flex size-8 items-center justify-center rounded-lg bg-secondary">
                     <Map className="size-4 text-muted-foreground" />
                   </div>
-                </CardHeader>
-                <CardContent>
+                </div>
+                <div className="p-6 pt-0">
                   <span className="text-2xl font-semibold tracking-tight tabular-nums">{activeAreas}</span>
                   <p className="text-xs text-muted-foreground mt-0.5">in development</p>
-                </CardContent>
-              </Card>
+                </div>
+              </div>
             </HoverCard>
           </StaggerItem>
         </Stagger>

--- a/src/components/layout/InvestorSidebar.tsx
+++ b/src/components/layout/InvestorSidebar.tsx
@@ -6,7 +6,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { motion, LayoutGroup } from 'motion/react';
-import { LogOut, LayoutDashboard, FileDown, Settings, Home, DollarSign } from 'lucide-react';
+import { LogOut, LayoutDashboard, FileDown, Settings, Home, DollarSign, FileText } from 'lucide-react';
 import { toast } from 'sonner';
 import { Separator } from '@/components/ui/separator';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
@@ -125,6 +125,29 @@ export function InvestorSidebar({ email, displayName, avatarUrl, isAdmin = false
                 <LayoutDashboard className={`h-4 w-4 ${pathname === '/investor' ? 'text-seeko-accent' : ''}`} />
               </span>
               <span className="relative whitespace-nowrap">Dashboard</span>
+            </Link>
+
+            {/* Documents */}
+            <Link
+              href="/investor/docs"
+              className={[
+                'relative flex items-center rounded-lg py-2 text-sm gap-3 px-3',
+                pathname.startsWith('/investor/docs')
+                  ? 'text-seeko-accent font-medium'
+                  : 'text-muted-foreground hover:text-sidebar-foreground hover:bg-white/5 transition-colors',
+              ].join(' ')}
+            >
+              {pathname.startsWith('/investor/docs') && (
+                <motion.div
+                  layoutId="investor-nav-highlight"
+                  className="absolute inset-0 rounded-lg bg-white/[0.06]"
+                  transition={NAV_HIGHLIGHT.spring}
+                />
+              )}
+              <span className="relative flex items-center justify-center size-7 shrink-0">
+                <FileText className={`h-4 w-4 ${pathname.startsWith('/investor/docs') ? 'text-seeko-accent' : ''}`} />
+              </span>
+              <span className="relative whitespace-nowrap">Documents</span>
             </Link>
 
             {/* Payments */}
@@ -287,6 +310,26 @@ export function InvestorSidebar({ email, displayName, avatarUrl, isAdmin = false
                       >
                         <LayoutDashboard className="size-5" />
                         Dashboard
+                      </Link>
+                    </motion.div>
+                    <motion.div className="relative flex flex-1" whileTap={{ scale: BOTTOM_NAV.tapScale }} transition={BOTTOM_NAV.tapSpring}>
+                      {pathname.startsWith('/investor/docs') && (
+                        <motion.div
+                          layoutId="investor-mobile-indicator"
+                          className="absolute top-0 left-1/2 -translate-x-1/2 w-5 h-0.5 rounded-full bg-seeko-accent"
+                          transition={NAV_HIGHLIGHT.spring}
+                        />
+                      )}
+                      <Link
+                        href="/investor/docs"
+                        onClick={() => trigger('selection')}
+                        className={[
+                          'flex flex-1 flex-col items-center justify-center gap-1 text-[10px] font-medium transition-colors',
+                          pathname.startsWith('/investor/docs') ? 'text-seeko-accent' : 'text-muted-foreground',
+                        ].join(' ')}
+                      >
+                        <FileText className="size-5" />
+                        Docs
                       </Link>
                     </motion.div>
                     <motion.div className="relative flex flex-1" whileTap={{ scale: BOTTOM_NAV.tapScale }} transition={BOTTOM_NAV.tapSpring}>


### PR DESCRIPTION
## Summary

- **Login screen polish**: Restore from main, remove unused frosted glass redesign, fix code input overflow with flex-based sizing, add scale animation on typing, frameless card appearance
- **Investor NDA skip**: Investors (`is_investor`) bypass the NDA/agreement redirect in proxy
- **Investor panel design refresh**: Replace all border-based Card components with shadow-based surface pattern (`bg-[#222222]` + composite box-shadow) matching the main dashboard. Update typography (text-3xl bold, tracking-tight, text-balance), add tabular-nums on all numbers, lighten dividers
- **Investor documents tab**: New `/investor/docs` page reusing DocList. Investors bypass all department/classification restrictions on docs and decks. Nav links added to desktop sidebar and mobile bottom nav
- **Notification system**: Live toast notifications, bidirectional swipe actions, mobile scroll lock fixes
- **Other polish**: Typography refinements, scroll lock utility, design reference updates

## Test plan

- [ ] Login page renders correctly — code input cells are evenly sized, scale animation triggers on typing
- [ ] Investor can log in and is NOT redirected to the agreement page
- [ ] Investor panel shows updated surface styling (shadow-based cards, not border-based)
- [ ] Investor can access `/investor/docs` and see all documents including department-restricted ones
- [ ] Documents tab appears in both desktop sidebar and mobile bottom nav
- [ ] Non-investor users still see department restrictions on docs
- [ ] Notification swipe actions work on mobile (right = dismiss, left = mark read)

🤖 Generated with [Claude Code](https://claude.com/claude-code)