### PR TITLE
feat: admin deadline editing for shared decks

### DIFF
--- a/src/app/api/doc-share/update-deadline/route.ts
+++ b/src/app/api/doc-share/update-deadline/route.ts
@@ -32,9 +32,14 @@ export async function PATCH(request: NextRequest) {
     return NextResponse.json({ error: 'Can only update active invites' }, { status: 400 });
   }
 
-  await (service.from('external_signing_invites') as any)
+  const { error: updateError } = await (service.from('external_signing_invites') as any)
     .update({ expires_at: newDate.toISOString() })
     .eq('id', invite_id);
+
+  if (updateError) {
+    console.error('[doc-share/update-deadline] update failed:', updateError);
+    return NextResponse.json({ error: 'Failed to update deadline' }, { status: 500 });
+  }
 
   return NextResponse.json({ success: true, expires_at: newDate.toISOString() });
 }

--- a/src/app/api/doc-share/update-deadline/route.ts
+++ b/src/app/api/doc-share/update-deadline/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { getServiceClient } from '@/lib/supabase/service';
+
+export async function PATCH(request: NextRequest) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { data: profile } = await supabase.from('profiles').select('is_admin').eq('id', user.id).single();
+  if (!profile?.is_admin) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  const { invite_id, expires_at } = await request.json();
+  if (!invite_id) return NextResponse.json({ error: 'invite_id required' }, { status: 400 });
+  if (!expires_at) return NextResponse.json({ error: 'expires_at required' }, { status: 400 });
+
+  // Validate future date
+  const newDate = new Date(expires_at);
+  if (isNaN(newDate.getTime())) return NextResponse.json({ error: 'Invalid date' }, { status: 400 });
+  if (newDate <= new Date()) return NextResponse.json({ error: 'Date must be in the future' }, { status: 400 });
+
+  const service = getServiceClient();
+  const { data: invite } = await (service
+    .from('external_signing_invites') as any)
+    .select('status, purpose')
+    .eq('id', invite_id)
+    .single() as { data: { status: string; purpose: string } | null };
+
+  if (!invite) return NextResponse.json({ error: 'Invite not found' }, { status: 404 });
+  if (invite.purpose !== 'doc_share') return NextResponse.json({ error: 'Not a doc share invite' }, { status: 400 });
+  if (invite.status !== 'pending' && invite.status !== 'verified') {
+    return NextResponse.json({ error: 'Can only update active invites' }, { status: 400 });
+  }
+
+  await (service.from('external_signing_invites') as any)
+    .update({ expires_at: newDate.toISOString() })
+    .eq('id', invite_id);
+
+  return NextResponse.json({ success: true, expires_at: newDate.toISOString() });
+}

--- a/src/components/dashboard/DocList.tsx
+++ b/src/components/dashboard/DocList.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useMemo } from 'react';
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
-import { FileText, Lock, Pencil, Trash2, Plus, Search, Clock, ChevronDown, Circle, Presentation, Share2, XCircle, RotateCcw, Eye } from 'lucide-react';
+import { FileText, Lock, Pencil, Trash2, Plus, Search, Clock, ChevronDown, Circle, Presentation, Share2, XCircle, RotateCcw, Eye, Calendar, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 import { Doc } from '@/lib/types';
@@ -27,6 +27,7 @@ import { DeckViewer } from './DeckViewer';
 import { DocDeleteConfirm } from './DocDeleteConfirm';
 import { DocContent } from './DocContent';
 import { DocShareDialog } from './DocShareDialog';
+import { DatePicker } from '@/components/ui/date-picker';
 import { useHaptics } from '@/components/HapticsProvider';
 
 /** Strip HTML tags and decode common entities for plain-text previews */
@@ -53,6 +54,18 @@ function timeAgo(dateStr: string | undefined | null): string {
   const days = Math.floor(hours / 24);
   if (days < 7) return `${days}d ago`;
   return new Date(dateStr).toLocaleDateString();
+}
+
+function timeUntil(dateStr: string | undefined | null): string {
+  if (!dateStr) return '';
+  const diff = new Date(dateStr).getTime() - Date.now();
+  if (diff <= 0) return 'expired';
+  const days = Math.floor(diff / 86400000);
+  if (days === 0) return 'today';
+  if (days === 1) return 'in 1d';
+  if (days < 7) return `in ${days}d`;
+  if (days < 30) return `in ${Math.floor(days / 7)}w`;
+  return `in ${Math.floor(days / 30)}mo`;
 }
 
 function isRecentlyUpdated(doc: Doc): boolean {
@@ -190,6 +203,9 @@ export function DocList({ docs: initialDocs, userDepartment, isAdmin = false, is
   const [sharedLinks, setSharedLinks] = useState<any[]>([]);
   const [sharedLoading, setSharedLoading] = useState(false);
   const [sharedExpanded, setSharedExpanded] = useState(false);
+  const [editingDeadlineId, setEditingDeadlineId] = useState<string | null>(null);
+  const [deadlineDate, setDeadlineDate] = useState('');
+  const [deadlineLoading, setDeadlineLoading] = useState(false);
 
   const isLocked = (d: Doc) => {
     if (isAdmin || isInvestor) return false;
@@ -287,6 +303,27 @@ export function DocList({ docs: initialDocs, userDepartment, isAdmin = false, is
       toast.success('Share link resent');
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to resend');
+    }
+  }
+
+  async function handleUpdateDeadline(inviteId: string, newExpiresAt: string) {
+    setDeadlineLoading(true);
+    try {
+      const res = await fetch('/api/doc-share/update-deadline', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ invite_id: inviteId, expires_at: new Date(newExpiresAt + 'T00:00:00').toISOString() }),
+      });
+      if (!res.ok) throw new Error((await res.json()).error || 'Failed to update deadline');
+      const data = await res.json();
+      setSharedLinks(prev => prev.map(l => l.id === inviteId ? { ...l, expires_at: data.expires_at } : l));
+      toast.success('Deadline updated');
+      setEditingDeadlineId(null);
+      setDeadlineDate('');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to update deadline');
+    } finally {
+      setDeadlineLoading(false);
     }
   }
 
@@ -529,6 +566,12 @@ export function DocList({ docs: initialDocs, userDepartment, isAdmin = false, is
                             {link.view_count ?? 0}
                           </span>
                           <span className="shrink-0">{timeAgo(link.created_at)}</span>
+                          {link.expires_at && (link.status === 'pending' || link.status === 'verified') && (
+                            <span className="flex items-center gap-1 shrink-0">
+                              <Clock className="size-3" />
+                              {timeUntil(link.expires_at)}
+                            </span>
+                          )}
                         </div>
                       </div>
                       <div className="flex items-center gap-1.5 shrink-0">
@@ -552,8 +595,63 @@ export function DocList({ docs: initialDocs, userDepartment, isAdmin = false, is
                             <RotateCcw className="size-3.5" />
                           </button>
                         )}
+                        {(link.status === 'pending' || link.status === 'verified') && (
+                          <button
+                            type="button"
+                            title="Edit deadline"
+                            onClick={() => {
+                              const current = link.expires_at ? new Date(link.expires_at).toISOString().split('T')[0] : '';
+                              setDeadlineDate(current);
+                              setEditingDeadlineId(editingDeadlineId === link.id ? null : link.id);
+                            }}
+                            className="flex size-7 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+                          >
+                            <Calendar className="size-3.5" />
+                          </button>
+                        )}
                       </div>
                     </CardContent>
+                    <AnimatePresence>
+                      {editingDeadlineId === link.id && (
+                        <motion.div
+                          initial={{ opacity: 0, height: 0 }}
+                          animate={{ opacity: 1, height: 'auto' }}
+                          exit={{ opacity: 0, height: 0 }}
+                          transition={{ type: 'spring', visualDuration: 0.3, bounce: 0 }}
+                          className="overflow-hidden border-t border-border/50"
+                        >
+                          <div className="p-3 flex flex-col gap-2">
+                            <p className="text-xs text-muted-foreground">
+                              Current expiry: {link.expires_at ? new Date(link.expires_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }) : 'None'}
+                            </p>
+                            <DatePicker
+                              value={deadlineDate}
+                              onChange={setDeadlineDate}
+                              minDate={(() => { const d = new Date(); d.setDate(d.getDate() + 1); d.setHours(0,0,0,0); return d; })()}
+                              dateLabel="New deadline"
+                            />
+                            <div className="flex items-center gap-2 mt-1">
+                              <Button
+                                size="sm"
+                                disabled={!deadlineDate || deadlineLoading}
+                                onClick={() => handleUpdateDeadline(link.id, deadlineDate)}
+                                className="gap-1.5 bg-seeko-accent text-black hover:bg-seeko-accent/90"
+                              >
+                                {deadlineLoading ? <Loader2 className="size-3 animate-spin" /> : null}
+                                Update
+                              </Button>
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                onClick={() => { setEditingDeadlineId(null); setDeadlineDate(''); }}
+                              >
+                                Cancel
+                              </Button>
+                            </div>
+                          </div>
+                        </motion.div>
+                      )}
+                    </AnimatePresence>
                   </Card>
               ))}
               {sharedLinks.length > 3 && (

--- a/src/components/dashboard/DocList.tsx
+++ b/src/components/dashboard/DocList.tsx
@@ -314,8 +314,8 @@ export function DocList({ docs: initialDocs, userDepartment, isAdmin = false, is
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ invite_id: inviteId, expires_at: new Date(newExpiresAt + 'T00:00:00').toISOString() }),
       });
-      if (!res.ok) throw new Error((await res.json()).error || 'Failed to update deadline');
       const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Failed to update deadline');
       setSharedLinks(prev => prev.map(l => l.id === inviteId ? { ...l, expires_at: data.expires_at } : l));
       toast.success('Deadline updated');
       setEditingDeadlineId(null);


### PR DESCRIPTION
## Summary

- Adds `PATCH /api/doc-share/update-deadline` route for admins to change `expires_at` on active shared deck/doc invites
- Adds calendar button + DatePicker popover to Shared tab invite cards for editing deadlines
- Adds expiry countdown indicator (clock icon + relative time) to invite card metadata

## Details

Admins can now change the expiration date on shared invites after creation, without needing to revoke and re-share. The calendar button appears on active (pending/verified) invites and opens an inline date picker with a minimum date of tomorrow. The API validates admin auth, future date, active status, and checks the Supabase update result for errors.

## Test plan

- [ ] Navigate to `/docs?tab=shared` as an admin
- [ ] Verify calendar button appears on pending/verified invites only
- [ ] Click calendar button — DatePicker opens with current expiry pre-filled
- [ ] Select a future date, click "Update" — toast confirms, expiry updates on card
- [ ] Verify calendar button does NOT appear on expired/revoked invites
- [ ] Verify past dates and today are disabled in the date picker
- [ ] Cancel button closes picker without changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)