### PR TITLE
Organize sent invites: search, filters, grouping, archive

### DIFF
--- a/docs/plans/2026-04-05-sent-invites-organization-design.md
+++ b/docs/plans/2026-04-05-sent-invites-organization-design.md
@@ -1,0 +1,130 @@
+# Sent Invites Organization — Design
+
+**Date:** 2026-04-05
+**Page:** `/admin/external-signing`
+**Component:** `src/components/external-signing/InviteTable.tsx`
+
+## Problem
+
+The sent-invites table is a flat list of all rows from `external_signing_invites` (currently 29 rows, growing). Four pain points:
+
+- **A.** Hard to find a specific invite in the flat list
+- **B.** Signing and Invoice rows both render as "Custom" — indistinguishable
+- **C.** Expired/revoked invites clutter the active ones
+- **D.** Multiple invites to the same recipient are scattered
+
+## Scope
+
+Organize sent invites **in place** inside the existing single card — no tabs, no new pages, no new routes. Client-side filtering and grouping only. Doc-share invites are excluded (handled in `/docs`).
+
+## Structure
+
+One `<Card>` with three stacked regions:
+
+```
+┌─ Sent Invites (29)         [🔍 Search recipient…]  [⌘ Group] ─┐
+│  ● All  ○ Pending  ○ Verified  ○ Signed  ○ Archive           │
+│ ─────────────────────────────────────────────────────────── │
+│  Recipient              Type    Document        Status   Sent │
+│  …                                                             │
+│                                                               │
+│  Show archived (12) ↓                                        │
+└───────────────────────────────────────────────────────────────┘
+```
+
+1. **Header row** — title + count on left, search input and group toggle on right
+2. **Status filter chip row** — single-select, `All · Pending · Verified · Signed · Archive`
+3. **Table** — same columns as today + new `Type` tag column
+4. **Archive footer** — inline expand link when archive filter is inactive and archived rows exist
+
+## Filter logic
+
+| Control | Behavior |
+|---|---|
+| Search | Client-side filter on `recipient_email`, case-insensitive, debounced 150ms |
+| Status chip `All` | Shows pending + verified + signed |
+| Status chip `Pending` / `Verified` / `Signed` | Single status only |
+| Status chip `Archive` | Shows expired + revoked only |
+| Group toggle (off) | Flat rows, sorted pending → verified → signed, newest-first within each |
+| Group toggle (on) | Collapses rows sharing `recipient_email`; parent shows count + latest status; click chevron to expand |
+| Archive footer link | Inline expand (no modal); appears only when status ≠ `Archive` and archived rows exist |
+
+## New: Type column
+
+Replaces the ambiguous "Custom" label with a small muted tag next to the document name:
+
+- `template_type === 'invoice'` → `Invoice` tag
+- `template_type === 'preset'` → `Signing` tag + preset template id
+- `template_type === 'custom'` → `Signing` tag + custom title
+- `template_type === 'doc_share'` → filtered out of this table
+
+## State model
+
+```ts
+type SortedStatus = 'all' | 'pending' | 'verified' | 'signed' | 'archive';
+
+const [filters, setFilters] = useState({
+  search: '',
+  status: 'all' as SortedStatus,
+  groupByRecipient: false,
+  showArchived: false,
+});
+```
+
+All derived data (filtered list, grouped list, archive count) is `useMemo`'d off `invites + filters`.
+
+## Motion
+
+```
+   0ms   card mounts (initial={false} — no entrance on page load)
+   0ms   rows render in current filter state
+ →user action: filter chip clicked
+   0ms   AnimatePresence exits old rows (opacity → 0, y: -4px, 120ms)
+ 120ms   new rows enter, staggered 30ms per row
+         opacity 0→1, y: 8→0, scale 0.98→1
+         spring: { type: 'spring', duration: 0.3, bounce: 0 }
+ →user action: group toggle
+   0ms   layout animation collapses/expands
+         spring: { type: 'spring', duration: 0.35, bounce: 0 }
+ →user action: chevron expand
+   0ms   child rows slide down, opacity 0→1, staggered 20ms
+```
+
+## Craft details
+
+- **Tabular numerals** on `Sent` and `Expires` date columns
+- **Text-wrap: pretty** on document titles
+- **Concentric radius**: card `rounded-xl` (12px) → table `rounded-lg` (8px) → status badges `rounded-full`
+- **Shadows over borders** on card
+- **Scale 0.96 on press** for chip buttons and row action icons
+- **40×40 hit areas** on row action icons (extend with pseudo-element)
+- **No `transition: all`** — explicit `opacity, transform, background-color`
+- **`initial={false}`** on the outer `AnimatePresence`
+- **Font smoothing** `-webkit-font-smoothing: antialiased` (inherited from root, verify)
+
+## Files touched
+
+- `src/components/external-signing/InviteTable.tsx` — rewrite: add toolbar, filter state, grouping, archive section, type tag, motion
+
+No changes to:
+- Supabase schema
+- API routes
+- `src/app/(dashboard)/admin/external-signing/page.tsx` or `client.tsx`
+- `src/lib/types.ts`
+
+## Out of scope (YAGNI)
+
+- Pagination — 29 rows is fine; revisit at 200+
+- Server-side filtering — client-side is adequate at this scale
+- Bulk actions
+- CSV export
+- Sortable columns
+- Unified view including doc-share
+
+## Success criteria
+
+1. A user can find any specific recipient's invite in ≤ 2 interactions (search OR group-expand)
+2. Signing vs Invoice rows are visually distinguishable at a glance
+3. Default view shows only active invites; archive is one click away
+4. Filter changes feel instant and interruptible (no queued animations)
+5. Per `/interface-craft critique`, the card passes craft checklist post-implementation

--- a/docs/plans/2026-04-05-sent-invites-organization.md
+++ b/docs/plans/2026-04-05-sent-invites-organization.md
@@ -1,0 +1,844 @@
+# Sent Invites Organization Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Organize the sent-invites table on `/admin/external-signing` in-place with search, status filters, recipient grouping, and archive separation — all inside the existing single card, no tabs, no new routes.
+
+**Architecture:** Client-side filter/group logic extracted as pure functions in a new `lib` module (TDD-friendly), then wired into a rewritten `InviteTable.tsx` with staggered motion using existing `springs` from `@/lib/motion`. Doc-share rows are filtered out of this table.
+
+**Tech Stack:** Next.js 16 · React 19 · Tailwind v4 · shadcn/ui · motion/react · Vitest + jsdom · Supabase client
+
+**Design doc:** `docs/plans/2026-04-05-sent-invites-organization-design.md`
+
+---
+
+## Task 1: Extract and TDD the filter-logic module
+
+**Rationale:** Component rendering is hard to TDD; pure filter/group functions are not. Extract first, test first.
+
+**Files:**
+- Create: `src/lib/invite-filters.ts`
+- Create: `src/lib/__tests__/invite-filters.test.ts`
+
+### Step 1.1: Write the failing test for `filterByStatus`
+
+Create `src/lib/__tests__/invite-filters.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { filterByStatus, type FilterStatus } from '../invite-filters';
+import type { ExternalSigningInvite } from '../types';
+
+const makeInvite = (overrides: Partial<ExternalSigningInvite>): ExternalSigningInvite => ({
+  id: 'x',
+  token: 't',
+  recipient_email: 'a@b.com',
+  status: 'pending',
+  template_type: 'preset',
+  template_id: 'nda',
+  custom_title: null,
+  personal_note: null,
+  expires_at: '2026-05-01T00:00:00Z',
+  signed_at: null,
+  created_at: '2026-04-01T00:00:00Z',
+  verification_attempts: 0,
+  created_by: 'u',
+  signer_name: null,
+  is_guardian_signing: false,
+  ...overrides,
+} as ExternalSigningInvite);
+
+describe('filterByStatus', () => {
+  const invites = [
+    makeInvite({ id: '1', status: 'pending' }),
+    makeInvite({ id: '2', status: 'verified' }),
+    makeInvite({ id: '3', status: 'signed' }),
+    makeInvite({ id: '4', status: 'expired' }),
+    makeInvite({ id: '5', status: 'revoked' }),
+  ];
+
+  it('all → active statuses only (pending/verified/signed)', () => {
+    const result = filterByStatus(invites, 'all');
+    expect(result.map(i => i.id)).toEqual(['1', '2', '3']);
+  });
+
+  it('pending → only pending', () => {
+    expect(filterByStatus(invites, 'pending').map(i => i.id)).toEqual(['1']);
+  });
+
+  it('verified → only verified', () => {
+    expect(filterByStatus(invites, 'verified').map(i => i.id)).toEqual(['2']);
+  });
+
+  it('signed → only signed', () => {
+    expect(filterByStatus(invites, 'signed').map(i => i.id)).toEqual(['3']);
+  });
+
+  it('archive → expired + revoked', () => {
+    expect(filterByStatus(invites, 'archive').map(i => i.id)).toEqual(['4', '5']);
+  });
+});
+```
+
+### Step 1.2: Run to verify it fails
+
+Run: `cd /Volumes/CODEUSER/seeko-studio && npx vitest run src/lib/__tests__/invite-filters.test.ts`
+Expected: FAIL — cannot import `../invite-filters`
+
+### Step 1.3: Implement minimal `filterByStatus`
+
+Create `src/lib/invite-filters.ts`:
+
+```ts
+import type { ExternalSigningInvite } from './types';
+
+export type FilterStatus = 'all' | 'pending' | 'verified' | 'signed' | 'archive';
+
+const ACTIVE_STATUSES = new Set(['pending', 'verified', 'signed']);
+const ARCHIVE_STATUSES = new Set(['expired', 'revoked']);
+
+export function filterByStatus(
+  invites: ExternalSigningInvite[],
+  status: FilterStatus,
+): ExternalSigningInvite[] {
+  if (status === 'all') return invites.filter(i => ACTIVE_STATUSES.has(i.status));
+  if (status === 'archive') return invites.filter(i => ARCHIVE_STATUSES.has(i.status));
+  return invites.filter(i => i.status === status);
+}
+```
+
+### Step 1.4: Run tests to verify they pass
+
+Run: `npx vitest run src/lib/__tests__/invite-filters.test.ts`
+Expected: 5 passing
+
+### Step 1.5: Add `filterBySearch` test + impl
+
+Append to test file:
+
+```ts
+describe('filterBySearch', () => {
+  const invites = [
+    makeInvite({ id: '1', recipient_email: 'alice@example.com' }),
+    makeInvite({ id: '2', recipient_email: 'BOB@example.com' }),
+    makeInvite({ id: '3', recipient_email: 'carol@other.org' }),
+  ];
+
+  it('returns all when query is empty', () => {
+    expect(filterBySearch(invites, '').length).toBe(3);
+    expect(filterBySearch(invites, '   ').length).toBe(3);
+  });
+
+  it('matches case-insensitively on recipient_email', () => {
+    expect(filterBySearch(invites, 'BOB').map(i => i.id)).toEqual(['2']);
+    expect(filterBySearch(invites, 'alice').map(i => i.id)).toEqual(['1']);
+  });
+
+  it('matches partial substring', () => {
+    expect(filterBySearch(invites, 'example').map(i => i.id)).toEqual(['1', '2']);
+  });
+});
+```
+
+Add import at top: `import { filterByStatus, filterBySearch, type FilterStatus } from '../invite-filters';`
+
+Append to `invite-filters.ts`:
+
+```ts
+export function filterBySearch(
+  invites: ExternalSigningInvite[],
+  query: string,
+): ExternalSigningInvite[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return invites;
+  return invites.filter(i => i.recipient_email.toLowerCase().includes(q));
+}
+```
+
+Run: `npx vitest run src/lib/__tests__/invite-filters.test.ts` → 8 passing
+
+### Step 1.6: Add `excludeDocShare` test + impl
+
+Append test:
+
+```ts
+describe('excludeDocShare', () => {
+  it('removes rows where template_type is doc_share', () => {
+    const invites = [
+      makeInvite({ id: '1', template_type: 'preset' }),
+      makeInvite({ id: '2', template_type: 'custom' }),
+      makeInvite({ id: '3', template_type: 'invoice' }),
+      makeInvite({ id: '4', template_type: 'doc_share' }),
+    ];
+    expect(excludeDocShare(invites).map(i => i.id)).toEqual(['1', '2', '3']);
+  });
+});
+```
+
+Update import: add `excludeDocShare`. Append to `invite-filters.ts`:
+
+```ts
+export function excludeDocShare(invites: ExternalSigningInvite[]): ExternalSigningInvite[] {
+  return invites.filter(i => i.template_type !== 'doc_share');
+}
+```
+
+Run tests → 9 passing
+
+### Step 1.7: Add `groupByRecipient` test + impl
+
+Append test:
+
+```ts
+describe('groupByRecipient', () => {
+  const invites = [
+    makeInvite({ id: '1', recipient_email: 'a@x.com', created_at: '2026-04-03' }),
+    makeInvite({ id: '2', recipient_email: 'a@x.com', created_at: '2026-04-01' }),
+    makeInvite({ id: '3', recipient_email: 'b@x.com', created_at: '2026-04-02' }),
+  ];
+
+  it('groups invites by recipient_email', () => {
+    const groups = groupByRecipient(invites);
+    expect(groups.length).toBe(2);
+    expect(groups[0].email).toBe('a@x.com');
+    expect(groups[0].invites.length).toBe(2);
+    expect(groups[1].email).toBe('b@x.com');
+  });
+
+  it('sorts group members newest-first', () => {
+    const groups = groupByRecipient(invites);
+    expect(groups[0].invites.map(i => i.id)).toEqual(['1', '2']);
+  });
+
+  it('orders groups by most-recent invite', () => {
+    const groups = groupByRecipient(invites);
+    expect(groups.map(g => g.email)).toEqual(['a@x.com', 'b@x.com']);
+  });
+});
+```
+
+Update import: add `groupByRecipient`. Append to `invite-filters.ts`:
+
+```ts
+export type InviteGroup = {
+  email: string;
+  invites: ExternalSigningInvite[];
+};
+
+export function groupByRecipient(invites: ExternalSigningInvite[]): InviteGroup[] {
+  const map = new Map<string, ExternalSigningInvite[]>();
+  for (const inv of invites) {
+    const list = map.get(inv.recipient_email) ?? [];
+    list.push(inv);
+    map.set(inv.recipient_email, list);
+  }
+  const groups: InviteGroup[] = [];
+  for (const [email, list] of map) {
+    list.sort((a, b) => b.created_at.localeCompare(a.created_at));
+    groups.push({ email, invites: list });
+  }
+  groups.sort((a, b) => b.invites[0].created_at.localeCompare(a.invites[0].created_at));
+  return groups;
+}
+```
+
+Run tests → 12 passing
+
+### Step 1.8: Add `sortByActivePriority` test + impl
+
+Append test:
+
+```ts
+describe('sortByActivePriority', () => {
+  it('orders pending → verified → signed, newest-first within each', () => {
+    const invites = [
+      makeInvite({ id: '1', status: 'signed', created_at: '2026-04-03' }),
+      makeInvite({ id: '2', status: 'pending', created_at: '2026-04-01' }),
+      makeInvite({ id: '3', status: 'verified', created_at: '2026-04-02' }),
+      makeInvite({ id: '4', status: 'pending', created_at: '2026-04-04' }),
+    ];
+    const sorted = sortByActivePriority(invites);
+    expect(sorted.map(i => i.id)).toEqual(['4', '2', '3', '1']);
+  });
+});
+```
+
+Update import: add `sortByActivePriority`. Append to `invite-filters.ts`:
+
+```ts
+const STATUS_ORDER: Record<string, number> = { pending: 0, verified: 1, signed: 2, expired: 3, revoked: 4 };
+
+export function sortByActivePriority(invites: ExternalSigningInvite[]): ExternalSigningInvite[] {
+  return [...invites].sort((a, b) => {
+    const orderDiff = (STATUS_ORDER[a.status] ?? 9) - (STATUS_ORDER[b.status] ?? 9);
+    if (orderDiff !== 0) return orderDiff;
+    return b.created_at.localeCompare(a.created_at);
+  });
+}
+```
+
+Run tests → 13 passing
+
+### Step 1.9: Commit
+
+```bash
+cd /Volumes/CODEUSER/seeko-studio
+git add src/lib/invite-filters.ts src/lib/__tests__/invite-filters.test.ts
+git commit -m "feat(invites): add filter/group/sort utilities for sent-invites view
+
+- filterByStatus: supports all/pending/verified/signed/archive
+- filterBySearch: case-insensitive recipient_email match
+- excludeDocShare: strips doc_share rows from signing-table view
+- groupByRecipient: groups invites per email, newest-first
+- sortByActivePriority: pending → verified → signed ordering"
+```
+
+---
+
+## Task 2: Rewrite `InviteTable.tsx` — baseline + type tag
+
+**Files:**
+- Modify: `src/components/external-signing/InviteTable.tsx` (full rewrite)
+
+### Step 2.1: Add the new toolbar + type tag (no filters wired yet)
+
+Rewrite `InviteTable.tsx`. Keep existing data-fetch and action handlers; change render:
+
+```tsx
+'use client';
+
+import { useEffect, useState, useCallback, useMemo } from 'react';
+import { createClient } from '@/lib/supabase/client';
+import { RotateCw, Ban, Download, Loader2, Send, Search, Users } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { toast } from 'sonner';
+import type { ExternalSigningInvite } from '@/lib/types';
+import {
+  filterByStatus,
+  filterBySearch,
+  excludeDocShare,
+  sortByActivePriority,
+  type FilterStatus,
+} from '@/lib/invite-filters';
+
+interface InviteTableProps { refreshKey: number; }
+
+const STATUS_VARIANT: Record<string, 'default' | 'secondary' | 'outline' | 'destructive'> = {
+  pending: 'outline', verified: 'secondary', signed: 'default', expired: 'secondary', revoked: 'destructive',
+};
+
+const STATUS_CHIPS: { value: FilterStatus; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'pending', label: 'Pending' },
+  { value: 'verified', label: 'Verified' },
+  { value: 'signed', label: 'Signed' },
+  { value: 'archive', label: 'Archive' },
+];
+
+function getTypeTag(invite: ExternalSigningInvite): { label: string; doc: string } {
+  if (invite.template_type === 'invoice') {
+    return { label: 'Invoice', doc: invite.custom_title || 'Invoice request' };
+  }
+  if (invite.template_type === 'preset') {
+    return { label: 'Signing', doc: invite.template_id || 'Preset' };
+  }
+  return { label: 'Signing', doc: invite.custom_title || 'Custom' };
+}
+
+export function InviteTable({ refreshKey }: InviteTableProps) {
+  const [invites, setInvites] = useState<ExternalSigningInvite[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [status, setStatus] = useState<FilterStatus>('all');
+
+  const fetchInvites = useCallback(async () => {
+    setLoading(true);
+    const supabase = createClient();
+    const { data } = await supabase
+      .from('external_signing_invites')
+      .select('id, token, recipient_email, status, template_type, template_id, custom_title, personal_note, expires_at, signed_at, created_at, verification_attempts, created_by, signer_name, is_guardian_signing')
+      .order('created_at', { ascending: false });
+    setInvites((data as ExternalSigningInvite[]) || []);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { fetchInvites(); }, [fetchInvites, refreshKey]);
+
+  // Keep existing handleAction and handleDownload (copy from current file)
+  async function handleAction(inviteId: string, action: 'revoke' | 'resend') {
+    setActionLoading(inviteId);
+    try {
+      const res = await fetch(`/api/external-signing/${action}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ invite_id: inviteId }),
+      });
+      if (!res.ok) { const data = await res.json(); throw new Error(data.error); }
+      toast.success(action === 'revoke' ? 'Invite revoked' : 'Invite resent');
+      fetchInvites();
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : `Failed to ${action}`);
+    } finally { setActionLoading(null); }
+  }
+
+  async function handleDownload(inviteId: string) {
+    setActionLoading(inviteId);
+    try {
+      const supabase = createClient();
+      const { data, error } = await supabase.storage.from('agreements').download(`external/${inviteId}/agreement.pdf`);
+      if (error || !data) throw new Error('Failed to download');
+      const url = URL.createObjectURL(data);
+      const a = document.createElement('a');
+      a.href = url; a.download = `agreement-${inviteId}.pdf`; a.click();
+      URL.revokeObjectURL(url);
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : 'Download failed');
+    } finally { setActionLoading(null); }
+  }
+
+  const signingInvites = useMemo(() => excludeDocShare(invites), [invites]);
+  const filtered = useMemo(() => {
+    const byStatus = filterByStatus(signingInvites, status);
+    const bySearch = filterBySearch(byStatus, search);
+    return status === 'all' ? sortByActivePriority(bySearch) : bySearch;
+  }, [signingInvites, status, search]);
+
+  if (loading) {
+    return <div className="flex justify-center py-12"><Loader2 className="size-5 animate-spin text-muted-foreground" /></div>;
+  }
+
+  if (signingInvites.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-3 py-12 text-center">
+        <div className="flex size-10 items-center justify-center rounded-full bg-muted ring-1 ring-border">
+          <Send className="size-4 text-muted-foreground" />
+        </div>
+        <div>
+          <p className="text-sm font-medium text-muted-foreground">No invites sent yet</p>
+          <p className="text-xs text-muted-foreground/60">Send your first invite using the form above</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* Header */}
+      <div className="flex items-center justify-between gap-4">
+        <h2 className="text-sm font-medium text-muted-foreground">
+          Sent Invites
+          <span className="ml-2 text-xs text-muted-foreground/60 tabular-nums">({filtered.length})</span>
+        </h2>
+        <div className="relative w-64">
+          <Search className="absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground/60" />
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search recipient…"
+            className="h-8 w-full rounded-md border border-border bg-muted/20 pl-8 pr-3 text-xs text-foreground placeholder:text-muted-foreground/60 focus:outline-none focus:ring-1 focus:ring-seeko-accent/40"
+          />
+        </div>
+      </div>
+
+      {/* Status chips */}
+      <div className="flex flex-wrap gap-1.5">
+        {STATUS_CHIPS.map((chip) => {
+          const active = status === chip.value;
+          return (
+            <button
+              key={chip.value}
+              onClick={() => setStatus(chip.value)}
+              className={`rounded-full px-3 py-1 text-xs font-medium transition-[background-color,color,transform] active:scale-[0.96] ${
+                active
+                  ? 'bg-foreground text-background'
+                  : 'bg-muted/40 text-muted-foreground hover:bg-muted/70 hover:text-foreground'
+              }`}
+            >
+              {chip.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto rounded-xl border border-border">
+        <table className="w-full text-left text-sm">
+          <thead>
+            <tr className="border-b border-border bg-muted/30">
+              <th className="px-4 py-2.5 text-xs font-medium text-muted-foreground">Recipient</th>
+              <th className="px-4 py-2.5 text-xs font-medium text-muted-foreground">Type</th>
+              <th className="px-4 py-2.5 text-xs font-medium text-muted-foreground">Document</th>
+              <th className="px-4 py-2.5 text-xs font-medium text-muted-foreground">Status</th>
+              <th className="px-4 py-2.5 text-xs font-medium text-muted-foreground">Sent</th>
+              <th className="px-4 py-2.5 text-xs font-medium text-muted-foreground">Expires</th>
+              <th className="px-4 py-2.5 text-xs font-medium text-muted-foreground sr-only">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((invite) => {
+              const { label: typeLabel, doc } = getTypeTag(invite);
+              return (
+                <tr key={invite.id} className="border-b border-border/50 transition-[background-color] hover:bg-muted/20">
+                  <td className="px-4 py-3 text-foreground font-mono text-xs">
+                    {invite.recipient_email}
+                    {invite.is_guardian_signing && (
+                      <Badge variant="outline" className="ml-2 text-[10px]">Guardian</Badge>
+                    )}
+                  </td>
+                  <td className="px-4 py-3">
+                    <span className="rounded-full bg-muted/40 px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+                      {typeLabel}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground text-xs" style={{ textWrap: 'pretty' }}>{doc}</td>
+                  <td className="px-4 py-3">
+                    <Badge variant={STATUS_VARIANT[invite.status] || 'secondary'}>{invite.status}</Badge>
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground text-xs tabular-nums">
+                    {new Date(invite.created_at).toLocaleDateString()}
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground text-xs tabular-nums">
+                    {new Date(invite.expires_at).toLocaleDateString()}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex gap-1">
+                      {(invite.status === 'pending' || invite.status === 'verified') && (
+                        <>
+                          <button
+                            onClick={() => handleAction(invite.id, 'resend')}
+                            disabled={actionLoading === invite.id}
+                            title="Resend invite"
+                            className="relative rounded p-1.5 transition-[background-color,transform] hover:bg-muted active:scale-[0.96] group before:absolute before:inset-0 before:-m-2 before:content-['']"
+                          >
+                            <RotateCw className="size-3.5 text-muted-foreground group-hover:text-foreground transition-[color]" />
+                          </button>
+                          <button
+                            onClick={() => handleAction(invite.id, 'revoke')}
+                            disabled={actionLoading === invite.id}
+                            title="Revoke invite"
+                            className="relative rounded p-1.5 transition-[background-color,transform] hover:bg-destructive/10 active:scale-[0.96] group before:absolute before:inset-0 before:-m-2 before:content-['']"
+                          >
+                            <Ban className="size-3.5 text-muted-foreground group-hover:text-destructive transition-[color]" />
+                          </button>
+                        </>
+                      )}
+                      {invite.status === 'signed' && (
+                        <button
+                          onClick={() => handleDownload(invite.id)}
+                          disabled={actionLoading === invite.id}
+                          title="Download signed PDF"
+                          className="relative rounded p-1.5 transition-[background-color,transform] hover:bg-seeko-accent/10 active:scale-[0.96] group before:absolute before:inset-0 before:-m-2 before:content-['']"
+                        >
+                          <Download className="size-3.5 text-muted-foreground group-hover:text-seeko-accent transition-[color]" />
+                        </button>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+```
+
+### Step 2.2: Manually verify in browser
+
+Run: `npm run dev` → open `http://localhost:3000/admin/external-signing`
+Expected:
+- Search input filters as you type
+- Status chips switch filter; "All" excludes archive; "Archive" shows only expired/revoked
+- Type column shows `Signing` or `Invoice` tag
+- No doc_share rows visible
+- Dates use tabular figures
+
+### Step 2.3: Commit
+
+```bash
+git add src/components/external-signing/InviteTable.tsx
+git commit -m "feat(invites): add search, status chips, and type tag to sent-invites table
+
+- Client-side search on recipient_email
+- Status filter chips (All/Pending/Verified/Signed/Archive)
+- New Type column distinguishes Signing vs Invoice rows
+- Excludes doc_share rows (handled in /docs)
+- Tabular numerals on dates, scale-on-press on chip/action buttons
+- Extended hit areas on row action icons via pseudo-element"
+```
+
+---
+
+## Task 3: Debounce search input
+
+**Files:**
+- Modify: `src/components/external-signing/InviteTable.tsx`
+
+### Step 3.1: Add debounced search state
+
+Below `const [search, setSearch] = useState('');` add:
+
+```tsx
+const [debouncedSearch, setDebouncedSearch] = useState('');
+useEffect(() => {
+  const t = setTimeout(() => setDebouncedSearch(search), 150);
+  return () => clearTimeout(t);
+}, [search]);
+```
+
+Change the `filterBySearch` call to use `debouncedSearch` instead of `search`.
+
+### Step 3.2: Verify typing feels snappy, no layout thrash
+
+Run dev server, type quickly in the search box. Rows should only re-filter after 150ms of no typing.
+
+### Step 3.3: Commit
+
+```bash
+git add src/components/external-signing/InviteTable.tsx
+git commit -m "perf(invites): debounce search input by 150ms"
+```
+
+---
+
+## Task 4: Add row enter/exit motion with stagger
+
+**Files:**
+- Modify: `src/components/external-signing/InviteTable.tsx`
+
+### Step 4.1: Replace `<tbody>` rows with `motion.tr` inside `AnimatePresence`
+
+Add imports:
+
+```tsx
+import { AnimatePresence, motion } from 'motion/react';
+```
+
+Wrap the `.map()` in `<AnimatePresence initial={false} mode="popLayout">` and change each `<tr>` to `<motion.tr>` with:
+
+```tsx
+<motion.tr
+  key={invite.id}
+  layout
+  initial={{ opacity: 0, y: 8, scale: 0.98 }}
+  animate={{ opacity: 1, y: 0, scale: 1 }}
+  exit={{ opacity: 0, y: -4 }}
+  transition={{ type: 'spring', duration: 0.3, bounce: 0, delay: index * 0.03 }}
+  className="border-b border-border/50 transition-[background-color] hover:bg-muted/20"
+>
+```
+
+Change the map signature to `{filtered.map((invite, index) => {`. Cap the stagger delay for larger lists: `delay: Math.min(index, 10) * 0.03`.
+
+### Step 4.2: Verify interruptible animation
+
+Run dev server. Click filter chips rapidly. Rows should smoothly interrupt and restart without queueing.
+
+### Step 4.3: Commit
+
+```bash
+git add src/components/external-signing/InviteTable.tsx
+git commit -m "feat(invites): animate row transitions with staggered spring motion
+
+- AnimatePresence with initial={false} to skip on page-load
+- Spring (bounce: 0) for enter, subtle y:-4 exit
+- 30ms stagger capped at 10 rows to keep filter changes snappy"
+```
+
+---
+
+## Task 5: Add recipient grouping toggle
+
+**Files:**
+- Modify: `src/components/external-signing/InviteTable.tsx`
+
+### Step 5.1: Add group state + toggle button
+
+Under the search input, add a group toggle button. Add state:
+
+```tsx
+const [grouped, setGrouped] = useState(false);
+```
+
+In the header, right after the search input, add:
+
+```tsx
+<button
+  onClick={() => setGrouped(g => !g)}
+  title={grouped ? 'Ungroup' : 'Group by recipient'}
+  className={`flex size-8 items-center justify-center rounded-md border transition-[background-color,color,border-color,transform] active:scale-[0.96] ${
+    grouped ? 'border-seeko-accent/40 bg-seeko-accent/10 text-seeko-accent' : 'border-border bg-muted/20 text-muted-foreground hover:text-foreground'
+  }`}
+>
+  <Users className="size-3.5" />
+</button>
+```
+
+Wrap the search + toggle in a `<div className="flex items-center gap-2">`.
+
+### Step 5.2: Add grouped rendering
+
+Import `groupByRecipient` and `InviteGroup` from `@/lib/invite-filters`.
+
+Add a `groupedData` memo:
+
+```tsx
+const groupedData = useMemo(() => grouped ? groupByRecipient(filtered) : null, [grouped, filtered]);
+const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
+```
+
+When `groupedData` exists, render parent rows with expand chevrons + child rows inside `AnimatePresence`. Each parent row shows:
+- Recipient email
+- Count badge: `{group.invites.length} invites`
+- Status of the most recent invite
+- Chevron that rotates 90° when expanded
+
+Toggle expansion:
+
+```tsx
+function toggleGroup(email: string) {
+  setExpandedGroups(prev => {
+    const next = new Set(prev);
+    if (next.has(email)) next.delete(email); else next.add(email);
+    return next;
+  });
+}
+```
+
+Implementation (conditional tbody):
+
+```tsx
+{groupedData ? (
+  groupedData.map(group => (
+    <GroupRow
+      key={group.email}
+      group={group}
+      expanded={expandedGroups.has(group.email)}
+      onToggle={() => toggleGroup(group.email)}
+      renderRow={(inv, i) => /* same row render as flat path */}
+    />
+  ))
+) : (
+  filtered.map((invite, index) => /* same row render */)
+)}
+```
+
+Extract the row render into a reusable `renderInviteRow(invite, index, { handleAction, handleDownload, actionLoading })` helper inside the component file.
+
+### Step 5.3: Verify grouping works
+
+Run dev. Click the group button. Rows collapse by email. Click chevron to expand a group.
+
+### Step 5.4: Commit
+
+```bash
+git add src/components/external-signing/InviteTable.tsx
+git commit -m "feat(invites): add recipient grouping toggle with expand/collapse"
+```
+
+---
+
+## Task 6: Add archive footer link
+
+**Files:**
+- Modify: `src/components/external-signing/InviteTable.tsx`
+
+### Step 6.1: Compute archive count + render footer link
+
+After the table, when `status !== 'archive'`, compute and render:
+
+```tsx
+const archiveCount = useMemo(
+  () => filterByStatus(filterBySearch(signingInvites, debouncedSearch), 'archive').length,
+  [signingInvites, debouncedSearch],
+);
+const [showArchive, setShowArchive] = useState(false);
+
+// after the table:
+{status !== 'archive' && archiveCount > 0 && (
+  <button
+    onClick={() => setShowArchive(s => !s)}
+    className="flex w-full items-center justify-center gap-1.5 rounded-lg py-2 text-xs text-muted-foreground hover:text-foreground transition-[color]"
+  >
+    {showArchive ? 'Hide archived' : `Show archived (${archiveCount})`}
+  </button>
+)}
+```
+
+When `showArchive` is true, render a second table (or second `<tbody>`) with the archive rows using the same row renderer, visually muted (`opacity-60`).
+
+### Step 6.2: Verify archive reveal
+
+Run dev. The footer appears when there are archived items. Clicking expands them inline.
+
+### Step 6.3: Commit
+
+```bash
+git add src/components/external-signing/InviteTable.tsx
+git commit -m "feat(invites): add inline archive expand footer"
+```
+
+---
+
+## Task 7: Run critique + visual QA
+
+**Step 7.1:** Take a screenshot of the finished table at `/admin/external-signing`.
+
+**Step 7.2:** Invoke `/interface-craft critique` with the screenshot. Address any P0/P1 findings.
+
+**Step 7.3:** Verify the craft checklist:
+- [ ] Concentric radius (card → table → badges)
+- [ ] Tabular numerals on dates
+- [ ] Scale-on-press on chips + action buttons
+- [ ] 40×40 hit areas on action icons
+- [ ] No `transition: all`
+- [ ] `initial={false}` on AnimatePresence
+- [ ] Search debounced
+- [ ] doc_share excluded
+- [ ] Archive hidden by default
+- [ ] Group toggle works
+
+**Step 7.4:** Commit any craft fixes.
+
+```bash
+git add -u && git commit -m "polish(invites): craft fixes from critique pass"
+```
+
+---
+
+## Task 8: Verification
+
+**Step 8.1:** Run tests
+`cd /Volumes/CODEUSER/seeko-studio && npx vitest run src/lib/__tests__/invite-filters.test.ts`
+Expected: all pass
+
+**Step 8.2:** Run typecheck
+`npx tsc --noEmit`
+Expected: no errors
+
+**Step 8.3:** Run lint (if configured)
+`npm run lint`
+Expected: no errors introduced
+
+**Step 8.4:** Manual acceptance
+- Search finds a recipient by partial email
+- Each status chip shows the expected subset
+- "All" excludes archive; "Archive" shows only expired/revoked
+- Group toggle collapses correctly; expand chevrons work
+- Archive footer appears when applicable; click expands inline
+- Row actions (resend/revoke/download) still work
+- No doc_share rows visible
+- Filter changes feel instant, animations interruptible
+
+---
+
+## Summary
+
+- **8 tasks**, each committable independently
+- **13 TDD tests** covering all filter/group/sort logic
+- **Single-file rewrite** for `InviteTable.tsx`; no API, schema, or route changes
+- **Craft checklist** enforced via critique pass in Task 7

--- a/src/components/external-signing/InviteTable.tsx
+++ b/src/components/external-signing/InviteTable.tsx
@@ -330,25 +330,20 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
                       animate={{ opacity: 1, y: 0 }}
                       exit={{ opacity: 0, transition: { duration: 0.12 } }}
                       transition={{ type: 'spring', duration: 0.3, bounce: 0, delay: Math.min(gIndex, 10) * 0.03 }}
-                      onClick={() => toggleGroup(group.email)}
-                      tabIndex={0}
-                      role="button"
-                      aria-expanded={expanded}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                          e.preventDefault();
-                          toggleGroup(group.email);
-                        }
-                      }}
-                      className="border-b border-border/50 cursor-pointer transition-[background-color] hover:bg-muted/20 focus-visible:outline-none focus-visible:bg-muted/30"
+                      className="border-b border-border/50 transition-[background-color] hover:bg-muted/20"
                     >
                       <td className="px-4 py-3 text-foreground font-mono text-xs">
-                        <div className="flex items-center gap-2">
+                        <button
+                          type="button"
+                          aria-expanded={expanded}
+                          onClick={() => toggleGroup(group.email)}
+                          className="flex items-center gap-2 rounded-sm focus-visible:outline-none focus-visible:bg-muted/30"
+                        >
                           <ChevronRight
                             className={`size-3.5 text-muted-foreground transition-transform ${expanded ? 'rotate-90' : ''}`}
                           />
                           {group.email}
-                        </div>
+                        </button>
                       </td>
                       <td className="px-4 py-3" colSpan={2}>
                         <span className="text-xs text-muted-foreground tabular-nums">

--- a/src/components/external-signing/InviteTable.tsx
+++ b/src/components/external-signing/InviteTable.tsx
@@ -132,10 +132,9 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
     return (
       <motion.tr
         key={invite.id}
-        layout
-        initial={{ opacity: 0, y: 8, scale: 0.98 }}
-        animate={{ opacity: 1, y: 0, scale: 1 }}
-        exit={{ opacity: 0, y: -4 }}
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0 }}
         transition={{ type: 'spring', duration: 0.3, bounce: 0, delay: Math.min(index, 10) * 0.03 }}
         className="border-b border-border/50 transition-[background-color] hover:bg-muted/20"
       >
@@ -281,7 +280,7 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
             </tr>
           </thead>
           <tbody>
-            <AnimatePresence initial={false} mode="popLayout">
+            <AnimatePresence initial={false}>
             {(() => {
               if (groupedData) {
                 return groupedData.flatMap((group, gIndex) => {
@@ -290,10 +289,9 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
                   const rows = [
                     <motion.tr
                       key={`group-${group.email}`}
-                      layout
-                      initial={{ opacity: 0, y: 8, scale: 0.98 }}
-                      animate={{ opacity: 1, y: 0, scale: 1 }}
-                      exit={{ opacity: 0, y: -4 }}
+                      initial={{ opacity: 0, y: 8 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      exit={{ opacity: 0 }}
                       transition={{ type: 'spring', duration: 0.3, bounce: 0, delay: Math.min(gIndex, 10) * 0.03 }}
                       onClick={() => toggleGroup(group.email)}
                       tabIndex={0}
@@ -366,7 +364,7 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
                 <div className="overflow-x-auto rounded-xl border border-border opacity-60">
                   <table className="w-full text-left text-sm">
                     <tbody>
-                      <AnimatePresence initial={false} mode="popLayout">
+                      <AnimatePresence initial={false}>
                         {archiveInvites.map((invite, index) => renderInviteRow(invite, index))}
                       </AnimatePresence>
                     </tbody>

--- a/src/components/external-signing/InviteTable.tsx
+++ b/src/components/external-signing/InviteTable.tsx
@@ -288,7 +288,16 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
                       exit={{ opacity: 0, y: -4 }}
                       transition={{ type: 'spring', duration: 0.3, bounce: 0, delay: Math.min(gIndex, 10) * 0.03 }}
                       onClick={() => toggleGroup(group.email)}
-                      className="border-b border-border/50 cursor-pointer transition-[background-color] hover:bg-muted/20"
+                      tabIndex={0}
+                      role="button"
+                      aria-expanded={expanded}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          toggleGroup(group.email);
+                        }
+                      }}
+                      className="border-b border-border/50 cursor-pointer transition-[background-color] hover:bg-muted/20 focus-visible:outline-none focus-visible:bg-muted/30"
                     >
                       <td className="px-4 py-3 text-foreground font-mono text-xs">
                         <div className="flex items-center gap-2">

--- a/src/components/external-signing/InviteTable.tsx
+++ b/src/components/external-signing/InviteTable.tsx
@@ -271,6 +271,8 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
           </div>
           <button
             onClick={() => setGrouped(g => !g)}
+            aria-label={grouped ? 'Ungroup recipients' : 'Group by recipient'}
+            aria-pressed={grouped}
             title={grouped ? 'Ungroup' : 'Group by recipient'}
             className={`relative flex size-8 items-center justify-center rounded-md border transition-[background-color,color,border-color,transform] active:scale-[0.96] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-seeko-accent/40 before:absolute before:inset-0 before:-m-1 before:content-[''] ${
               grouped

--- a/src/components/external-signing/InviteTable.tsx
+++ b/src/components/external-signing/InviteTable.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState, useCallback, useMemo } from 'react';
 import { AnimatePresence, motion } from 'motion/react';
 import { createClient } from '@/lib/supabase/client';
 import { RotateCw, Ban, Download, Loader2, Send, Search, Users, ChevronRight } from 'lucide-react';
-import { Badge } from '@/components/ui/badge';
 import { toast } from 'sonner';
 import type { ExternalSigningInvite } from '@/lib/types';
 import {
@@ -19,12 +18,14 @@ import {
 
 interface InviteTableProps { refreshKey: number; }
 
-const STATUS_VARIANT: Record<string, 'default' | 'secondary' | 'outline' | 'destructive'> = {
-  pending: 'outline',
-  verified: 'secondary',
-  signed: 'default',
-  expired: 'secondary',
-  revoked: 'destructive',
+// Solid variants for statuses that need attention; outline/muted for completed.
+// Pending is the loudest because it blocks an external party; signed is quiet because it's done.
+const STATUS_CLASSES: Record<string, string> = {
+  pending: 'bg-seeko-accent/15 text-seeko-accent ring-1 ring-inset ring-seeko-accent/30',
+  verified: 'bg-blue-400/15 text-blue-300 ring-1 ring-inset ring-blue-400/30',
+  signed: 'border border-border text-muted-foreground',
+  expired: 'border border-border text-muted-foreground',
+  revoked: 'bg-red-400/15 text-red-300 ring-1 ring-inset ring-red-400/30',
 };
 
 const STATUS_CHIPS: { value: FilterStatus; label: string }[] = [
@@ -35,12 +36,32 @@ const STATUS_CHIPS: { value: FilterStatus; label: string }[] = [
   { value: 'archive', label: 'Archive' },
 ];
 
-function getTypeTag(invite: ExternalSigningInvite): { label: string; doc: string } {
-  const type = invite.template_type as string;
-  if (type === 'invoice') return { label: 'Invoice', doc: invite.custom_title || 'Invoice request' };
-  if (type === 'preset') return { label: 'Signing', doc: invite.template_id || 'Preset' };
-  return { label: 'Signing', doc: invite.custom_title || 'Custom' };
+// Humanize DB-style template ids like "vendor_agreement" → "Vendor Agreement".
+function humanizeDoc(raw: string): string {
+  return raw
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+    .replace(/\bNda\b/g, 'NDA')
+    .replace(/\bPdf\b/g, 'PDF');
 }
+
+type TypeTag = { label: 'Signing' | 'Invoice'; doc: string; tone: 'signing' | 'invoice' };
+
+function getTypeTag(invite: ExternalSigningInvite): TypeTag {
+  const type = invite.template_type as string;
+  if (type === 'invoice') {
+    // Custom titles carry signal; the default "Invoice request" label repeats the Type tag — elide it.
+    const custom = invite.custom_title?.trim();
+    return { label: 'Invoice', doc: custom || '—', tone: 'invoice' };
+  }
+  if (type === 'preset') return { label: 'Signing', doc: humanizeDoc(invite.template_id || 'Preset'), tone: 'signing' };
+  return { label: 'Signing', doc: invite.custom_title || 'Custom', tone: 'signing' };
+}
+
+const TYPE_TAG_CLASSES: Record<'signing' | 'invoice', string> = {
+  signing: 'bg-muted/40 text-muted-foreground',
+  invoice: 'bg-amber-400/8 text-amber-300/80 ring-1 ring-inset ring-amber-400/15',
+};
 
 export function InviteTable({ refreshKey }: InviteTableProps) {
   const [invites, setInvites] = useState<ExternalSigningInvite[]>([]);
@@ -128,7 +149,7 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
   }, [signingInvites, debouncedSearch]);
 
   const renderInviteRow = (invite: ExternalSigningInvite, index: number, indent: boolean = false) => {
-    const { label: typeLabel, doc } = getTypeTag(invite);
+    const { label: typeLabel, doc, tone } = getTypeTag(invite);
     return (
       <motion.tr
         key={invite.id}
@@ -139,28 +160,39 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
         transition={{ type: 'spring', duration: 0.3, bounce: 0, delay: Math.min(index, 10) * 0.03 }}
         className="border-b border-border/50 transition-[background-color] hover:bg-muted/20"
       >
-        <td className={`px-4 py-3 text-foreground font-mono text-xs ${indent ? 'pl-10' : ''}`}>
-          {invite.recipient_email}
-          {invite.is_guardian_signing && (
-            <Badge variant="outline" className="ml-2 text-[10px]">Guardian</Badge>
-          )}
+        <td className={`px-4 py-3 align-middle text-foreground font-mono text-xs ${indent ? 'pl-10' : ''}`}>
+          <div className="flex items-center gap-2 max-w-[240px]">
+            <span className="truncate" title={invite.recipient_email}>{invite.recipient_email}</span>
+            {invite.is_guardian_signing && (
+              <span
+                title="Guardian signing for a minor"
+                className="shrink-0 inline-flex items-center rounded-full bg-muted/40 px-1.5 py-0.5 text-[9px] font-medium text-muted-foreground"
+              >
+                Guardian
+              </span>
+            )}
+          </div>
         </td>
-        <td className="px-4 py-3">
-          <span className="rounded-full bg-muted/40 px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+        <td className="px-4 py-3 align-middle">
+          <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium ${TYPE_TAG_CLASSES[tone]}`}>
             {typeLabel}
           </span>
         </td>
-        <td className="px-4 py-3 text-muted-foreground text-xs text-pretty">{doc}</td>
-        <td className="px-4 py-3">
-          <Badge variant={STATUS_VARIANT[invite.status] || 'secondary'}>{invite.status}</Badge>
+        <td className="px-4 py-3 align-middle text-muted-foreground text-xs">
+          <span className="block max-w-[160px] truncate" title={doc}>{doc}</span>
         </td>
-        <td className="px-4 py-3 text-muted-foreground text-xs tabular-nums">
+        <td className="px-4 py-3 align-middle">
+          <span className={`inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium ${STATUS_CLASSES[invite.status] || 'border border-border text-muted-foreground'}`}>
+            {invite.status}
+          </span>
+        </td>
+        <td className="px-4 py-3 align-middle text-muted-foreground text-xs tabular-nums">
           {new Date(invite.created_at).toLocaleDateString()}
         </td>
-        <td className="px-4 py-3 text-muted-foreground text-xs tabular-nums">
+        <td className="px-4 py-3 align-middle text-muted-foreground text-xs tabular-nums">
           {new Date(invite.expires_at).toLocaleDateString()}
         </td>
-        <td className="px-4 py-3">
+        <td className="px-4 py-3 align-middle">
           <div className="flex gap-1">
             {(invite.status === 'pending' || invite.status === 'verified') && (
               <>
@@ -321,7 +353,7 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
                         </span>
                       </td>
                       <td className="px-4 py-3">
-                        <Badge variant={STATUS_VARIANT[latest.status] || 'secondary'}>{latest.status}</Badge>
+                        <span className={`inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium ${STATUS_CLASSES[latest.status] || 'border border-border text-muted-foreground'}`}>{latest.status}</span>
                       </td>
                       <td className="px-4 py-3 text-muted-foreground text-xs tabular-nums">
                         {new Date(latest.created_at).toLocaleDateString()}

--- a/src/components/external-signing/InviteTable.tsx
+++ b/src/components/external-signing/InviteTable.tsx
@@ -132,9 +132,10 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
     return (
       <motion.tr
         key={invite.id}
+        layout
         initial={{ opacity: 0, y: 8 }}
         animate={{ opacity: 1, y: 0 }}
-        exit={{ opacity: 0 }}
+        exit={{ opacity: 0, transition: { duration: 0.12 } }}
         transition={{ type: 'spring', duration: 0.3, bounce: 0, delay: Math.min(index, 10) * 0.03 }}
         className="border-b border-border/50 transition-[background-color] hover:bg-muted/20"
       >
@@ -289,9 +290,10 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
                   const rows = [
                     <motion.tr
                       key={`group-${group.email}`}
+                      layout
                       initial={{ opacity: 0, y: 8 }}
                       animate={{ opacity: 1, y: 0 }}
-                      exit={{ opacity: 0 }}
+                      exit={{ opacity: 0, transition: { duration: 0.12 } }}
                       transition={{ type: 'spring', duration: 0.3, bounce: 0, delay: Math.min(gIndex, 10) * 0.03 }}
                       onClick={() => toggleGroup(group.email)}
                       tabIndex={0}

--- a/src/components/external-signing/InviteTable.tsx
+++ b/src/components/external-signing/InviteTable.tsx
@@ -262,6 +262,7 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
               type="text"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
+              aria-label="Search recipient"
               placeholder="Search recipient…"
               className="h-8 w-full rounded-md border border-border bg-muted/20 pl-8 pr-3 text-xs text-foreground placeholder:text-muted-foreground/60 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-seeko-accent/40 focus:outline-none"
             />

--- a/src/components/external-signing/InviteTable.tsx
+++ b/src/components/external-signing/InviteTable.tsx
@@ -46,15 +46,17 @@ function humanizeDoc(raw: string): string {
 }
 
 type TypeTag = { label: 'Signing' | 'Invoice'; doc: string; tone: 'signing' | 'invoice' };
+type InviteTableInvite = Omit<ExternalSigningInvite, 'template_type'> & {
+  template_type: ExternalSigningInvite['template_type'] | 'invoice';
+};
 
-function getTypeTag(invite: ExternalSigningInvite): TypeTag {
-  const type = invite.template_type as string;
-  if (type === 'invoice') {
+function getTypeTag(invite: InviteTableInvite): TypeTag {
+  if (invite.template_type === 'invoice') {
     // Custom titles carry signal; the default "Invoice request" label repeats the Type tag — elide it.
     const custom = invite.custom_title?.trim();
     return { label: 'Invoice', doc: custom || '—', tone: 'invoice' };
   }
-  if (type === 'preset') return { label: 'Signing', doc: humanizeDoc(invite.template_id || 'Preset'), tone: 'signing' };
+  if (invite.template_type === 'preset') return { label: 'Signing', doc: humanizeDoc(invite.template_id || 'Preset'), tone: 'signing' };
   return { label: 'Signing', doc: invite.custom_title || 'Custom', tone: 'signing' };
 }
 

--- a/src/components/external-signing/InviteTable.tsx
+++ b/src/components/external-signing/InviteTable.tsx
@@ -44,6 +44,11 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
   const [loading, setLoading] = useState(true);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedSearch(search), 150);
+    return () => clearTimeout(t);
+  }, [search]);
   const [status, setStatus] = useState<FilterStatus>('all');
 
   const fetchInvites = useCallback(async () => {
@@ -93,9 +98,9 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
   const signingInvites = useMemo(() => excludeDocShare(invites), [invites]);
   const filtered = useMemo(() => {
     const byStatus = filterByStatus(signingInvites, status);
-    const bySearch = filterBySearch(byStatus, search);
+    const bySearch = filterBySearch(byStatus, debouncedSearch);
     return status === 'all' ? sortByActivePriority(bySearch) : bySearch;
-  }, [signingInvites, status, search]);
+  }, [signingInvites, status, debouncedSearch]);
 
   if (loading) {
     return <div className="flex justify-center py-12"><Loader2 className="size-5 animate-spin text-muted-foreground" /></div>;

--- a/src/components/external-signing/InviteTable.tsx
+++ b/src/components/external-signing/InviteTable.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState, useCallback, useMemo } from 'react';
+import { AnimatePresence, motion } from 'motion/react';
 import { createClient } from '@/lib/supabase/client';
 import { RotateCw, Ban, Download, Loader2, Send, Search } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
@@ -172,10 +173,19 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
             </tr>
           </thead>
           <tbody>
-            {filtered.map((invite) => {
+            <AnimatePresence initial={false} mode="popLayout">
+            {filtered.map((invite, index) => {
               const { label: typeLabel, doc } = getTypeTag(invite);
               return (
-                <tr key={invite.id} className="border-b border-border/50 transition-[background-color] hover:bg-muted/20">
+                <motion.tr
+                  key={invite.id}
+                  layout
+                  initial={{ opacity: 0, y: 8, scale: 0.98 }}
+                  animate={{ opacity: 1, y: 0, scale: 1 }}
+                  exit={{ opacity: 0, y: -4 }}
+                  transition={{ type: 'spring', duration: 0.3, bounce: 0, delay: Math.min(index, 10) * 0.03 }}
+                  className="border-b border-border/50 transition-[background-color] hover:bg-muted/20"
+                >
                   <td className="px-4 py-3 text-foreground font-mono text-xs">
                     {invite.recipient_email}
                     {invite.is_guardian_signing && (
@@ -231,9 +241,10 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
                       )}
                     </div>
                   </td>
-                </tr>
+                </motion.tr>
               );
             })}
+            </AnimatePresence>
           </tbody>
         </table>
       </div>

--- a/src/components/external-signing/InviteTable.tsx
+++ b/src/components/external-signing/InviteTable.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useCallback, useMemo } from 'react';
 import { AnimatePresence, motion } from 'motion/react';
 import { createClient } from '@/lib/supabase/client';
-import { RotateCw, Ban, Download, Loader2, Send, Search } from 'lucide-react';
+import { RotateCw, Ban, Download, Loader2, Send, Search, Users, ChevronRight } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { toast } from 'sonner';
 import type { ExternalSigningInvite } from '@/lib/types';
@@ -12,7 +12,9 @@ import {
   filterBySearch,
   excludeDocShare,
   sortByActivePriority,
+  groupByRecipient,
   type FilterStatus,
+  type InviteGroup,
 } from '@/lib/invite-filters';
 
 interface InviteTableProps { refreshKey: number; }
@@ -51,6 +53,16 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
     return () => clearTimeout(t);
   }, [search]);
   const [status, setStatus] = useState<FilterStatus>('all');
+  const [grouped, setGrouped] = useState(false);
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
+
+  function toggleGroup(email: string) {
+    setExpandedGroups(prev => {
+      const next = new Set(prev);
+      if (next.has(email)) next.delete(email); else next.add(email);
+      return next;
+    });
+  }
 
   const fetchInvites = useCallback(async () => {
     setLoading(true);
@@ -103,6 +115,11 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
     return status === 'all' ? sortByActivePriority(bySearch) : bySearch;
   }, [signingInvites, status, debouncedSearch]);
 
+  const groupedData = useMemo<InviteGroup[] | null>(
+    () => (grouped ? groupByRecipient(filtered) : null),
+    [grouped, filtered],
+  );
+
   if (loading) {
     return <div className="flex justify-center py-12"><Loader2 className="size-5 animate-spin text-muted-foreground" /></div>;
   }
@@ -128,15 +145,28 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
           Sent Invites
           <span className="ml-2 text-xs text-muted-foreground/60 tabular-nums">({filtered.length})</span>
         </h2>
-        <div className="relative w-64">
-          <Search className="absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground/60" />
-          <input
-            type="text"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder="Search recipient…"
-            className="h-8 w-full rounded-md border border-border bg-muted/20 pl-8 pr-3 text-xs text-foreground placeholder:text-muted-foreground/60 focus:outline-none focus:ring-1 focus:ring-seeko-accent/40"
-          />
+        <div className="flex items-center gap-2">
+          <div className="relative w-64">
+            <Search className="absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground/60" />
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search recipient…"
+              className="h-8 w-full rounded-md border border-border bg-muted/20 pl-8 pr-3 text-xs text-foreground placeholder:text-muted-foreground/60 focus:outline-none focus:ring-1 focus:ring-seeko-accent/40"
+            />
+          </div>
+          <button
+            onClick={() => setGrouped(g => !g)}
+            title={grouped ? 'Ungroup' : 'Group by recipient'}
+            className={`flex size-8 items-center justify-center rounded-md border transition-[background-color,color,border-color,transform] active:scale-[0.96] ${
+              grouped
+                ? 'border-seeko-accent/40 bg-seeko-accent/10 text-seeko-accent'
+                : 'border-border bg-muted/20 text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            <Users className="size-3.5" />
+          </button>
         </div>
       </div>
 
@@ -174,9 +204,10 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
           </thead>
           <tbody>
             <AnimatePresence initial={false} mode="popLayout">
-            {filtered.map((invite, index) => {
-              const { label: typeLabel, doc } = getTypeTag(invite);
-              return (
+            {(() => {
+              const renderInviteRow = (invite: ExternalSigningInvite, index: number, indent: boolean = false) => {
+                const { label: typeLabel, doc } = getTypeTag(invite);
+                return (
                 <motion.tr
                   key={invite.id}
                   layout
@@ -186,7 +217,7 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
                   transition={{ type: 'spring', duration: 0.3, bounce: 0, delay: Math.min(index, 10) * 0.03 }}
                   className="border-b border-border/50 transition-[background-color] hover:bg-muted/20"
                 >
-                  <td className="px-4 py-3 text-foreground font-mono text-xs">
+                  <td className={`px-4 py-3 text-foreground font-mono text-xs ${indent ? 'pl-10' : ''}`}>
                     {invite.recipient_email}
                     {invite.is_guardian_signing && (
                       <Badge variant="outline" className="ml-2 text-[10px]">Guardian</Badge>
@@ -242,8 +273,56 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
                     </div>
                   </td>
                 </motion.tr>
-              );
-            })}
+                );
+              };
+              if (groupedData) {
+                return groupedData.flatMap((group, gIndex) => {
+                  const expanded = expandedGroups.has(group.email);
+                  const latest = group.invites[0];
+                  const rows = [
+                    <motion.tr
+                      key={`group-${group.email}`}
+                      layout
+                      initial={{ opacity: 0, y: 8, scale: 0.98 }}
+                      animate={{ opacity: 1, y: 0, scale: 1 }}
+                      exit={{ opacity: 0, y: -4 }}
+                      transition={{ type: 'spring', duration: 0.3, bounce: 0, delay: Math.min(gIndex, 10) * 0.03 }}
+                      onClick={() => toggleGroup(group.email)}
+                      className="border-b border-border/50 cursor-pointer transition-[background-color] hover:bg-muted/20"
+                    >
+                      <td className="px-4 py-3 text-foreground font-mono text-xs">
+                        <div className="flex items-center gap-2">
+                          <ChevronRight
+                            className={`size-3.5 text-muted-foreground transition-transform ${expanded ? 'rotate-90' : ''}`}
+                          />
+                          {group.email}
+                        </div>
+                      </td>
+                      <td className="px-4 py-3" colSpan={2}>
+                        <span className="text-xs text-muted-foreground tabular-nums">
+                          {group.invites.length} {group.invites.length === 1 ? 'invite' : 'invites'}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <Badge variant={STATUS_VARIANT[latest.status] || 'secondary'}>{latest.status}</Badge>
+                      </td>
+                      <td className="px-4 py-3 text-muted-foreground text-xs tabular-nums">
+                        {new Date(latest.created_at).toLocaleDateString()}
+                      </td>
+                      <td className="px-4 py-3 text-muted-foreground text-xs tabular-nums">
+                        {new Date(latest.expires_at).toLocaleDateString()}
+                      </td>
+                      <td className="px-4 py-3" />
+                    </motion.tr>,
+                  ];
+                  if (expanded) {
+                    group.invites.forEach((inv, i) => rows.push(renderInviteRow(inv, i, true)));
+                  }
+                  return rows;
+                });
+              }
+              return filtered.map((invite, index) => renderInviteRow(invite, index));
+            })()}
             </AnimatePresence>
           </tbody>
         </table>

--- a/src/components/external-signing/InviteTable.tsx
+++ b/src/components/external-signing/InviteTable.tsx
@@ -150,7 +150,7 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
             {typeLabel}
           </span>
         </td>
-        <td className="px-4 py-3 text-muted-foreground text-xs" style={{ textWrap: 'pretty' }}>{doc}</td>
+        <td className="px-4 py-3 text-muted-foreground text-xs text-pretty">{doc}</td>
         <td className="px-4 py-3">
           <Badge variant={STATUS_VARIANT[invite.status] || 'secondary'}>{invite.status}</Badge>
         </td>
@@ -231,13 +231,13 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder="Search recipient…"
-              className="h-8 w-full rounded-md border border-border bg-muted/20 pl-8 pr-3 text-xs text-foreground placeholder:text-muted-foreground/60 focus:outline-none focus:ring-1 focus:ring-seeko-accent/40"
+              className="h-8 w-full rounded-md border border-border bg-muted/20 pl-8 pr-3 text-xs text-foreground placeholder:text-muted-foreground/60 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-seeko-accent/40 focus:outline-none"
             />
           </div>
           <button
             onClick={() => setGrouped(g => !g)}
             title={grouped ? 'Ungroup' : 'Group by recipient'}
-            className={`flex size-8 items-center justify-center rounded-md border transition-[background-color,color,border-color,transform] active:scale-[0.96] ${
+            className={`relative flex size-8 items-center justify-center rounded-md border transition-[background-color,color,border-color,transform] active:scale-[0.96] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-seeko-accent/40 before:absolute before:inset-0 before:-m-1 before:content-[''] ${
               grouped
                 ? 'border-seeko-accent/40 bg-seeko-accent/10 text-seeko-accent'
                 : 'border-border bg-muted/20 text-muted-foreground hover:text-foreground'
@@ -255,7 +255,7 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
             <button
               key={chip.value}
               onClick={() => setStatus(chip.value)}
-              className={`rounded-full px-3 py-1 text-xs font-medium transition-[background-color,color,transform] active:scale-[0.96] ${
+              className={`rounded-full px-3 py-1 text-xs font-medium transition-[background-color,color,transform] active:scale-[0.96] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-seeko-accent/40 ${
                 active
                   ? 'bg-foreground text-background'
                   : 'bg-muted/40 text-muted-foreground hover:bg-muted/70 hover:text-foreground'

--- a/src/components/external-signing/InviteTable.tsx
+++ b/src/components/external-signing/InviteTable.tsx
@@ -1,15 +1,20 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useMemo } from 'react';
 import { createClient } from '@/lib/supabase/client';
-import { RotateCw, Ban, Download, Loader2, Send } from 'lucide-react';
+import { RotateCw, Ban, Download, Loader2, Send, Search } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { toast } from 'sonner';
 import type { ExternalSigningInvite } from '@/lib/types';
+import {
+  filterByStatus,
+  filterBySearch,
+  excludeDocShare,
+  sortByActivePriority,
+  type FilterStatus,
+} from '@/lib/invite-filters';
 
-interface InviteTableProps {
-  refreshKey: number;
-}
+interface InviteTableProps { refreshKey: number; }
 
 const STATUS_VARIANT: Record<string, 'default' | 'secondary' | 'outline' | 'destructive'> = {
   pending: 'outline',
@@ -19,10 +24,27 @@ const STATUS_VARIANT: Record<string, 'default' | 'secondary' | 'outline' | 'dest
   revoked: 'destructive',
 };
 
+const STATUS_CHIPS: { value: FilterStatus; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'pending', label: 'Pending' },
+  { value: 'verified', label: 'Verified' },
+  { value: 'signed', label: 'Signed' },
+  { value: 'archive', label: 'Archive' },
+];
+
+function getTypeTag(invite: ExternalSigningInvite): { label: string; doc: string } {
+  const type = invite.template_type as string;
+  if (type === 'invoice') return { label: 'Invoice', doc: invite.custom_title || 'Invoice request' };
+  if (type === 'preset') return { label: 'Signing', doc: invite.template_id || 'Preset' };
+  return { label: 'Signing', doc: invite.custom_title || 'Custom' };
+}
+
 export function InviteTable({ refreshKey }: InviteTableProps) {
   const [invites, setInvites] = useState<ExternalSigningInvite[]>([]);
   const [loading, setLoading] = useState(true);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [status, setStatus] = useState<FilterStatus>('all');
 
   const fetchInvites = useCallback(async () => {
     setLoading(true);
@@ -45,49 +67,41 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ invite_id: inviteId }),
       });
-      if (!res.ok) {
-        const data = await res.json();
-        throw new Error(data.error);
-      }
+      if (!res.ok) { const data = await res.json(); throw new Error(data.error); }
       toast.success(action === 'revoke' ? 'Invite revoked' : 'Invite resent');
       fetchInvites();
     } catch (err: unknown) {
       toast.error(err instanceof Error ? err.message : `Failed to ${action}`);
-    } finally {
-      setActionLoading(null);
-    }
+    } finally { setActionLoading(null); }
   }
 
   async function handleDownload(inviteId: string) {
     setActionLoading(inviteId);
     try {
       const supabase = createClient();
-      const { data, error } = await supabase.storage
-        .from('agreements')
-        .download(`external/${inviteId}/agreement.pdf`);
+      const { data, error } = await supabase.storage.from('agreements').download(`external/${inviteId}/agreement.pdf`);
       if (error || !data) throw new Error('Failed to download');
       const url = URL.createObjectURL(data);
       const a = document.createElement('a');
-      a.href = url;
-      a.download = `agreement-${inviteId}.pdf`;
-      a.click();
+      a.href = url; a.download = `agreement-${inviteId}.pdf`; a.click();
       URL.revokeObjectURL(url);
     } catch (err: unknown) {
       toast.error(err instanceof Error ? err.message : 'Download failed');
-    } finally {
-      setActionLoading(null);
-    }
+    } finally { setActionLoading(null); }
   }
+
+  const signingInvites = useMemo(() => excludeDocShare(invites), [invites]);
+  const filtered = useMemo(() => {
+    const byStatus = filterByStatus(signingInvites, status);
+    const bySearch = filterBySearch(byStatus, search);
+    return status === 'all' ? sortByActivePriority(bySearch) : bySearch;
+  }, [signingInvites, status, search]);
 
   if (loading) {
-    return (
-      <div className="flex justify-center py-12">
-        <Loader2 className="size-5 animate-spin text-muted-foreground" />
-      </div>
-    );
+    return <div className="flex justify-center py-12"><Loader2 className="size-5 animate-spin text-muted-foreground" /></div>;
   }
 
-  if (invites.length === 0) {
+  if (signingInvites.length === 0) {
     return (
       <div className="flex flex-col items-center gap-3 py-12 text-center">
         <div className="flex size-10 items-center justify-center rounded-full bg-muted ring-1 ring-border">
@@ -103,17 +117,48 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
 
   return (
     <div className="space-y-3">
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-4">
         <h2 className="text-sm font-medium text-muted-foreground">
           Sent Invites
-          <span className="ml-2 text-xs text-muted-foreground/60">({invites.length})</span>
+          <span className="ml-2 text-xs text-muted-foreground/60 tabular-nums">({filtered.length})</span>
         </h2>
+        <div className="relative w-64">
+          <Search className="absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground/60" />
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search recipient…"
+            className="h-8 w-full rounded-md border border-border bg-muted/20 pl-8 pr-3 text-xs text-foreground placeholder:text-muted-foreground/60 focus:outline-none focus:ring-1 focus:ring-seeko-accent/40"
+          />
+        </div>
       </div>
+
+      <div className="flex flex-wrap gap-1.5">
+        {STATUS_CHIPS.map((chip) => {
+          const active = status === chip.value;
+          return (
+            <button
+              key={chip.value}
+              onClick={() => setStatus(chip.value)}
+              className={`rounded-full px-3 py-1 text-xs font-medium transition-[background-color,color,transform] active:scale-[0.96] ${
+                active
+                  ? 'bg-foreground text-background'
+                  : 'bg-muted/40 text-muted-foreground hover:bg-muted/70 hover:text-foreground'
+              }`}
+            >
+              {chip.label}
+            </button>
+          );
+        })}
+      </div>
+
       <div className="overflow-x-auto rounded-xl border border-border">
         <table className="w-full text-left text-sm">
           <thead>
             <tr className="border-b border-border bg-muted/30">
               <th className="px-4 py-2.5 text-xs font-medium text-muted-foreground">Recipient</th>
+              <th className="px-4 py-2.5 text-xs font-medium text-muted-foreground">Type</th>
               <th className="px-4 py-2.5 text-xs font-medium text-muted-foreground">Document</th>
               <th className="px-4 py-2.5 text-xs font-medium text-muted-foreground">Status</th>
               <th className="px-4 py-2.5 text-xs font-medium text-muted-foreground">Sent</th>
@@ -122,64 +167,68 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
             </tr>
           </thead>
           <tbody>
-            {invites.map((invite) => (
-              <tr key={invite.id} className="border-b border-border/50 transition-colors hover:bg-muted/20">
-                <td className="px-4 py-3 text-foreground font-mono text-xs">
-                  {invite.recipient_email}
-                  {invite.is_guardian_signing && (
-                    <Badge variant="outline" className="ml-2 text-[10px]">Guardian</Badge>
-                  )}
-                </td>
-                <td className="px-4 py-3 text-muted-foreground text-xs">
-                  {invite.template_type === 'preset' ? invite.template_id : invite.custom_title || 'Custom'}
-                </td>
-                <td className="px-4 py-3">
-                  <Badge variant={STATUS_VARIANT[invite.status] || 'secondary'}>
-                    {invite.status}
-                  </Badge>
-                </td>
-                <td className="px-4 py-3 text-muted-foreground text-xs">
-                  {new Date(invite.created_at).toLocaleDateString()}
-                </td>
-                <td className="px-4 py-3 text-muted-foreground text-xs">
-                  {new Date(invite.expires_at).toLocaleDateString()}
-                </td>
-                <td className="px-4 py-3">
-                  <div className="flex gap-1">
-                    {(invite.status === 'pending' || invite.status === 'verified') && (
-                      <>
-                        <button
-                          onClick={() => handleAction(invite.id, 'resend')}
-                          disabled={actionLoading === invite.id}
-                          title="Resend invite"
-                          className="rounded p-1.5 hover:bg-muted transition-colors group"
-                        >
-                          <RotateCw className="size-3.5 text-muted-foreground group-hover:text-foreground transition-colors" />
-                        </button>
-                        <button
-                          onClick={() => handleAction(invite.id, 'revoke')}
-                          disabled={actionLoading === invite.id}
-                          title="Revoke invite"
-                          className="rounded p-1.5 hover:bg-destructive/10 transition-colors group"
-                        >
-                          <Ban className="size-3.5 text-muted-foreground group-hover:text-destructive transition-colors" />
-                        </button>
-                      </>
+            {filtered.map((invite) => {
+              const { label: typeLabel, doc } = getTypeTag(invite);
+              return (
+                <tr key={invite.id} className="border-b border-border/50 transition-[background-color] hover:bg-muted/20">
+                  <td className="px-4 py-3 text-foreground font-mono text-xs">
+                    {invite.recipient_email}
+                    {invite.is_guardian_signing && (
+                      <Badge variant="outline" className="ml-2 text-[10px]">Guardian</Badge>
                     )}
-                    {invite.status === 'signed' && (
-                      <button
-                        onClick={() => handleDownload(invite.id)}
-                        disabled={actionLoading === invite.id}
-                        title="Download signed PDF"
-                        className="rounded p-1.5 hover:bg-seeko-accent/10 transition-colors group"
-                      >
-                        <Download className="size-3.5 text-muted-foreground group-hover:text-seeko-accent transition-colors" />
-                      </button>
-                    )}
-                  </div>
-                </td>
-              </tr>
-            ))}
+                  </td>
+                  <td className="px-4 py-3">
+                    <span className="rounded-full bg-muted/40 px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+                      {typeLabel}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground text-xs" style={{ textWrap: 'pretty' }}>{doc}</td>
+                  <td className="px-4 py-3">
+                    <Badge variant={STATUS_VARIANT[invite.status] || 'secondary'}>{invite.status}</Badge>
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground text-xs tabular-nums">
+                    {new Date(invite.created_at).toLocaleDateString()}
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground text-xs tabular-nums">
+                    {new Date(invite.expires_at).toLocaleDateString()}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex gap-1">
+                      {(invite.status === 'pending' || invite.status === 'verified') && (
+                        <>
+                          <button
+                            onClick={() => handleAction(invite.id, 'resend')}
+                            disabled={actionLoading === invite.id}
+                            title="Resend invite"
+                            className="relative rounded p-1.5 transition-[background-color,transform] hover:bg-muted active:scale-[0.96] group before:absolute before:inset-0 before:-m-2 before:content-['']"
+                          >
+                            <RotateCw className="size-3.5 text-muted-foreground group-hover:text-foreground transition-[color]" />
+                          </button>
+                          <button
+                            onClick={() => handleAction(invite.id, 'revoke')}
+                            disabled={actionLoading === invite.id}
+                            title="Revoke invite"
+                            className="relative rounded p-1.5 transition-[background-color,transform] hover:bg-destructive/10 active:scale-[0.96] group before:absolute before:inset-0 before:-m-2 before:content-['']"
+                          >
+                            <Ban className="size-3.5 text-muted-foreground group-hover:text-destructive transition-[color]" />
+                          </button>
+                        </>
+                      )}
+                      {invite.status === 'signed' && (
+                        <button
+                          onClick={() => handleDownload(invite.id)}
+                          disabled={actionLoading === invite.id}
+                          title="Download signed PDF"
+                          className="relative rounded p-1.5 transition-[background-color,transform] hover:bg-seeko-accent/10 active:scale-[0.96] group before:absolute before:inset-0 before:-m-2 before:content-['']"
+                        >
+                          <Download className="size-3.5 text-muted-foreground group-hover:text-seeko-accent transition-[color]" />
+                        </button>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>

--- a/src/components/external-signing/InviteTable.tsx
+++ b/src/components/external-signing/InviteTable.tsx
@@ -120,6 +120,84 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
     [grouped, filtered],
   );
 
+  const [showArchive, setShowArchive] = useState(false);
+
+  const archiveInvites = useMemo(() => {
+    const byStatus = filterByStatus(signingInvites, 'archive');
+    return filterBySearch(byStatus, debouncedSearch);
+  }, [signingInvites, debouncedSearch]);
+
+  const renderInviteRow = (invite: ExternalSigningInvite, index: number, indent: boolean = false) => {
+    const { label: typeLabel, doc } = getTypeTag(invite);
+    return (
+      <motion.tr
+        key={invite.id}
+        layout
+        initial={{ opacity: 0, y: 8, scale: 0.98 }}
+        animate={{ opacity: 1, y: 0, scale: 1 }}
+        exit={{ opacity: 0, y: -4 }}
+        transition={{ type: 'spring', duration: 0.3, bounce: 0, delay: Math.min(index, 10) * 0.03 }}
+        className="border-b border-border/50 transition-[background-color] hover:bg-muted/20"
+      >
+        <td className={`px-4 py-3 text-foreground font-mono text-xs ${indent ? 'pl-10' : ''}`}>
+          {invite.recipient_email}
+          {invite.is_guardian_signing && (
+            <Badge variant="outline" className="ml-2 text-[10px]">Guardian</Badge>
+          )}
+        </td>
+        <td className="px-4 py-3">
+          <span className="rounded-full bg-muted/40 px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+            {typeLabel}
+          </span>
+        </td>
+        <td className="px-4 py-3 text-muted-foreground text-xs" style={{ textWrap: 'pretty' }}>{doc}</td>
+        <td className="px-4 py-3">
+          <Badge variant={STATUS_VARIANT[invite.status] || 'secondary'}>{invite.status}</Badge>
+        </td>
+        <td className="px-4 py-3 text-muted-foreground text-xs tabular-nums">
+          {new Date(invite.created_at).toLocaleDateString()}
+        </td>
+        <td className="px-4 py-3 text-muted-foreground text-xs tabular-nums">
+          {new Date(invite.expires_at).toLocaleDateString()}
+        </td>
+        <td className="px-4 py-3">
+          <div className="flex gap-1">
+            {(invite.status === 'pending' || invite.status === 'verified') && (
+              <>
+                <button
+                  onClick={() => handleAction(invite.id, 'resend')}
+                  disabled={actionLoading === invite.id}
+                  title="Resend invite"
+                  className="relative rounded p-1.5 transition-[background-color,transform] hover:bg-muted active:scale-[0.96] group before:absolute before:inset-0 before:-m-2 before:content-['']"
+                >
+                  <RotateCw className="size-3.5 text-muted-foreground group-hover:text-foreground transition-[color]" />
+                </button>
+                <button
+                  onClick={() => handleAction(invite.id, 'revoke')}
+                  disabled={actionLoading === invite.id}
+                  title="Revoke invite"
+                  className="relative rounded p-1.5 transition-[background-color,transform] hover:bg-destructive/10 active:scale-[0.96] group before:absolute before:inset-0 before:-m-2 before:content-['']"
+                >
+                  <Ban className="size-3.5 text-muted-foreground group-hover:text-destructive transition-[color]" />
+                </button>
+              </>
+            )}
+            {invite.status === 'signed' && (
+              <button
+                onClick={() => handleDownload(invite.id)}
+                disabled={actionLoading === invite.id}
+                title="Download signed PDF"
+                className="relative rounded p-1.5 transition-[background-color,transform] hover:bg-seeko-accent/10 active:scale-[0.96] group before:absolute before:inset-0 before:-m-2 before:content-['']"
+              >
+                <Download className="size-3.5 text-muted-foreground group-hover:text-seeko-accent transition-[color]" />
+              </button>
+            )}
+          </div>
+        </td>
+      </motion.tr>
+    );
+  };
+
   if (loading) {
     return <div className="flex justify-center py-12"><Loader2 className="size-5 animate-spin text-muted-foreground" /></div>;
   }
@@ -205,76 +283,6 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
           <tbody>
             <AnimatePresence initial={false} mode="popLayout">
             {(() => {
-              const renderInviteRow = (invite: ExternalSigningInvite, index: number, indent: boolean = false) => {
-                const { label: typeLabel, doc } = getTypeTag(invite);
-                return (
-                <motion.tr
-                  key={invite.id}
-                  layout
-                  initial={{ opacity: 0, y: 8, scale: 0.98 }}
-                  animate={{ opacity: 1, y: 0, scale: 1 }}
-                  exit={{ opacity: 0, y: -4 }}
-                  transition={{ type: 'spring', duration: 0.3, bounce: 0, delay: Math.min(index, 10) * 0.03 }}
-                  className="border-b border-border/50 transition-[background-color] hover:bg-muted/20"
-                >
-                  <td className={`px-4 py-3 text-foreground font-mono text-xs ${indent ? 'pl-10' : ''}`}>
-                    {invite.recipient_email}
-                    {invite.is_guardian_signing && (
-                      <Badge variant="outline" className="ml-2 text-[10px]">Guardian</Badge>
-                    )}
-                  </td>
-                  <td className="px-4 py-3">
-                    <span className="rounded-full bg-muted/40 px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
-                      {typeLabel}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 text-muted-foreground text-xs" style={{ textWrap: 'pretty' }}>{doc}</td>
-                  <td className="px-4 py-3">
-                    <Badge variant={STATUS_VARIANT[invite.status] || 'secondary'}>{invite.status}</Badge>
-                  </td>
-                  <td className="px-4 py-3 text-muted-foreground text-xs tabular-nums">
-                    {new Date(invite.created_at).toLocaleDateString()}
-                  </td>
-                  <td className="px-4 py-3 text-muted-foreground text-xs tabular-nums">
-                    {new Date(invite.expires_at).toLocaleDateString()}
-                  </td>
-                  <td className="px-4 py-3">
-                    <div className="flex gap-1">
-                      {(invite.status === 'pending' || invite.status === 'verified') && (
-                        <>
-                          <button
-                            onClick={() => handleAction(invite.id, 'resend')}
-                            disabled={actionLoading === invite.id}
-                            title="Resend invite"
-                            className="relative rounded p-1.5 transition-[background-color,transform] hover:bg-muted active:scale-[0.96] group before:absolute before:inset-0 before:-m-2 before:content-['']"
-                          >
-                            <RotateCw className="size-3.5 text-muted-foreground group-hover:text-foreground transition-[color]" />
-                          </button>
-                          <button
-                            onClick={() => handleAction(invite.id, 'revoke')}
-                            disabled={actionLoading === invite.id}
-                            title="Revoke invite"
-                            className="relative rounded p-1.5 transition-[background-color,transform] hover:bg-destructive/10 active:scale-[0.96] group before:absolute before:inset-0 before:-m-2 before:content-['']"
-                          >
-                            <Ban className="size-3.5 text-muted-foreground group-hover:text-destructive transition-[color]" />
-                          </button>
-                        </>
-                      )}
-                      {invite.status === 'signed' && (
-                        <button
-                          onClick={() => handleDownload(invite.id)}
-                          disabled={actionLoading === invite.id}
-                          title="Download signed PDF"
-                          className="relative rounded p-1.5 transition-[background-color,transform] hover:bg-seeko-accent/10 active:scale-[0.96] group before:absolute before:inset-0 before:-m-2 before:content-['']"
-                        >
-                          <Download className="size-3.5 text-muted-foreground group-hover:text-seeko-accent transition-[color]" />
-                        </button>
-                      )}
-                    </div>
-                  </td>
-                </motion.tr>
-                );
-              };
               if (groupedData) {
                 return groupedData.flatMap((group, gIndex) => {
                   const expanded = expandedGroups.has(group.email);
@@ -336,6 +344,39 @@ export function InviteTable({ refreshKey }: InviteTableProps) {
           </tbody>
         </table>
       </div>
+
+      {status !== 'archive' && archiveInvites.length > 0 && (
+        <div className="space-y-2">
+          <button
+            onClick={() => setShowArchive(s => !s)}
+            className="flex w-full items-center justify-center gap-1.5 rounded-lg py-2 text-xs text-muted-foreground hover:text-foreground transition-[color]"
+          >
+            {showArchive ? 'Hide archived' : `Show archived (${archiveInvites.length})`}
+          </button>
+          <AnimatePresence initial={false}>
+            {showArchive && (
+              <motion.div
+                key="archive-panel"
+                initial={{ opacity: 0, height: 0 }}
+                animate={{ opacity: 1, height: 'auto' }}
+                exit={{ opacity: 0, height: 0 }}
+                transition={{ type: 'spring', duration: 0.35, bounce: 0 }}
+                className="overflow-hidden"
+              >
+                <div className="overflow-x-auto rounded-xl border border-border opacity-60">
+                  <table className="w-full text-left text-sm">
+                    <tbody>
+                      <AnimatePresence initial={false} mode="popLayout">
+                        {archiveInvites.map((invite, index) => renderInviteRow(invite, index))}
+                      </AnimatePresence>
+                    </tbody>
+                  </table>
+                </div>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/external-signing/InviteTable.tsx
+++ b/src/components/external-signing/InviteTable.tsx
@@ -46,11 +46,8 @@ function humanizeDoc(raw: string): string {
 }
 
 type TypeTag = { label: 'Signing' | 'Invoice'; doc: string; tone: 'signing' | 'invoice' };
-type InviteTableInvite = Omit<ExternalSigningInvite, 'template_type'> & {
-  template_type: ExternalSigningInvite['template_type'] | 'invoice';
-};
 
-function getTypeTag(invite: InviteTableInvite): TypeTag {
+function getTypeTag(invite: ExternalSigningInvite): TypeTag {
   if (invite.template_type === 'invoice') {
     // Custom titles carry signal; the default "Invoice request" label repeats the Type tag — elide it.
     const custom = invite.custom_title?.trim();

--- a/src/lib/__tests__/invite-filters.test.ts
+++ b/src/lib/__tests__/invite-filters.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { filterByStatus, filterBySearch, excludeDocShare, groupByRecipient, sortByActivePriority, type FilterStatus } from '../invite-filters';
+import type { ExternalSigningInvite } from '../types';
+
+const makeInvite = (overrides: Partial<ExternalSigningInvite>): ExternalSigningInvite => ({
+  id: 'x',
+  token: 't',
+  recipient_email: 'a@b.com',
+  status: 'pending',
+  template_type: 'preset',
+  template_id: 'nda',
+  expires_at: '2026-05-01T00:00:00Z',
+  created_at: '2026-04-01T00:00:00Z',
+  verification_attempts: 0,
+  created_by: 'u',
+  is_guardian_signing: false,
+  ...overrides,
+} as ExternalSigningInvite);
+
+describe('filterByStatus', () => {
+  const invites = [
+    makeInvite({ id: '1', status: 'pending' }),
+    makeInvite({ id: '2', status: 'verified' }),
+    makeInvite({ id: '3', status: 'signed' }),
+    makeInvite({ id: '4', status: 'expired' }),
+    makeInvite({ id: '5', status: 'revoked' }),
+  ];
+
+  it('all → active statuses only (pending/verified/signed)', () => {
+    const result = filterByStatus(invites, 'all');
+    expect(result.map(i => i.id)).toEqual(['1', '2', '3']);
+  });
+
+  it('pending → only pending', () => {
+    expect(filterByStatus(invites, 'pending').map(i => i.id)).toEqual(['1']);
+  });
+
+  it('verified → only verified', () => {
+    expect(filterByStatus(invites, 'verified').map(i => i.id)).toEqual(['2']);
+  });
+
+  it('signed → only signed', () => {
+    expect(filterByStatus(invites, 'signed').map(i => i.id)).toEqual(['3']);
+  });
+
+  it('archive → expired + revoked', () => {
+    expect(filterByStatus(invites, 'archive').map(i => i.id)).toEqual(['4', '5']);
+  });
+});
+
+describe('filterBySearch', () => {
+  const invites = [
+    makeInvite({ id: '1', recipient_email: 'alice@example.com' }),
+    makeInvite({ id: '2', recipient_email: 'BOB@example.com' }),
+    makeInvite({ id: '3', recipient_email: 'carol@other.org' }),
+  ];
+
+  it('returns all when query is empty', () => {
+    expect(filterBySearch(invites, '').length).toBe(3);
+    expect(filterBySearch(invites, '   ').length).toBe(3);
+  });
+
+  it('matches case-insensitively on recipient_email', () => {
+    expect(filterBySearch(invites, 'BOB').map(i => i.id)).toEqual(['2']);
+    expect(filterBySearch(invites, 'alice').map(i => i.id)).toEqual(['1']);
+  });
+
+  it('matches partial substring', () => {
+    expect(filterBySearch(invites, 'example').map(i => i.id)).toEqual(['1', '2']);
+  });
+});
+
+describe('excludeDocShare', () => {
+  it('removes rows where template_type is doc_share', () => {
+    const invites = [
+      makeInvite({ id: '1', template_type: 'preset' }),
+      makeInvite({ id: '2', template_type: 'custom' }),
+      makeInvite({ id: '3', template_type: 'invoice' as ExternalSigningInvite['template_type'] }),
+      makeInvite({ id: '4', template_type: 'doc_share' as ExternalSigningInvite['template_type'] }),
+    ];
+    expect(excludeDocShare(invites).map(i => i.id)).toEqual(['1', '2', '3']);
+  });
+});
+
+describe('groupByRecipient', () => {
+  const invites = [
+    makeInvite({ id: '1', recipient_email: 'a@x.com', created_at: '2026-04-03' }),
+    makeInvite({ id: '2', recipient_email: 'a@x.com', created_at: '2026-04-01' }),
+    makeInvite({ id: '3', recipient_email: 'b@x.com', created_at: '2026-04-02' }),
+  ];
+
+  it('groups invites by recipient_email', () => {
+    const groups = groupByRecipient(invites);
+    expect(groups.length).toBe(2);
+    expect(groups[0].email).toBe('a@x.com');
+    expect(groups[0].invites.length).toBe(2);
+    expect(groups[1].email).toBe('b@x.com');
+  });
+
+  it('sorts group members newest-first', () => {
+    const groups = groupByRecipient(invites);
+    expect(groups[0].invites.map(i => i.id)).toEqual(['1', '2']);
+  });
+
+  it('orders groups by most-recent invite', () => {
+    const groups = groupByRecipient(invites);
+    expect(groups.map(g => g.email)).toEqual(['a@x.com', 'b@x.com']);
+  });
+});
+
+describe('sortByActivePriority', () => {
+  it('orders pending → verified → signed, newest-first within each', () => {
+    const invites = [
+      makeInvite({ id: '1', status: 'signed', created_at: '2026-04-03' }),
+      makeInvite({ id: '2', status: 'pending', created_at: '2026-04-01' }),
+      makeInvite({ id: '3', status: 'verified', created_at: '2026-04-02' }),
+      makeInvite({ id: '4', status: 'pending', created_at: '2026-04-04' }),
+    ];
+    const sorted = sortByActivePriority(invites);
+    expect(sorted.map(i => i.id)).toEqual(['4', '2', '3', '1']);
+  });
+});

--- a/src/lib/__tests__/invite-filters.test.ts
+++ b/src/lib/__tests__/invite-filters.test.ts
@@ -75,9 +75,9 @@ describe('excludeDocShare', () => {
     const invites = [
       makeInvite({ id: '1', template_type: 'preset' }),
       makeInvite({ id: '2', template_type: 'custom' }),
-      { ...makeInvite({ id: '3' }), template_type: 'invoice' },
-      { ...makeInvite({ id: '4' }), template_type: 'doc_share' },
-    ] as unknown as ExternalSigningInvite[];
+      makeInvite({ id: '3', template_type: 'invoice' }),
+      makeInvite({ id: '4', template_type: 'doc_share' }),
+    ];
     expect(excludeDocShare(invites).map(i => i.id)).toEqual(['1', '2', '3']);
   });
 });

--- a/src/lib/__tests__/invite-filters.test.ts
+++ b/src/lib/__tests__/invite-filters.test.ts
@@ -75,9 +75,9 @@ describe('excludeDocShare', () => {
     const invites = [
       makeInvite({ id: '1', template_type: 'preset' }),
       makeInvite({ id: '2', template_type: 'custom' }),
-      makeInvite({ id: '3', template_type: 'invoice' as ExternalSigningInvite['template_type'] }),
-      makeInvite({ id: '4', template_type: 'doc_share' as ExternalSigningInvite['template_type'] }),
-    ];
+      { ...makeInvite({ id: '3' }), template_type: 'invoice' },
+      { ...makeInvite({ id: '4' }), template_type: 'doc_share' },
+    ] as unknown as ExternalSigningInvite[];
     expect(excludeDocShare(invites).map(i => i.id)).toEqual(['1', '2', '3']);
   });
 });

--- a/src/lib/invite-filters.ts
+++ b/src/lib/invite-filters.ts
@@ -24,7 +24,7 @@ export function filterBySearch(
 }
 
 export function excludeDocShare(invites: ExternalSigningInvite[]): ExternalSigningInvite[] {
-  return invites.filter(i => (i.template_type as string) !== 'doc_share');
+  return invites.filter(i => i.template_type !== 'doc_share');
 }
 
 export type InviteGroup = {

--- a/src/lib/invite-filters.ts
+++ b/src/lib/invite-filters.ts
@@ -1,0 +1,59 @@
+import type { ExternalSigningInvite } from './types';
+
+export type FilterStatus = 'all' | 'pending' | 'verified' | 'signed' | 'archive';
+
+const ACTIVE_STATUSES = new Set(['pending', 'verified', 'signed']);
+const ARCHIVE_STATUSES = new Set(['expired', 'revoked']);
+
+export function filterByStatus(
+  invites: ExternalSigningInvite[],
+  status: FilterStatus,
+): ExternalSigningInvite[] {
+  if (status === 'all') return invites.filter(i => ACTIVE_STATUSES.has(i.status));
+  if (status === 'archive') return invites.filter(i => ARCHIVE_STATUSES.has(i.status));
+  return invites.filter(i => i.status === status);
+}
+
+export function filterBySearch(
+  invites: ExternalSigningInvite[],
+  query: string,
+): ExternalSigningInvite[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return invites;
+  return invites.filter(i => i.recipient_email.toLowerCase().includes(q));
+}
+
+export function excludeDocShare(invites: ExternalSigningInvite[]): ExternalSigningInvite[] {
+  return invites.filter(i => (i.template_type as string) !== 'doc_share');
+}
+
+export type InviteGroup = {
+  email: string;
+  invites: ExternalSigningInvite[];
+};
+
+export function groupByRecipient(invites: ExternalSigningInvite[]): InviteGroup[] {
+  const map = new Map<string, ExternalSigningInvite[]>();
+  for (const inv of invites) {
+    const list = map.get(inv.recipient_email) ?? [];
+    list.push(inv);
+    map.set(inv.recipient_email, list);
+  }
+  const groups: InviteGroup[] = [];
+  for (const [email, list] of map) {
+    list.sort((a, b) => b.created_at.localeCompare(a.created_at));
+    groups.push({ email, invites: list });
+  }
+  groups.sort((a, b) => b.invites[0].created_at.localeCompare(a.invites[0].created_at));
+  return groups;
+}
+
+const STATUS_ORDER: Record<string, number> = { pending: 0, verified: 1, signed: 2, expired: 3, revoked: 4 };
+
+export function sortByActivePriority(invites: ExternalSigningInvite[]): ExternalSigningInvite[] {
+  return [...invites].sort((a, b) => {
+    const orderDiff = (STATUS_ORDER[a.status] ?? 9) - (STATUS_ORDER[b.status] ?? 9);
+    if (orderDiff !== 0) return orderDiff;
+    return b.created_at.localeCompare(a.created_at);
+  });
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -213,7 +213,7 @@ export type ExternalSigningInvite = {
   id: string;
   token: string;
   recipient_email: string;
-  template_type: 'preset' | 'custom';
+  template_type: 'preset' | 'custom' | 'invoice' | 'doc_share';
   template_id?: string;
   custom_sections?: ExternalAgreementSection[];
   custom_title?: string;


### PR DESCRIPTION
## Summary
- Reorganize `/admin/external-signing` sent-invites table in-place — single card, no new pages
- Add client-side search, status filter chips, recipient grouping toggle, archive footer
- New Type column distinguishes Signing vs Invoice rows (doc_share excluded — handled in /docs)
- Humanized document names (`vendor_agreement` → `Vendor Agreement`)
- Flipped status visual weight: pending = solid accent (needs attention), signed = muted outline (done)
- Color-coded Type tags: Signing neutral, Invoice amber-tinted
- Inlined Guardian badge, consistent row heights via `align-middle` + truncation with tooltips
- Staggered spring motion on filter transitions (fixed text-collapse + stutter bugs from Framer `popLayout` + table row incompatibility)
- 13 Vitest tests covering filter/group/sort utilities in new `src/lib/invite-filters.ts`

## Test plan
- [ ] Navigate to `/admin/external-signing` as admin
- [ ] Search recipient email — filters as you type (debounced 150ms)
- [ ] Click each status chip (All / Pending / Verified / Signed / Archive) — rows transition smoothly, no text jumping
- [ ] Default "All" view excludes archive; "Archive" chip shows only expired + revoked
- [ ] Toggle group-by-recipient (Users icon) — rows collapse per email, click chevron to expand
- [ ] Keyboard: Tab to group row, press Enter or Space to expand/collapse (a11y)
- [ ] "Show archived (N)" footer appears on non-Archive tabs; clicking expands inline
- [ ] Resend / revoke / download actions still work on applicable rows
- [ ] Long emails truncate with hover tooltip; Guardian badge inline with row

🤖 Generated with [Claude Code](https://claude.com/claude-code)