### PR TITLE
Dashboard adjustments: defaults, area rename, layout

### DIFF
--- a/docs/personas/ia.md
+++ b/docs/personas/ia.md
@@ -65,7 +65,7 @@ Every authenticated user gets a profile row automatically on signup. This double
 | phase       | area_phase enum   | Alpha, Beta, Launch                      |
 | created_at  | timestamptz       |                                          |
 
-**Rows:** Dojo, Battleground, Fighting Club
+**Rows:** Main Game, Fighting Club
 
 ---
 
@@ -125,7 +125,7 @@ Every authenticated user gets a profile row automatically on signup. This double
 ```
 Supabase (seeko-studio project)
 ├── tasks          ← area_id → areas, assignee_id → profiles
-├── areas          ← Dojo, Battleground, Fighting Club
+├── areas          ← Main Game, Fighting Club
 ├── profiles       ← auto-created from auth.users (= team roster)
 ├── payments       ← recipient_id → profiles, created_by → profiles
 │   └── payment_items ← task_id → tasks (optional)
@@ -141,7 +141,7 @@ Supabase (seeko-studio project)
 **Departments:** Coding · Visual Art · UI/UX · Animation · Asset Creation
 **Statuses:** Complete · In Progress · In Review · Blocked
 **Priorities:** High · Medium · Low
-**Game Areas:** Dojo · Battleground · Fighting Club
+**Game Areas:** Main Game · Fighting Club
 
 ---
 

--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -281,9 +281,11 @@ export default async function OverviewPage() {
                 <p className="text-xs text-muted-foreground">{areasSubtitle}</p>
               </div>
               <div className="p-6 pt-0">
-                <Stagger className="grid grid-cols-1 md:grid-cols-3 gap-4" delayMs={delay(TIMING.areasInner)}>
+                <Stagger className="flex flex-col gap-4 md:flex-row md:flex-wrap md:justify-center" delayMs={delay(TIMING.areasInner)}>
                   {areas.map(area => (
-                    <DashboardAreaCard key={area.id} area={area} isAdmin={isAdmin} />
+                    <div key={area.id} className="w-full md:w-[calc(33.333%-0.667rem)]">
+                      <DashboardAreaCard area={area} isAdmin={isAdmin} />
+                    </div>
                   ))}
                 </Stagger>
               </div>

--- a/src/components/dashboard/GameTreeTimeline.tsx
+++ b/src/components/dashboard/GameTreeTimeline.tsx
@@ -7,7 +7,7 @@ const LINE_X = 8;
 
 const TREE = [
   {
-    title: 'Battleground (UBAKU GROUND)',
+    title: 'Main Game (UBAKU GROUND)',
     items: [
       'Embed combat & movement system',
       'Quest + Achievement system',

--- a/src/components/dashboard/TaskList.tsx
+++ b/src/components/dashboard/TaskList.tsx
@@ -197,7 +197,7 @@ export function TaskList({ tasks: initialTasks, isAdmin = false, team = [], docs
 
   /* --- filter state --- */
   const [filterAssignee, setFilterAssignee] = useState('All');
-  const [filterStatus, setFilterStatus] = useState('All');
+  const [filterStatus, setFilterStatus] = useState<string>('In Progress');
   const [filterPriority, setFilterPriority] = useState('All');
 
   /* --- task mutation state --- */

--- a/src/lib/supabase/data.ts
+++ b/src/lib/supabase/data.ts
@@ -34,7 +34,8 @@ export async function fetchAreas(): Promise<Area[]> {
 
   const { data, error } = await supabase
     .from('areas')
-    .select('id, name, status, progress, description, phase, created_at')
+    .select('id, name, status, progress, description, phase, created_at, sort_order')
+    .order('sort_order', { ascending: true })
     .order('name', { ascending: true });
 
   if (error) throw error;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -29,6 +29,7 @@ export type Area = {
   progress: number;
   description?: string;
   phase?: string;
+  sort_order?: number;
 };
 
 export type Profile = {

--- a/supabase/migrations/20260405000001_areas_sort_order.sql
+++ b/supabase/migrations/20260405000001_areas_sort_order.sql
@@ -1,7 +1,16 @@
 -- Add sort_order column to areas so the dashboard can control display order
 -- independent of name or created_at.
 
-ALTER TABLE public.areas ADD COLUMN IF NOT EXISTS sort_order INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE public.areas ADD COLUMN IF NOT EXISTS sort_order INTEGER NOT NULL DEFAULT 100;
+
+-- Ensure the default is 100 even if the column already existed with a prior default.
+-- New areas added without an explicit sort_order land at the end of the list
+-- rather than tying with seeded rows at 0.
+ALTER TABLE public.areas ALTER COLUMN sort_order SET DEFAULT 100;
+
+-- Rename legacy 'Battleground' row to 'Main Game' so fresh environments and
+-- replays match the name the dashboard renders. Idempotent: no-op if already renamed.
+UPDATE public.areas SET name = 'Main Game' WHERE name = 'Battleground';
 
 -- Seed initial ordering: Main Game first, Fighting Club second.
 UPDATE public.areas SET sort_order = 0 WHERE name = 'Main Game';

--- a/supabase/migrations/20260405000001_areas_sort_order.sql
+++ b/supabase/migrations/20260405000001_areas_sort_order.sql
@@ -1,11 +1,11 @@
 -- Add sort_order column to areas so the dashboard can control display order
 -- independent of name or created_at.
 
-ALTER TABLE areas ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE public.areas ADD COLUMN IF NOT EXISTS sort_order INTEGER NOT NULL DEFAULT 0;
 
 -- Seed initial ordering: Main Game first, Fighting Club second.
-UPDATE areas SET sort_order = 0 WHERE name = 'Main Game';
-UPDATE areas SET sort_order = 1 WHERE name = 'Fighting Club';
+UPDATE public.areas SET sort_order = 0 WHERE name = 'Main Game';
+UPDATE public.areas SET sort_order = 1 WHERE name = 'Fighting Club';
 
 -- Secondary index for ordering queries.
-CREATE INDEX idx_areas_sort_order ON areas(sort_order);
+CREATE INDEX IF NOT EXISTS idx_areas_sort_order ON public.areas(sort_order);

--- a/supabase/migrations/20260405000001_areas_sort_order.sql
+++ b/supabase/migrations/20260405000001_areas_sort_order.sql
@@ -1,0 +1,11 @@
+-- Add sort_order column to areas so the dashboard can control display order
+-- independent of name or created_at.
+
+ALTER TABLE areas ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0;
+
+-- Seed initial ordering: Main Game first, Fighting Club second.
+UPDATE areas SET sort_order = 0 WHERE name = 'Main Game';
+UPDATE areas SET sort_order = 1 WHERE name = 'Fighting Club';
+
+-- Secondary index for ordering queries.
+CREATE INDEX idx_areas_sort_order ON areas(sort_order);


### PR DESCRIPTION
## Summary
- Tasks page filter now defaults to **In Progress** (was "All")
- Renamed area **Battleground** → **Main Game**; removed **Dojo** (had no tasks)
- Updated hardcoded "Battleground" in GameTreeTimeline title
- Updated docs/personas/ia.md to reflect new area list
- Game Areas cards preserve their original 33% width and now **center as a pair** when only 2 areas exist (no dead slot on the right)
- Added \`sort_order\` column on \`areas\` + migration; \`fetchAreas\` orders by sort_order then name (Main Game first)

## Test plan
- [ ] Load /tasks — filter defaults to "In Progress"
- [ ] Load home dashboard — Game Areas shows Main Game (first) + Fighting Club (second), cards centered
- [ ] Load home dashboard on mobile — cards stack vertically
- [ ] Add a 3rd area and verify cards fill the row edge-to-edge
- [ ] GameTreeTimeline shows "Main Game (UBAKU GROUND)" instead of "Battleground"

🤖 Generated with [Claude Code](https://claude.com/claude-code)