### PR TITLE
fix(payments): show contractor PayPal email on invoice + recent payment rows

### DIFF
--- a/src/components/dashboard/PaymentsAdmin.tsx
+++ b/src/components/dashboard/PaymentsAdmin.tsx
@@ -167,6 +167,14 @@ export function PaymentsAdmin({ team }: PaymentsAdminProps) {
     .filter(p => p.status === 'paid')
     .slice(0, 10);
 
+  // Map: payment.id → paypal_email submitted on the linked invoice request
+  const paypalEmailByPaymentId = new Map<string, string>();
+  for (const inv of invoiceRequests) {
+    if (inv.submitted_payment_id && inv.paypal_email) {
+      paypalEmailByPaymentId.set(inv.submitted_payment_id, inv.paypal_email);
+    }
+  }
+
   const handlePay = (member: TeamMember) => {
     setSelectedRecipient(member);
     setCreateDialogOpen(true);
@@ -499,7 +507,11 @@ export function PaymentsAdmin({ team }: PaymentsAdminProps) {
             ) : (
               <div className="divide-y divide-border/50">
                 {recentPaid.map(payment => (
-                  <PaidPaymentRow key={payment.id} payment={payment} />
+                  <PaidPaymentRow
+                    key={payment.id}
+                    payment={payment}
+                    externalPaypalEmail={paypalEmailByPaymentId.get(payment.id) ?? null}
+                  />
                 ))}
               </div>
             )}
@@ -525,8 +537,13 @@ export function PaymentsAdmin({ team }: PaymentsAdminProps) {
 }
 
 /* ── Paid Payment Row (expandable) ── */
-function PaidPaymentRow({ payment }: { payment: Payment }) {
+function PaidPaymentRow({ payment, externalPaypalEmail }: { payment: Payment; externalPaypalEmail: string | null }) {
   const [expanded, setExpanded] = useState(false);
+  const paypalEmail = payment.recipient?.paypal_email ?? externalPaypalEmail;
+  const title = payment.recipient?.display_name ?? payment.recipient_email ?? 'External';
+  const fallbackInitials = payment.recipient?.display_name
+    ? getInitials(payment.recipient.display_name)
+    : (payment.recipient_email ?? '?').slice(0, 2).toUpperCase();
 
   return (
     <div>
@@ -541,11 +558,11 @@ function PaidPaymentRow({ payment }: { payment: Payment }) {
           <Avatar className="size-8 ring-1 ring-white/[0.06]">
             <AvatarImage src={payment.recipient?.avatar_url ?? undefined} />
             <AvatarFallback className="bg-secondary text-foreground text-[10px]">
-              {getInitials(payment.recipient?.display_name ?? '?')}
+              {fallbackInitials}
             </AvatarFallback>
           </Avatar>
           <div className="min-w-0">
-            <p className="text-sm font-medium text-foreground truncate">{payment.recipient?.display_name}</p>
+            <p className="text-sm font-medium text-foreground truncate">{title}</p>
             <p className="text-[11px] text-muted-foreground">
               {payment.items?.length ?? 0} item{(payment.items?.length ?? 0) !== 1 ? 's' : ''}
               {payment.description && <span className="ml-1.5 text-muted-foreground/50">· {payment.description}</span>}
@@ -574,7 +591,28 @@ function PaidPaymentRow({ payment }: { payment: Payment }) {
             transition={{ duration: 0.2, ease: 'easeInOut' }}
             className="overflow-hidden"
           >
-            <div className="pb-3 px-1 pt-1">
+            <div className="pb-3 px-1 pt-1 space-y-2">
+              {paypalEmail && (
+                <div className="flex items-center justify-between gap-3 rounded-lg bg-white/[0.02] px-3 py-2 text-xs">
+                  <span className="text-[10px] uppercase tracking-wider text-muted-foreground">PayPal</span>
+                  <span
+                    role="button"
+                    tabIndex={0}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      navigator.clipboard.writeText(paypalEmail);
+                      toast.success('PayPal email copied');
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') { e.stopPropagation(); navigator.clipboard.writeText(paypalEmail); toast.success('PayPal email copied'); }
+                    }}
+                    className="font-mono text-foreground/90 truncate hover:text-seeko-accent transition-colors cursor-copy"
+                    title="Click to copy"
+                  >
+                    {paypalEmail}
+                  </span>
+                </div>
+              )}
               {payment.items && payment.items.length > 0 && (
                 <div className="rounded-lg bg-white/[0.02] p-3 space-y-2">
                   {payment.items.map(item => (
@@ -809,6 +847,27 @@ function InvoiceRequestRow({ invite, index, onAction }: { invite: InvoiceRequest
               </>
             )}
           </div>
+          {invite.paypal_email && (
+            <div className="flex items-center gap-1.5 mt-0.5 text-[11px] text-muted-foreground/70">
+              <span className="text-[9px] uppercase tracking-wider text-muted-foreground/50">PayPal</span>
+              <span
+                role="button"
+                tabIndex={0}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  navigator.clipboard.writeText(invite.paypal_email!);
+                  toast.success('PayPal email copied');
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') { e.stopPropagation(); navigator.clipboard.writeText(invite.paypal_email!); toast.success('PayPal email copied'); }
+                }}
+                className="font-mono truncate hover:text-seeko-accent transition-colors cursor-copy"
+                title="Click to copy"
+              >
+                {invite.paypal_email}
+              </span>
+            </div>
+          )}
         </div>
       </div>
       <div className="flex items-center gap-2.5 shrink-0">


### PR DESCRIPTION
## Summary
- Admins had no way to see which PayPal email a contractor submitted via the invoice-request flow — both the Invoice Requests row and the Recent Payments row hid it.
- Surface the submitted PayPal email under the Invoice Requests row (click-to-copy).
- Surface the PayPal email in the expanded Recent Payments row, looked up via `external_signing_invites.submitted_payment_id`.
- Fall back to `recipient_email` for the row title when a payment has no linked profile (external invoices were rendering with an empty name).

No API or schema changes — data was already returned by the admin-gated `/api/invoice-request/list` endpoint.

## Security
- `paypal_email` is already returned by `/api/invoice-request/list`, which 403s on non-admins.
- Component lives behind the `PaymentsPasswordGate` admin password.
- React text interpolation auto-escapes — no XSS surface.
- `navigator.clipboard.writeText` writes the viewer's own clipboard with data they're already authorized to read.

## Test plan
- [ ] Log in as admin, open `/payments`, enter password
- [ ] Invoice Requests card: rows with a submitted PayPal email show a `PAYPAL · email@…` line; click copies to clipboard
- [ ] Recent Payments card: expand a row that came from an external invoice — the expanded panel shows a `PAYPAL` line; click copies
- [ ] Recent Payments rows for external invoices now show the recipient_email as the title instead of being blank
- [ ] Internal team payments still show `recipient.paypal_email` (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)