### PR TITLE
chore(deps): bump postcss to 8.5.12 (clear XSS advisory)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5920,9 +5920,9 @@
       "license": "MIT-0"
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- Bumps deduped `postcss` (used by `@tailwindcss/postcss` and `vite`) from **8.5.8 → 8.5.12** to clear GHSA on `</style>` stringify XSS.
- Lockfile-only change (3 lines).

## Caveat
- `next` still bundles its own `postcss@8.4.31` under `node_modules/next/node_modules/postcss`. That copy is pinned by Next.js and cannot be moved without a Next release.
- Both paths run **at build time on trusted CSS input** — not exploitable in this codebase regardless of version.

## Test plan
- [x] `npm run build` passes locally
- [ ] Render preview deploy passes
- [ ] CSS output unchanged (visual smoke check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)