### PR TITLE
feat(external-signing): light signer ceremony + completion certificate + hardening

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "clsx": "^2.1.1",
         "dialkit": "^1.1.0",
         "dompurify": "^3.4.0",
+        "isomorphic-dompurify": "^3.15.0",
         "jose": "^6.2.0",
         "lucide-react": "^0.576.0",
         "motion": "^12.34.5",
@@ -121,30 +122,19 @@
       }
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
-      "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
-      "dev": true,
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^3.1.1",
-        "@csstools/css-color-parser": "^4.0.2",
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
         "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0",
-        "lru-cache": "^11.2.6"
+        "@csstools/css-tokenizer": "^4.0.0"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/@asamuzakjp/dom-selector": {
@@ -171,11 +161,19 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/@asamuzakjp/nwsapi": {
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
@@ -493,7 +491,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
       "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "css-tree": "^3.0.0"
@@ -506,7 +503,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
       "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -523,10 +519,9 @@
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
-      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
-      "dev": true,
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
       "funding": [
         {
           "type": "github",
@@ -547,10 +542,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
-      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
-      "dev": true,
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
       "funding": [
         {
           "type": "github",
@@ -564,7 +558,7 @@
       "license": "MIT",
       "dependencies": {
         "@csstools/color-helpers": "^6.0.2",
-        "@csstools/css-calc": "^3.1.1"
+        "@csstools/css-calc": "^3.2.1"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -578,7 +572,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
       "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -598,10 +591,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.0.29",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.29.tgz",
-      "integrity": "sha512-jx9GjkkP5YHuTmko2eWAvpPnb0mB4mGRr2U7XwVNwevm8nlpobZEVk+GNmiYMk2VuA75v+plfXWyroWKmICZXg==",
-      "dev": true,
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
+      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
       "funding": [
         {
           "type": "github",
@@ -612,13 +604,20 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT-0"
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@csstools/css-tokenizer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
       "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1087,10 +1086,9 @@
       }
     },
     "node_modules/@exodus/bytes": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.14.1.tgz",
-      "integrity": "sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ==",
-      "dev": true,
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -4561,14 +4559,13 @@
       "license": "MIT"
     },
     "node_modules/css-tree": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
-      "dev": true,
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "license": "MIT",
       "dependencies": {
-        "mdn-data": "2.12.2",
-        "source-map-js": "^1.0.1"
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
@@ -4629,7 +4626,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
       "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^5.0.0",
@@ -4661,7 +4657,6 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/dequal": {
@@ -4725,9 +4720,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.7.tgz",
+      "integrity": "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -4761,13 +4756,12 @@
       }
     },
     "node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=0.12"
+        "node": ">=20.19.0"
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
@@ -5007,7 +5001,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.6.0"
@@ -5085,7 +5078,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-url": {
@@ -5093,6 +5085,84 @@
       "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
       "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
       "license": "MIT"
+    },
+    "node_modules/isomorphic-dompurify": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-3.15.0.tgz",
+      "integrity": "sha512-9ZtkbQ8+SgNf6LuDAdu9bq23dVXMIGNM8ZYnyl2MufyZiSD5dqAUJcyjtYZz7B80HuPpEn/f0NCS6zKvavHtfA==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "^3.4.7",
+        "jsdom": "^29.1.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/jay-peg": {
       "version": "1.1.1",
@@ -5596,10 +5666,9 @@
       }
     },
     "node_modules/mdn-data": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
-      "dev": true,
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "license": "CC0-1.0"
     },
     "node_modules/mdurl": {
@@ -5849,13 +5918,12 @@
       "license": "MIT"
     },
     "node_modules/parse5": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
-      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
-      "dev": true,
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
       "license": "MIT",
       "dependencies": {
-        "entities": "^6.0.0"
+        "entities": "^8.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -6419,7 +6487,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6630,7 +6697,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
@@ -6832,7 +6898,6 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tailwind-merge": {
@@ -6928,7 +6993,6 @@
       "version": "7.0.24",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.24.tgz",
       "integrity": "sha512-1r6vQTTt1rUiJkI5vX7KG8PR342Ru/5Oh13kEQP2SMbRSZpOey9SrBe27IDxkoWulx8ShWu4K6C0BkctP8Z1bQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^7.0.24"
@@ -6941,14 +7005,12 @@
       "version": "7.0.24",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.24.tgz",
       "integrity": "sha512-pj7yygNMoMRqG7ML2SDQ0xNIOfN3IBDUcPVM2Sg6hP96oFNN2nqnzHreT3z9xLq85IWJyNTvD38O002DdOrPMw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tough-cookie": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
-      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
-      "dev": true,
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^7.0.5"
@@ -6961,7 +7023,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
@@ -7021,10 +7082,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.1.tgz",
-      "integrity": "sha512-5xoBibbmnjlcR3jdqtY2Lnx7WbrD/tHlT01TmvqZUFVc9Q1w4+j5hbnapTqbcXITMH1ovjq/W7BkqBilHiVAaA==",
-      "dev": true,
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.26.0.tgz",
+      "integrity": "sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -7285,7 +7345,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
@@ -7324,7 +7383,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20"
@@ -7334,7 +7392,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
       "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -7344,7 +7401,6 @@
       "version": "16.0.1",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
       "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.11.0",
@@ -7397,7 +7453,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -7407,7 +7462,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "clsx": "^2.1.1",
     "dialkit": "^1.1.0",
     "dompurify": "^3.4.0",
+    "isomorphic-dompurify": "^3.15.0",
     "jose": "^6.2.0",
     "lucide-react": "^0.576.0",
     "motion": "^12.34.5",

--- a/src/__tests__/agreement-hash.test.ts
+++ b/src/__tests__/agreement-hash.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { computeAgreementHash } from '@/lib/agreement-hash';
+
+const TITLE = 'Mutual Non-Disclosure Agreement';
+const SECTIONS = [
+  { number: 1, title: 'Confidentiality', content: '<p>Hold in strict confidence.</p>' },
+  { number: 2, title: 'Term', content: '<p>Three years.</p>' },
+];
+
+describe('computeAgreementHash', () => {
+  it('returns a 64-character lowercase hex string (SHA-256)', async () => {
+    const hash = await computeAgreementHash(TITLE, SECTIONS);
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is deterministic — identical input yields an identical hash', async () => {
+    const a = await computeAgreementHash(TITLE, SECTIONS);
+    const b = await computeAgreementHash(TITLE, SECTIONS);
+    expect(a).toBe(b);
+  });
+
+  it('is order-sensitive — reordering the sections changes the hash', async () => {
+    const ordered = await computeAgreementHash(TITLE, SECTIONS);
+    const reversed = await computeAgreementHash(TITLE, [SECTIONS[1], SECTIONS[0]]);
+    expect(reversed).not.toBe(ordered);
+  });
+
+  it('is content-sensitive — changing one section body changes the hash', async () => {
+    const original = await computeAgreementHash(TITLE, SECTIONS);
+    const tampered = await computeAgreementHash(TITLE, [
+      SECTIONS[0],
+      { ...SECTIONS[1], content: '<p>Five years.</p>' },
+    ]);
+    expect(tampered).not.toBe(original);
+  });
+
+  it('is field-boundary safe — moving text across the title/content boundary changes the hash', async () => {
+    // Guards against a naive concat (title+content) where "AB"+"" collides with "A"+"B".
+    const a = await computeAgreementHash('AB', [{ number: 1, title: '', content: '' }]);
+    const b = await computeAgreementHash('A', [{ number: 1, title: 'B', content: '' }]);
+    expect(a).not.toBe(b);
+  });
+});

--- a/src/__tests__/agreement-pdf.test.ts
+++ b/src/__tests__/agreement-pdf.test.ts
@@ -1,25 +1,108 @@
 import { describe, it, expect } from 'vitest';
-import { generateAgreementPdf } from '@/lib/agreement-pdf';
+import { PDFDocument } from 'pdf-lib';
+import { generateAgreementPdf, buildCertificateRows } from '@/lib/agreement-pdf';
+
+const BASE_INPUT = {
+  title: 'Non-Disclosure Agreement',
+  sections: [{ number: 1, title: 'Confidentiality', content: '<p>Test content</p>' }],
+  signer: {
+    fullName: 'John Doe',
+    address: '123 Main St, New York, NY 10001',
+    email: 'john@seeko.gg',
+    department: 'Coding',
+    role: 'Engineer',
+    engagementType: 'team_member' as const,
+    signedAt: new Date('2026-03-08T12:00:00Z'),
+  },
+};
 
 describe('generateAgreementPdf', () => {
   it('returns a Uint8Array with valid PDF magic bytes', async () => {
-    const pdf = await generateAgreementPdf({
-      title: 'Non-Disclosure Agreement',
-      sections: [{ number: 1, title: 'Confidentiality', content: '<p>Test content</p>' }],
-      signer: {
-        fullName: 'John Doe',
-        address: '123 Main St, New York, NY 10001',
-        email: 'john@seeko.gg',
-        department: 'Coding',
-        role: 'Engineer',
-        engagementType: 'team_member',
-        signedAt: new Date('2026-03-08T12:00:00Z'),
-      },
-    });
+    const pdf = await generateAgreementPdf(BASE_INPUT);
 
     expect(pdf).toBeInstanceOf(Uint8Array);
     expect(pdf.length).toBeGreaterThan(100);
     // PDF magic bytes: %PDF
     expect(String.fromCharCode(pdf[0], pdf[1], pdf[2], pdf[3])).toBe('%PDF');
+  });
+
+  it('appends ONE extra page (the Certificate of Completion) when certificate data is provided', async () => {
+    const withoutCert = await PDFDocument.load(await generateAgreementPdf(BASE_INPUT));
+    const withCert = await PDFDocument.load(
+      await generateAgreementPdf({
+        ...BASE_INPUT,
+        envelopeId: 'env-abc-123',
+        integrityHash: 'a'.repeat(64),
+        ip: '203.0.113.7',
+        userAgent: 'Mozilla/5.0 (Macintosh)',
+      }),
+    );
+    expect(withCert.getPageCount()).toBe(withoutCert.getPageCount() + 1);
+  });
+
+  it('does NOT append a certificate page for onboarding (no certificate data) — legacy/onboarding stays unchanged', async () => {
+    // Two identical onboarding calls produce the same page count (no cert appended).
+    const a = await PDFDocument.load(await generateAgreementPdf(BASE_INPUT));
+    const b = await PDFDocument.load(await generateAgreementPdf(BASE_INPUT));
+    expect(a.getPageCount()).toBe(b.getPageCount());
+  });
+
+  it('degrades gracefully — still appends the certificate (no throw) when ip/userAgent are absent', async () => {
+    const pdf = await generateAgreementPdf({
+      ...BASE_INPUT,
+      envelopeId: 'env-legacy',
+      integrityHash: 'b'.repeat(64),
+      // ip + userAgent intentionally omitted (a legacy/missing-header sign)
+    });
+    const doc = await PDFDocument.load(pdf);
+    const baseline = await PDFDocument.load(await generateAgreementPdf(BASE_INPUT));
+    expect(doc.getPageCount()).toBe(baseline.getPageCount() + 1);
+  });
+});
+
+describe('buildCertificateRows', () => {
+  const FULL = {
+    envelopeId: 'env-abc-123',
+    integrityHash: 'c'.repeat(64),
+    ip: '203.0.113.7',
+    userAgent: 'Mozilla/5.0 (Macintosh)',
+    signerName: 'John Doe',
+    signerEmail: 'john@seeko.gg',
+    signedAt: new Date('2026-03-08T12:30:45Z'),
+  };
+
+  it('renders every provided field as a label/value row', () => {
+    const rows = buildCertificateRows(FULL);
+    const map = Object.fromEntries(rows.map((r) => [r.label, r.value]));
+    expect(map['Envelope ID']).toBe('env-abc-123');
+    expect(map['Signer']).toBe('John Doe');
+    expect(map['Email']).toBe('john@seeko.gg');
+    expect(map['IP Address']).toBe('203.0.113.7');
+    expect(map['User Agent']).toBe('Mozilla/5.0 (Macintosh)');
+    expect(map['Document Hash (SHA-256)']).toBe('c'.repeat(64));
+  });
+
+  it('stamps the signed timestamp with an explicit, deterministic UTC timezone', () => {
+    const rows = buildCertificateRows(FULL);
+    const signed = rows.find((r) => r.label === 'Signed')!.value;
+    // Deterministic regardless of host timezone (formatted in UTC).
+    expect(signed).toContain('UTC');
+    expect(signed).toContain('2026');
+  });
+
+  it('renders "Not recorded" for absent audit fields (null/undefined/empty)', () => {
+    const rows = buildCertificateRows({
+      envelopeId: 'env-1',
+      integrityHash: undefined,
+      ip: null,
+      userAgent: '',
+      signerName: 'Jane',
+      signerEmail: 'jane@seeko.gg',
+      signedAt: new Date('2026-03-08T12:00:00Z'),
+    });
+    const map = Object.fromEntries(rows.map((r) => [r.label, r.value]));
+    expect(map['IP Address']).toBe('Not recorded');
+    expect(map['User Agent']).toBe('Not recorded');
+    expect(map['Document Hash (SHA-256)']).toBe('Not recorded');
   });
 });

--- a/src/app/api/external-signing/[token]/route.ts
+++ b/src/app/api/external-signing/[token]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServiceClient } from '@/lib/supabase/service';
+import { isSigningInvite } from '@/lib/invite-filters';
 import type { ExternalSigningInvite } from '@/lib/types';
 
 export async function GET(
@@ -15,7 +16,8 @@ export async function GET(
     .eq('token', token)
     .single() as { data: ExternalSigningInvite | null };
 
-  if (!invite) {
+  // Not-found and wrong-product (invoice / doc-share share this table) → one 404.
+  if (!isSigningInvite(invite)) {
     return NextResponse.json({ error: 'Invite not found' }, { status: 404 });
   }
 

--- a/src/app/api/external-signing/download/__tests__/route.test.ts
+++ b/src/app/api/external-signing/download/__tests__/route.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('next/server', () => ({
+  NextRequest: class {},
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({ body, status: init?.status ?? 200 }),
+    redirect: (url: string | URL, status?: number) => ({ redirectUrl: String(url), status: status ?? 307 }),
+  },
+}));
+
+const mockFrom = vi.fn();
+const mockCreateSignedUrl = vi.fn();
+vi.mock('@/lib/supabase/service', () => ({
+  getServiceClient: () => ({
+    from: mockFrom,
+    storage: { from: () => ({ createSignedUrl: mockCreateSignedUrl }) },
+  }),
+}));
+
+function makeSignedInvite(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'invite-1',
+    token: 'tok-abc',
+    status: 'signed',
+    template_type: 'preset',
+    template_id: 'mutual-nda',
+    ...overrides,
+  };
+}
+
+function makeFromImpl(invite: Record<string, unknown> | null) {
+  return () => ({
+    select: () => ({ eq: () => ({ single: async () => ({ data: invite }) }) }),
+  });
+}
+
+function makeReq(token: string | null, ip = '10.0.0.1') {
+  const params = new URLSearchParams();
+  if (token !== null) params.set('token', token);
+  return {
+    nextUrl: { searchParams: params },
+    headers: new Headers({ 'x-forwarded-for': ip }),
+  };
+}
+
+describe('GET /api/external-signing/download', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateSignedUrl.mockResolvedValue({ data: { signedUrl: 'https://signed.example/dl' }, error: null });
+  });
+
+  it('returns 400 when no token is supplied', async () => {
+    const { GET } = await import('../route');
+    const res = await GET(makeReq(null, '10.1.0.1') as any);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 for an unknown / non-signing token (never confirms a sibling product token)', async () => {
+    mockFrom.mockImplementation(makeFromImpl(null));
+    const { GET } = await import('../route');
+    const res = await GET(makeReq('nope', '10.1.0.2') as any);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when the token belongs to a non-signing row (invoice/doc-share)', async () => {
+    mockFrom.mockImplementation(makeFromImpl(makeSignedInvite({ template_type: 'invoice' })));
+    const { GET } = await import('../route');
+    const res = await GET(makeReq('tok-abc', '10.1.0.3') as any);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 409 when the invite exists but is not yet signed', async () => {
+    mockFrom.mockImplementation(makeFromImpl(makeSignedInvite({ status: 'verified' })));
+    const { GET } = await import('../route');
+    const res = await GET(makeReq('tok-abc', '10.1.0.4') as any);
+    expect(res.status).toBe(409);
+  });
+
+  it('302-redirects to a freshly-minted signed URL for a signed invite', async () => {
+    mockFrom.mockImplementation(makeFromImpl(makeSignedInvite()));
+    const { GET } = await import('../route');
+    const res = await GET(makeReq('tok-abc', '10.1.0.5') as any);
+    expect(res.status).toBe(302);
+    expect((res as { redirectUrl?: string }).redirectUrl).toBe('https://signed.example/dl');
+    expect(mockCreateSignedUrl).toHaveBeenCalledWith('external/invite-1/agreement.pdf', 1800);
+  });
+
+  it('returns 502 when the signed URL cannot be minted', async () => {
+    mockFrom.mockImplementation(makeFromImpl(makeSignedInvite()));
+    mockCreateSignedUrl.mockResolvedValue({ data: null, error: { message: 'nope' } });
+    const { GET } = await import('../route');
+    const res = await GET(makeReq('tok-abc', '10.1.0.6') as any);
+    expect(res.status).toBe(502);
+  });
+
+  it('rate-limits a single IP after too many requests (429)', async () => {
+    mockFrom.mockImplementation(makeFromImpl(makeSignedInvite()));
+    const { GET } = await import('../route');
+    const ip = '10.9.9.9';
+    let sawRateLimit = false;
+    // Far more than any reasonable per-hour cap; the limiter must eventually 429.
+    for (let i = 0; i < 60; i++) {
+      const res = await GET(makeReq('tok-abc', ip) as any);
+      if (res.status === 429) { sawRateLimit = true; break; }
+    }
+    expect(sawRateLimit).toBe(true);
+  });
+});

--- a/src/app/api/external-signing/download/route.ts
+++ b/src/app/api/external-signing/download/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServiceClient } from '@/lib/supabase/service';
+import { isSigningInvite } from '@/lib/invite-filters';
+import type { ExternalSigningInvite } from '@/lib/types';
+
+// Rate limiter: cap fresh signed-URL mints per IP per hour. A download is a
+// cheap, idempotent read, but each call asks storage for a brand-new signed URL,
+// so we still bound it — a token holder shouldn't be able to hammer the storage
+// signer (or harvest an unbounded stream of live URLs) from one address.
+const RATE_LIMIT = { max: 20, windowMs: 60 * 60 * 1000 };
+const ipHits = new Map<string, { count: number; resetAt: number }>();
+
+function isDownloadRateLimited(ip: string): boolean {
+  const now = Date.now();
+  if (ipHits.size > 100) {
+    for (const [key, entry] of ipHits) { if (now > entry.resetAt) ipHits.delete(key); }
+  }
+  const entry = ipHits.get(ip);
+  if (!entry || now > entry.resetAt) {
+    ipHits.set(ip, { count: 1, resetAt: now + RATE_LIMIT.windowMs });
+    return false;
+  }
+  if (entry.count >= RATE_LIMIT.max) return true;
+  entry.count++;
+  return false;
+}
+
+/**
+ * Token-gated signed-copy download for a completed signing.
+ *
+ * Bearer model: the URL token is the same credential the signer used to sign, so
+ * anyone holding it is already authorized to see their own document. We mint a
+ * fresh, short-lived (30-minute) storage signed URL per request and 302 to it —
+ * never a stable/public link, so a leaked redirect target expires quickly.
+ */
+export async function GET(request: NextRequest) {
+  const token = request.nextUrl.searchParams.get('token');
+  if (!token) return NextResponse.json({ error: 'Token required' }, { status: 400 });
+
+  const clientIp = request.headers.get('x-forwarded-for')?.split(',').pop()?.trim() || 'unknown';
+  if (isDownloadRateLimited(clientIp)) {
+    return NextResponse.json({ error: 'Too many download attempts. Try again later.' }, { status: 429 });
+  }
+
+  const service = getServiceClient();
+
+  const { data: invite } = await service
+    .from('external_signing_invites')
+    .select('id, token, status, template_type, template_id')
+    .eq('token', token)
+    .single() as { data: ExternalSigningInvite | null };
+
+  // Unknown tokens AND non-signing rows (invoice / doc-share share this table)
+  // collapse to one identical 404 — a signing route must never operate on, or
+  // confirm the existence of, a sibling product's token.
+  if (!isSigningInvite(invite)) {
+    return NextResponse.json({ error: 'Document not found' }, { status: 404 });
+  }
+
+  // Only a completed signing has a stored PDF behind it. (Distinguishing 409 from
+  // 404 here is safe: it's only reachable once you hold a valid signing token,
+  // at which point you're already the authorized party.)
+  if (invite.status !== 'signed') {
+    return NextResponse.json({ error: 'This agreement has not been signed yet' }, { status: 409 });
+  }
+
+  // Unlike the sign route's best-effort convenience URL, fetching the document IS
+  // the entire purpose of this request — a mint failure is a hard 502, not a
+  // silent fallback.
+  const pdfPath = `external/${invite.id}/agreement.pdf`;
+  const { data: signed, error } = await service.storage
+    .from('agreements')
+    .createSignedUrl(pdfPath, 1800);
+
+  if (error || !signed?.signedUrl) {
+    console.error('[external-signing/download] signed-URL mint failed:', error?.message ?? 'no signed URL returned');
+    return NextResponse.json({ error: 'Could not retrieve the document. Please try again.' }, { status: 502 });
+  }
+
+  return NextResponse.redirect(signed.signedUrl, 302);
+}

--- a/src/app/api/external-signing/reissue/__tests__/route.test.ts
+++ b/src/app/api/external-signing/reissue/__tests__/route.test.ts
@@ -1,0 +1,192 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('next/server', () => ({
+  NextRequest: class {},
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({ body, status: init?.status ?? 200 }),
+  },
+}));
+
+const mockFrom = vi.fn();
+vi.mock('@/lib/supabase/service', () => ({
+  getServiceClient: () => ({ from: mockFrom }),
+}));
+
+const mockSendInvite = vi.fn();
+const mockNotify = vi.fn();
+vi.mock('@/lib/email', () => ({
+  sendExternalInviteEmail: (...args: unknown[]) => mockSendInvite(...args),
+  sendReissueNotificationEmail: (...args: unknown[]) => mockNotify(...args),
+}));
+
+vi.mock('@/lib/external-agreement-templates', () => ({
+  getTemplateById: () => ({ name: 'Mutual NDA', sections: [] }),
+}));
+
+// bcryptjs is slow + native; the hash value is opaque to the route, so stub it.
+vi.mock('bcryptjs', () => ({
+  default: { hash: async () => 'hashed-code' },
+}));
+
+const PAST = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+type InviteStatus = 'pending' | 'verified' | 'signed' | 'expired' | 'revoked';
+type TemplateType = 'preset' | 'custom' | 'invoice' | 'doc_share';
+
+function makeInvite(overrides: { status?: InviteStatus; template_type?: TemplateType } = {}) {
+  return {
+    id: 'invite-1',
+    token: 'old-token-aaa',
+    status: overrides.status ?? 'expired',
+    expires_at: PAST,
+    recipient_email: 'signer@example.com',
+    template_type: overrides.template_type ?? 'preset',
+    template_id: 'mutual-nda',
+    custom_title: null,
+    personal_note: null,
+  };
+}
+
+/** from('external_signing_invites') resolves the invite on select; update is the captured spy. */
+function makeFromImpl(
+  invite: ReturnType<typeof makeInvite> | null,
+  updateSpy: ReturnType<typeof vi.fn>,
+) {
+  return () => ({
+    select: () => ({ eq: () => ({ single: async () => ({ data: invite }) }) }),
+    update: updateSpy,
+  });
+}
+
+function makeReq(ip: string, body: Record<string, unknown>) {
+  return {
+    headers: new Headers({ 'x-forwarded-for': ip, 'user-agent': 'vitest' }),
+    json: async () => body,
+  };
+}
+
+describe('POST /api/external-signing/reissue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSendInvite.mockResolvedValue(undefined);
+    mockNotify.mockResolvedValue(undefined);
+  });
+
+  it('returns 400 when no token is supplied', async () => {
+    const { POST } = await import('../route');
+    const res = await POST(makeReq('10.2.0.1', {}) as any);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when the token matches no invite', async () => {
+    mockFrom.mockImplementation(makeFromImpl(null, vi.fn()));
+    const { POST } = await import('../route');
+    const res = await POST(makeReq('10.2.0.2', { token: 'nope' }) as any);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 for a non-signing invite (invoice / doc_share) — no cross-product leak', async () => {
+    const updateSpy = vi.fn(() => ({ eq: async () => ({}) }));
+    mockFrom.mockImplementation(makeFromImpl(makeInvite({ template_type: 'invoice' }), updateSpy));
+    const { POST } = await import('../route');
+    const res = await POST(makeReq('10.2.0.3', { token: 'old-token-aaa' }) as any);
+    expect(res.status).toBe(404);
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(mockSendInvite).not.toHaveBeenCalled();
+  });
+
+  it('returns 409 when the invite is already signed', async () => {
+    const updateSpy = vi.fn(() => ({ eq: async () => ({}) }));
+    mockFrom.mockImplementation(makeFromImpl(makeInvite({ status: 'signed' }), updateSpy));
+    const { POST } = await import('../route');
+    const res = await POST(makeReq('10.2.0.4', { token: 'old-token-aaa' }) as any);
+    expect(res.status).toBe(409);
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when the invite was revoked (must stay dead — admin killed it)', async () => {
+    const updateSpy = vi.fn(() => ({ eq: async () => ({}) }));
+    mockFrom.mockImplementation(makeFromImpl(makeInvite({ status: 'revoked' }), updateSpy));
+    const { POST } = await import('../route');
+    const res = await POST(makeReq('10.2.0.5', { token: 'old-token-aaa' }) as any);
+    expect(res.status).toBe(403);
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(mockSendInvite).not.toHaveBeenCalled();
+  });
+
+  it('returns 409 when the link is still active (pending)', async () => {
+    const updateSpy = vi.fn(() => ({ eq: async () => ({}) }));
+    mockFrom.mockImplementation(makeFromImpl(makeInvite({ status: 'pending' }), updateSpy));
+    const { POST } = await import('../route');
+    const res = await POST(makeReq('10.2.0.6', { token: 'old-token-aaa' }) as any);
+    expect(res.status).toBe(409);
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 409 when the link is still active (verified)', async () => {
+    const updateSpy = vi.fn(() => ({ eq: async () => ({}) }));
+    mockFrom.mockImplementation(makeFromImpl(makeInvite({ status: 'verified' }), updateSpy));
+    const { POST } = await import('../route');
+    const res = await POST(makeReq('10.2.0.7', { token: 'old-token-aaa' }) as any);
+    expect(res.status).toBe(409);
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('rate-limits repeated reissues from one IP (429 once the cap is exceeded)', async () => {
+    mockFrom.mockImplementation(makeFromImpl(makeInvite({ status: 'expired' }), vi.fn(() => ({ eq: async () => ({}) }))));
+    const { POST } = await import('../route');
+    const ip = '10.2.0.99';
+    let last;
+    // Cap is 3/hour; the 4th request from the same IP must be blocked.
+    for (let i = 0; i < 4; i++) {
+      last = await POST(makeReq(ip, { token: 'old-token-aaa' }) as any);
+    }
+    expect(last!.status).toBe(429);
+  });
+
+  it('reissues an expired invite: 200, new token + future expiry + reset to pending, re-sends link, notifies admin', async () => {
+    let captured: Record<string, unknown> | null = null;
+    const updateSpy = vi.fn((arg: Record<string, unknown>) => {
+      captured = arg;
+      return { eq: async () => ({}) };
+    });
+    mockFrom.mockImplementation(makeFromImpl(makeInvite({ status: 'expired' }), updateSpy));
+
+    const { POST } = await import('../route');
+    const res = await POST(makeReq('10.2.0.10', { token: 'old-token-aaa' }) as any);
+
+    expect(res.status).toBe(200);
+
+    // DB reset
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(updateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'pending', verification_attempts: 0, verified_at: null }),
+    );
+    const c = captured as unknown as { token: string; expires_at: string };
+    expect(c.token).not.toBe('old-token-aaa');
+    expect(c.token.length).toBeGreaterThan(20);
+    expect(new Date(c.expires_at).getTime()).toBeGreaterThan(Date.now());
+
+    // Fresh signing link emailed to the recipient with the NEW token
+    expect(mockSendInvite).toHaveBeenCalledTimes(1);
+    expect(mockSendInvite).toHaveBeenCalledWith(
+      expect.objectContaining({ recipientEmail: 'signer@example.com', token: c.token }),
+    );
+
+    // Admin notified
+    expect(mockNotify).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 502 and does NOT touch the DB when the re-send email fails', async () => {
+    const updateSpy = vi.fn(() => ({ eq: async () => ({}) }));
+    mockFrom.mockImplementation(makeFromImpl(makeInvite({ status: 'expired' }), updateSpy));
+    mockSendInvite.mockRejectedValue(new Error('resend down'));
+
+    const { POST } = await import('../route');
+    const res = await POST(makeReq('10.2.0.11', { token: 'old-token-aaa' }) as any);
+
+    expect(res.status).toBe(502);
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/external-signing/reissue/route.ts
+++ b/src/app/api/external-signing/reissue/route.ts
@@ -1,0 +1,127 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServiceClient } from '@/lib/supabase/service';
+import { randomBytes, randomInt } from 'crypto';
+import bcrypt from 'bcryptjs';
+import { getTemplateById } from '@/lib/external-agreement-templates';
+import { sendExternalInviteEmail, sendReissueNotificationEmail } from '@/lib/email';
+import { isSigningInvite } from '@/lib/invite-filters';
+import type { ExternalSigningInvite } from '@/lib/types';
+
+// Public, token-gated self-service: a signer whose link has EXPIRED can request a
+// fresh one. Mints a new token + expiry and re-sends the signing email. Only ever
+// acts on `expired` invites — never `revoked` (admin killed it on purpose), `signed`
+// (already done), or still-live links — and never non-signing rows on the shared
+// `external_signing_invites` table. Rate-limited per IP because each call emails the
+// recipient (anti email-bombing).
+const RATE_LIMIT = { max: 3, windowMs: 60 * 60 * 1000 };
+const REISSUE_DAYS = 7; // mirrors the admin SendInviteForm default window
+const ipHits = new Map<string, { count: number; resetAt: number }>();
+
+function isReissueRateLimited(ip: string): boolean {
+  const now = Date.now();
+  if (ipHits.size > 100) {
+    for (const [key, entry] of ipHits) { if (now > entry.resetAt) ipHits.delete(key); }
+  }
+  const entry = ipHits.get(ip);
+  if (!entry || now > entry.resetAt) {
+    ipHits.set(ip, { count: 1, resetAt: now + RATE_LIMIT.windowMs });
+    return false;
+  }
+  if (entry.count >= RATE_LIMIT.max) return true;
+  entry.count++;
+  return false;
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  const { token } = body;
+  if (!token || typeof token !== 'string') {
+    return NextResponse.json({ error: 'Token required' }, { status: 400 });
+  }
+
+  const clientIp = request.headers.get('x-forwarded-for')?.split(',').pop()?.trim()
+    || request.headers.get('x-real-ip')
+    || 'unknown';
+  if (isReissueRateLimited(clientIp)) {
+    return NextResponse.json({ error: 'Too many requests. Try again later.' }, { status: 429 });
+  }
+
+  const service = getServiceClient();
+  const { data: invite } = await service
+    .from('external_signing_invites')
+    .select('id, token, status, expires_at, recipient_email, template_type, template_id, custom_title, personal_note')
+    .eq('token', token)
+    .single() as { data: ExternalSigningInvite | null };
+
+  // Unknown tokens AND non-signing rows return an identical 404 — never confirm the
+  // existence of an invoice / doc-share token through the signing surface.
+  if (!isSigningInvite(invite)) {
+    return NextResponse.json({ error: 'Invite not found' }, { status: 404 });
+  }
+
+  if (invite.status === 'signed') {
+    return NextResponse.json({ error: 'This agreement has already been signed' }, { status: 409 });
+  }
+  if (invite.status === 'revoked') {
+    return NextResponse.json(
+      { error: 'This link was revoked. Contact the sender for a new one.' },
+      { status: 403 },
+    );
+  }
+  if (invite.status !== 'expired') {
+    // pending / verified — the link is still usable, so there is nothing to reissue.
+    return NextResponse.json({ error: 'This link is still active.' }, { status: 409 });
+  }
+
+  // Mint a fresh token + end-of-day expiry. Resolve the email's template name exactly
+  // as the invite / resend routes do.
+  const newToken = randomBytes(32).toString('base64url');
+  const expiresAt = new Date();
+  expiresAt.setDate(expiresAt.getDate() + REISSUE_DAYS);
+  expiresAt.setHours(23, 59, 59, 999);
+
+  const verificationCode = String(randomInt(100000, 1000000));
+  const hashedCode = await bcrypt.hash(verificationCode, 10);
+
+  let templateName = invite.custom_title || 'Document';
+  if (invite.template_type === 'preset' && invite.template_id) {
+    const template = getTemplateById(invite.template_id);
+    templateName = template?.name || 'Document';
+  }
+
+  // Send the fresh link FIRST. If the email fails we surface a 502 and leave the invite
+  // untouched (still `expired`) so the signer can retry — never a committed `pending`
+  // row whose link was never delivered.
+  try {
+    await sendExternalInviteEmail({
+      recipientEmail: invite.recipient_email,
+      token: newToken,
+      personalNote: invite.personal_note,
+      templateName,
+      expiresAt,
+    });
+  } catch (err) {
+    console.error('Reissue email failed:', err);
+    return NextResponse.json(
+      { error: 'Could not send a new link. Please try again.' },
+      { status: 502 },
+    );
+  }
+
+  await (service.from('external_signing_invites') as any)
+    .update({
+      token: newToken,
+      expires_at: expiresAt.toISOString(),
+      verification_code: hashedCode,
+      verification_attempts: 0,
+      verified_at: null,
+      status: 'pending',
+    })
+    .eq('id', invite.id);
+
+  // Let the admin know a signer self-served a fresh link (non-blocking — a notify
+  // failure must not fail the reissue the signer already received).
+  sendReissueNotificationEmail({ recipientEmail: invite.recipient_email, templateName }).catch(console.error);
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/external-signing/resend/route.ts
+++ b/src/app/api/external-signing/resend/route.ts
@@ -4,6 +4,7 @@ import { getServiceClient } from '@/lib/supabase/service';
 import bcrypt from 'bcryptjs';
 import { sendExternalInviteEmail } from '@/lib/email';
 import { getTemplateById } from '@/lib/external-agreement-templates';
+import { isSigningInvite } from '@/lib/invite-filters';
 import type { ExternalSigningInvite } from '@/lib/types';
 
 export async function POST(request: NextRequest) {
@@ -24,7 +25,9 @@ export async function POST(request: NextRequest) {
     .eq('id', invite_id)
     .single() as { data: ExternalSigningInvite | null };
 
-  if (!invite) return NextResponse.json({ error: 'Invite not found' }, { status: 404 });
+  // Even an admin re-sends only signing rows here — invoice / doc-share share this
+  // table and have their own management surfaces. Not-found and wrong-product → 404.
+  if (!isSigningInvite(invite)) return NextResponse.json({ error: 'Invite not found' }, { status: 404 });
   if (invite.status === 'signed') return NextResponse.json({ error: 'Already signed' }, { status: 400 });
   if (invite.status === 'revoked') return NextResponse.json({ error: 'Invite is revoked' }, { status: 400 });
   if (new Date(invite.expires_at) < new Date()) return NextResponse.json({ error: 'Invite has expired — create a new one' }, { status: 400 });

--- a/src/app/api/external-signing/revoke/route.ts
+++ b/src/app/api/external-signing/revoke/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { getServiceClient } from '@/lib/supabase/service';
+import { isSigningInvite } from '@/lib/invite-filters';
+import type { ExternalSigningInvite } from '@/lib/types';
 
 export async function POST(request: NextRequest) {
   const supabase = await createClient();
@@ -16,11 +18,13 @@ export async function POST(request: NextRequest) {
   const service = getServiceClient();
   const { data: invite } = await service
     .from('external_signing_invites')
-    .select('status')
+    .select('status, template_type')
     .eq('id', invite_id)
-    .single() as { data: { status: string } | null };
+    .single() as { data: { status: string; template_type: ExternalSigningInvite['template_type'] } | null };
 
-  if (!invite) return NextResponse.json({ error: 'Invite not found' }, { status: 404 });
+  // Even an admin acts only on signing rows here — invoice / doc-share share this
+  // table and have their own management surfaces. Not-found and wrong-product → 404.
+  if (!isSigningInvite(invite)) return NextResponse.json({ error: 'Invite not found' }, { status: 404 });
   if (invite.status === 'signed') {
     return NextResponse.json({ error: 'Cannot revoke a signed invite' }, { status: 400 });
   }

--- a/src/app/api/external-signing/send-code/route.ts
+++ b/src/app/api/external-signing/send-code/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getServiceClient } from '@/lib/supabase/service';
 import bcrypt from 'bcryptjs';
 import { sendVerificationCodeEmail } from '@/lib/email';
+import { isSigningInvite } from '@/lib/invite-filters';
 import type { ExternalSigningInvite } from '@/lib/types';
 
 // Rate limiter: max 3 send-code requests per token per hour
@@ -37,11 +38,12 @@ export async function POST(request: NextRequest) {
 
   const { data: invite } = await service
     .from('external_signing_invites')
-    .select('id, recipient_email, status, expires_at')
+    .select('id, recipient_email, status, expires_at, template_type')
     .eq('token', token)
     .single() as { data: ExternalSigningInvite | null };
 
-  if (!invite) return NextResponse.json({ error: 'Invite not found' }, { status: 404 });
+  // Not-found and wrong-product (invoice / doc-share share this table) → one 404.
+  if (!isSigningInvite(invite)) return NextResponse.json({ error: 'Invite not found' }, { status: 404 });
 
   if (invite.status !== 'pending') {
     return NextResponse.json({ error: 'Invite is no longer available' }, { status: 400 });

--- a/src/app/api/external-signing/sign/__tests__/sign-certificate.test.ts
+++ b/src/app/api/external-signing/sign/__tests__/sign-certificate.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('next/server', () => ({
+  NextRequest: class {},
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({ body, status: init?.status ?? 200 }),
+  },
+}));
+
+const mockFrom = vi.fn();
+const mockUpload = vi.fn();
+const mockCreateSignedUrl = vi.fn();
+vi.mock('@/lib/supabase/service', () => ({
+  getServiceClient: () => ({
+    from: mockFrom,
+    storage: { from: () => ({ upload: mockUpload, createSignedUrl: mockCreateSignedUrl }) },
+  }),
+}));
+
+const mockGeneratePdf = vi.fn();
+vi.mock('@/lib/agreement-pdf', () => ({
+  generateAgreementPdf: mockGeneratePdf,
+}));
+
+const mockSendEmail = vi.fn();
+vi.mock('@/lib/email', () => ({
+  sendAgreementEmail: mockSendEmail,
+}));
+
+vi.mock('@/lib/external-agreement-templates', () => ({
+  getTemplateById: () => ({
+    name: 'Mutual NDA',
+    sections: [{ number: 1, title: 'Confidentiality', content: '<p>Body.</p>' }],
+  }),
+  withGuardianSection: (s: unknown) => s,
+}));
+
+const FUTURE = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+
+function makeInvite() {
+  return {
+    id: 'invite-1',
+    token: 'tok-abc',
+    status: 'verified',
+    expires_at: FUTURE,
+    recipient_email: 'signer@example.com',
+    template_type: 'preset',
+    template_id: 'mutual-nda',
+    custom_sections: null,
+    custom_title: null,
+    personal_note: null,
+    is_guardian_signing: false,
+  };
+}
+
+function makeFromImpl(invite: ReturnType<typeof makeInvite> | null, updateSpy: ReturnType<typeof vi.fn>) {
+  return () => ({
+    select: () => ({ eq: () => ({ single: async () => ({ data: invite }) }) }),
+    update: updateSpy,
+  });
+}
+
+function makeReq(ip: string, ua: string, body: Record<string, unknown>) {
+  return {
+    headers: new Headers({ 'x-forwarded-for': ip, 'user-agent': ua }),
+    json: async () => body,
+  };
+}
+
+const VALID_BODY = { token: 'tok-abc', full_name: 'Karti Patel', address: '1 Main St, City, ST 00000' };
+
+describe('POST /api/external-signing/sign — certificate + download URL', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGeneratePdf.mockResolvedValue(new Uint8Array([1, 2, 3]));
+    mockSendEmail.mockResolvedValue(undefined);
+    mockUpload.mockResolvedValue({ error: null });
+    mockCreateSignedUrl.mockResolvedValue({ data: { signedUrl: 'https://signed.example/abc' }, error: null });
+  });
+
+  it('returns a downloadUrl from a freshly-minted signed URL on success', async () => {
+    mockFrom.mockImplementation(makeFromImpl(makeInvite(), vi.fn(() => ({ eq: async () => ({}) }))));
+
+    const { POST } = await import('../route');
+    const res = await POST(makeReq('10.0.0.1', 'vitest-ua', VALID_BODY) as any);
+
+    expect(res.status).toBe(200);
+    expect((res.body as { downloadUrl?: string }).downloadUrl).toBe('https://signed.example/abc');
+  });
+
+  it('mints the signed URL for the invite path with a 30-minute (1800s) TTL', async () => {
+    mockFrom.mockImplementation(makeFromImpl(makeInvite(), vi.fn(() => ({ eq: async () => ({}) }))));
+
+    const { POST } = await import('../route');
+    await POST(makeReq('10.0.0.2', 'vitest-ua', VALID_BODY) as any);
+
+    expect(mockCreateSignedUrl).toHaveBeenCalledWith('external/invite-1/agreement.pdf', 1800);
+  });
+
+  it('passes the audit trail (envelopeId, integrity hash, ip, user-agent) into the PDF certificate', async () => {
+    mockFrom.mockImplementation(makeFromImpl(makeInvite(), vi.fn(() => ({ eq: async () => ({}) }))));
+
+    const { POST } = await import('../route');
+    await POST(makeReq('203.0.113.9', 'Mozilla/5.0 Test', VALID_BODY) as any);
+
+    expect(mockGeneratePdf).toHaveBeenCalledWith(
+      expect.objectContaining({
+        envelopeId: 'invite-1',
+        integrityHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+        ip: '203.0.113.9',
+        userAgent: 'Mozilla/5.0 Test',
+      }),
+    );
+  });
+
+  it('still succeeds (200) with downloadUrl null when the signed URL cannot be minted', async () => {
+    // A failed convenience-URL mint must not fail the signing the user already completed.
+    mockFrom.mockImplementation(makeFromImpl(makeInvite(), vi.fn(() => ({ eq: async () => ({}) }))));
+    mockCreateSignedUrl.mockResolvedValue({ data: null, error: { message: 'nope' } });
+
+    const { POST } = await import('../route');
+    const res = await POST(makeReq('10.0.0.3', 'vitest-ua', VALID_BODY) as any);
+
+    expect(res.status).toBe(200);
+    expect((res.body as { downloadUrl?: string | null }).downloadUrl).toBeNull();
+  });
+});

--- a/src/app/api/external-signing/sign/__tests__/sign-upload-failure.test.ts
+++ b/src/app/api/external-signing/sign/__tests__/sign-upload-failure.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('next/server', () => ({
+  NextRequest: class {},
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({ body, status: init?.status ?? 200 }),
+  },
+}));
+
+const mockFrom = vi.fn();
+const mockUpload = vi.fn();
+const mockCreateSignedUrl = vi.fn();
+vi.mock('@/lib/supabase/service', () => ({
+  getServiceClient: () => ({
+    from: mockFrom,
+    storage: { from: () => ({ upload: mockUpload, createSignedUrl: mockCreateSignedUrl }) },
+  }),
+}));
+
+const mockGeneratePdf = vi.fn();
+vi.mock('@/lib/agreement-pdf', () => ({
+  generateAgreementPdf: mockGeneratePdf,
+}));
+
+const mockSendEmail = vi.fn();
+vi.mock('@/lib/email', () => ({
+  sendAgreementEmail: mockSendEmail,
+}));
+
+vi.mock('@/lib/external-agreement-templates', () => ({
+  getTemplateById: () => ({
+    name: 'Mutual NDA',
+    sections: [{ heading: 'Confidential information', body: 'Body.' }],
+  }),
+  withGuardianSection: (s: unknown) => s,
+}));
+
+const FUTURE = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+
+function makeInvite() {
+  return {
+    id: 'invite-1',
+    token: 'tok-abc',
+    status: 'verified',
+    expires_at: FUTURE,
+    recipient_email: 'signer@example.com',
+    template_type: 'preset',
+    template_id: 'mutual-nda',
+    custom_sections: null,
+    custom_title: null,
+    personal_note: null,
+    is_guardian_signing: false,
+  };
+}
+
+/** from('external_signing_invites') resolves the invite on select; update is a spy. */
+function makeFromImpl(invite: ReturnType<typeof makeInvite> | null, updateSpy: ReturnType<typeof vi.fn>) {
+  return () => ({
+    select: () => ({ eq: () => ({ single: async () => ({ data: invite }) }) }),
+    update: updateSpy,
+  });
+}
+
+function makeReq(ip: string, body: Record<string, unknown>) {
+  return {
+    headers: new Headers({ 'x-forwarded-for': ip, 'user-agent': 'vitest' }),
+    json: async () => body,
+  };
+}
+
+const VALID_BODY = { token: 'tok-abc', full_name: 'Karti Patel', address: '1 Main St, City, ST 00000' };
+
+describe('POST /api/external-signing/sign — storage upload failure', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGeneratePdf.mockResolvedValue(new Uint8Array([1, 2, 3]));
+    mockSendEmail.mockResolvedValue(undefined);
+    mockCreateSignedUrl.mockResolvedValue({ data: { signedUrl: 'https://signed.example/ok' }, error: null });
+  });
+
+  it('returns 502 when the PDF upload fails', async () => {
+    const updateSpy = vi.fn(() => ({ eq: async () => ({}) }));
+    mockFrom.mockImplementation(makeFromImpl(makeInvite(), updateSpy));
+    mockUpload.mockResolvedValue({ error: { message: 'storage exploded' } });
+
+    const { POST } = await import('../route');
+    const res = await POST(makeReq('10.0.0.1', VALID_BODY) as any);
+
+    expect(res.status).toBe(502);
+  });
+
+  it('does NOT mark the invite signed when the upload fails', async () => {
+    const updateSpy = vi.fn(() => ({ eq: async () => ({}) }));
+    mockFrom.mockImplementation(makeFromImpl(makeInvite(), updateSpy));
+    mockUpload.mockResolvedValue({ error: { message: 'storage exploded' } });
+
+    const { POST } = await import('../route');
+    await POST(makeReq('10.0.0.2', VALID_BODY) as any);
+
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT send the signed-copy email when the upload fails', async () => {
+    const updateSpy = vi.fn(() => ({ eq: async () => ({}) }));
+    mockFrom.mockImplementation(makeFromImpl(makeInvite(), updateSpy));
+    mockUpload.mockResolvedValue({ error: { message: 'storage exploded' } });
+
+    const { POST } = await import('../route');
+    await POST(makeReq('10.0.0.3', VALID_BODY) as any);
+
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it('still completes (200) and marks signed when the upload succeeds', async () => {
+    const updateSpy = vi.fn(() => ({ eq: async () => ({}) }));
+    mockFrom.mockImplementation(makeFromImpl(makeInvite(), updateSpy));
+    mockUpload.mockResolvedValue({ error: null });
+
+    const { POST } = await import('../route');
+    const res = await POST(makeReq('10.0.0.4', VALID_BODY) as any);
+
+    expect(res.status).toBe(200);
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(updateSpy).toHaveBeenCalledWith(expect.objectContaining({ status: 'signed' }));
+    expect(mockSendEmail).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/api/external-signing/sign/route.ts
+++ b/src/app/api/external-signing/sign/route.ts
@@ -2,8 +2,17 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getServiceClient } from '@/lib/supabase/service';
 import { getTemplateById, withGuardianSection } from '@/lib/external-agreement-templates';
 import { generateAgreementPdf } from '@/lib/agreement-pdf';
+import { computeAgreementHash } from '@/lib/agreement-hash';
 import { sendAgreementEmail } from '@/lib/email';
+import { isSigningInvite } from '@/lib/invite-filters';
 import type { ExternalSigningInvite } from '@/lib/types';
+
+// Defensive caps on DB-sourced custom agreement content before it reaches pdf-lib.
+// custom_sections originate from parse-pdf (uploaded PDF → Claude → stored, never
+// sanitized at insert), so they are attacker-influenced; an unbounded array or a
+// multi-megabyte body would let a signer DoS the (expensive) PDF generation.
+const MAX_SECTIONS = 30;
+const MAX_SECTION_CONTENT_CHARS = 200_000;
 
 // Rate limiter: max 5 sign attempts per IP per hour (PDF generation is expensive)
 const RATE_LIMIT = { max: 5, windowMs: 60 * 60 * 1000 };
@@ -55,7 +64,12 @@ export async function POST(request: NextRequest) {
     .eq('token', token)
     .single() as { data: ExternalSigningInvite | null };
 
-  if (!invite) return NextResponse.json({ error: 'Invite not found' }, { status: 404 });
+  // Unknown tokens AND non-signing rows (invoice / doc-share share this table)
+  // collapse to one identical 404 — a signing route must never operate on, or
+  // confirm the existence of, a sibling product's token.
+  if (!isSigningInvite(invite)) {
+    return NextResponse.json({ error: 'Invite not found' }, { status: 404 });
+  }
 
   if (invite.status === 'signed') {
     return NextResponse.json({ error: 'This agreement has already been signed' }, { status: 409 });
@@ -79,11 +93,14 @@ export async function POST(request: NextRequest) {
     }
   }
 
-  // Capture IP + user agent
+  // Capture IP + user agent for the legal audit trail. Persist `null` (not the
+  // string 'unknown', and not a spoofable raw header) when the IP is unavailable:
+  // a fabricated value would poison the ESIGN/UETA audit record. The certificate
+  // renders "Not recorded" for null fields.
   const ip = request.headers.get('x-forwarded-for')?.split(',').pop()?.trim()
     || request.headers.get('x-real-ip')
-    || 'unknown';
-  const userAgent = request.headers.get('user-agent') || 'unknown';
+    || null;
+  const userAgent = request.headers.get('user-agent') || null;
 
   // Resolve sections
   let sections;
@@ -101,29 +118,75 @@ export async function POST(request: NextRequest) {
     sections = withGuardianSection(sections);
   }
 
-  // Generate PDF
-  const pdfBytes = await generateAgreementPdf({
-    title,
-    sections,
-    signer: {
-      fullName: full_name.trim(),
-      address: address.trim(),
-      email: invite.recipient_email,
-      signedAt: new Date(),
-      minorName: invite.is_guardian_signing ? minor_name.trim() : undefined,
-    },
-  });
+  // Defensive cap on the (DB-sourced) agreement body before it reaches pdf-lib.
+  // Reject — never silently truncate — so a signer is never handed a document
+  // missing clauses they're agreeing to.
+  if (Array.isArray(sections)) {
+    const totalChars = sections.reduce(
+      (n, s) => n + (typeof s?.content === 'string' ? s.content.length : 0),
+      0,
+    );
+    if (sections.length > MAX_SECTIONS || totalChars > MAX_SECTION_CONTENT_CHARS) {
+      return NextResponse.json({ error: 'This agreement is too large to process.' }, { status: 422 });
+    }
+  }
+
+  // Integrity hash over the EXACT content being signed (title + final, guardian-
+  // injected sections). Printed on the certificate so the stored document is
+  // self-verifying — re-hashing the agreement text must reproduce this value.
+  const integrityHash = await computeAgreementHash(title, sections);
+
+  // Generate PDF. pdf-lib's StandardFonts are Latin1-only, so a name/address with
+  // characters outside that set (CJK, emoji, some control chars) throws — return a
+  // clear 422 instead of an unhandled 500, and leave the invite 'verified' so the
+  // signer can correct their input and retry (never a half-committed signed state).
+  let pdfBytes: Uint8Array;
+  try {
+    pdfBytes = await generateAgreementPdf({
+      title,
+      sections,
+      signer: {
+        fullName: full_name.trim(),
+        address: address.trim(),
+        email: invite.recipient_email,
+        signedAt: new Date(),
+        minorName: invite.is_guardian_signing ? minor_name.trim() : undefined,
+      },
+      // Certificate of Completion audit trail. `ip`/`userAgent` may be null
+      // (missing headers) → the certificate prints "Not recorded" rather than a
+      // fabricated value.
+      envelopeId: invite.id,
+      integrityHash,
+      ip,
+      userAgent,
+    });
+  } catch (err) {
+    console.error('[external-signing/sign] PDF generation failed:', err instanceof Error ? err.message : err);
+    return NextResponse.json(
+      { error: 'We could not generate your document. Please check your name and address for unsupported characters.' },
+      { status: 422 },
+    );
+  }
 
   // Upload to storage
+  const pdfPath = `external/${invite.id}/agreement.pdf`;
   const { error: uploadError } = await service.storage
     .from('agreements')
-    .upload(`external/${invite.id}/agreement.pdf`, pdfBytes, {
+    .upload(pdfPath, pdfBytes, {
       contentType: 'application/pdf',
       upsert: true,
     });
 
   if (uploadError) {
+    // Do NOT mark the invite signed or email a copy if we couldn't store the
+    // PDF — that would leave the DB claiming "signed" with no document behind
+    // it (and a later download 404). Keep the invite 'verified' so the signer
+    // can retry, and surface a 502 so the client shows a retryable error.
     console.error('PDF upload error:', uploadError);
+    return NextResponse.json(
+      { error: 'Could not store the signed document. Please try again.' },
+      { status: 502 }
+    );
   }
 
   // Update invite record
@@ -149,5 +212,19 @@ export async function POST(request: NextRequest) {
     sections,
   }).catch(console.error);
 
-  return NextResponse.json({ success: true });
+  // Mint a short-lived (30-minute) signed URL so the signer can download their
+  // own copy from the success screen. A failure here must NOT fail the signing
+  // the signer already completed (and was emailed) — fall back to a null
+  // downloadUrl, which the success screen handles by showing the email path only.
+  let downloadUrl: string | null = null;
+  try {
+    const { data: signed } = await service.storage
+      .from('agreements')
+      .createSignedUrl(pdfPath, 1800);
+    downloadUrl = signed?.signedUrl ?? null;
+  } catch (err) {
+    console.error('[external-signing/sign] signed-URL mint failed:', err instanceof Error ? err.message : err);
+  }
+
+  return NextResponse.json({ success: true, downloadUrl });
 }

--- a/src/app/api/external-signing/verify/route.ts
+++ b/src/app/api/external-signing/verify/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getServiceClient } from '@/lib/supabase/service';
 import bcrypt from 'bcryptjs';
 import { getTemplateById } from '@/lib/external-agreement-templates';
+import { isSigningInvite } from '@/lib/invite-filters';
 import type { ExternalSigningInvite } from '@/lib/types';
 
 const MAX_ATTEMPTS = 5;
@@ -12,7 +13,7 @@ interface VerifyRow {
   expires_at: string;
   verification_code: string;
   verification_attempts: number;
-  template_type: string;
+  template_type: ExternalSigningInvite['template_type'];
   template_id: string | null;
   custom_sections: any;
   custom_title: string | null;
@@ -30,7 +31,9 @@ export async function POST(request: NextRequest) {
 
   // Atomic increment: only increment if under the limit, return the updated row.
   // This prevents race conditions where concurrent requests all read attempts=0.
-  // Note: purpose is NOT filtered here since external-signing invites use purpose='signing' or NULL.
+  // Cross-product isolation can't be enforced inside the RPC (signing rows use
+  // purpose='signing' OR NULL), so every row this route reads is run through
+  // isSigningInvite below before it is acted on.
   const { data: updated, error: rpcError } = await (service as any).rpc('increment_verification_attempt', {
     p_token: token,
     p_purpose: 'signing',
@@ -51,11 +54,12 @@ export async function POST(request: NextRequest) {
     // RPC returned nothing — either invite not found, wrong status, or attempts exhausted
     const { data: invite } = await service
       .from('external_signing_invites')
-      .select('id, status, verification_attempts')
+      .select('id, status, verification_attempts, template_type')
       .eq('token', token)
-      .single();
+      .single() as { data: Pick<ExternalSigningInvite, 'id' | 'status' | 'verification_attempts' | 'template_type'> | null };
 
-    if (!invite) return NextResponse.json({ error: 'Invite not found' }, { status: 404 });
+    // Not-found and wrong-product (invoice / doc-share) collapse to one 404.
+    if (!isSigningInvite(invite)) return NextResponse.json({ error: 'Invite not found' }, { status: 404 });
     if (invite.status === 'verified' || invite.status === 'signed') {
       return NextResponse.json({ error: 'Invite has already been verified' }, { status: 409 });
     }
@@ -66,6 +70,11 @@ export async function POST(request: NextRequest) {
   }
 
   const invite = updated[0];
+
+  // A non-signing row must never be verified through the signing surface.
+  if (!isSigningInvite(invite)) {
+    return NextResponse.json({ error: 'Invite not found' }, { status: 404 });
+  }
 
   // Check expiry
   if (new Date(invite.expires_at) < new Date()) {
@@ -117,7 +126,8 @@ async function verifyFallback(service: ReturnType<typeof getServiceClient>, toke
     .eq('token', token)
     .single() as { data: (ExternalSigningInvite & { verification_code: string }) | null };
 
-  if (!invite) return NextResponse.json({ error: 'Invite not found' }, { status: 404 });
+  // Not-found and wrong-product (invoice / doc-share) collapse to one 404.
+  if (!isSigningInvite(invite)) return NextResponse.json({ error: 'Invite not found' }, { status: 404 });
 
   if (invite.status === 'verified' || invite.status === 'signed') {
     return NextResponse.json({ error: 'Invite has already been verified' }, { status: 409 });

--- a/src/app/sign/[token]/__tests__/client-expired-reissue.test.tsx
+++ b/src/app/sign/[token]/__tests__/client-expired-reissue.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { SigningPageClient } from '../client';
+
+// The expired terminal lets a signer self-serve a fresh link via the reissue
+// endpoint. The new token is emailed (never returned), so the UI only confirms.
+describe('SigningPageClient — expired self-service reissue', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+  });
+
+  it('requests a fresh link from the expired terminal, then confirms', async () => {
+    render(<SigningPageClient token="tok-xyz" initialData={{ status: 'expired' }} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /new link/i }));
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    const [url, opts] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe('/api/external-signing/reissue');
+    expect(JSON.parse(opts.body as string)).toEqual({ token: 'tok-xyz' });
+
+    // The button is replaced by an inbox confirmation.
+    expect(await screen.findByText(/on its way/i)).toBeInTheDocument();
+  });
+
+  it('surfaces the server error when reissue fails', async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({ ok: false, json: async () => ({ error: 'Too many requests. Try again later.' }) });
+    render(<SigningPageClient token="tok-xyz" initialData={{ status: 'expired' }} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /new link/i }));
+
+    expect(await screen.findByText(/too many requests/i)).toBeInTheDocument();
+  });
+});

--- a/src/app/sign/[token]/__tests__/client-notfound.test.tsx
+++ b/src/app/sign/[token]/__tests__/client-notfound.test.tsx
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SigningPageClient } from '../client';
+
+// page.tsx routes unknown tokens AND sibling-product rows through the client as
+// status='notfound', so they wear the same light terminal chrome as every other
+// end state. These guard the two decisions that routing locked in: the unified
+// "Link not found" terminal renders, and the signer ceremony carries no logo.
+describe('SigningPageClient — not-found terminal', () => {
+  it('renders the unified "Link not found" terminal', () => {
+    render(<SigningPageClient token="whatever" initialData={{ status: 'notfound' }} />);
+    expect(screen.getByRole('heading', { name: /link not found/i })).toBeInTheDocument();
+  });
+
+  it('renders no logo image (the S-mark was removed from the signer)', () => {
+    const { container } = render(
+      <SigningPageClient token="whatever" initialData={{ status: 'notfound' }} />,
+    );
+    expect(container.querySelector('img')).toBeNull();
+  });
+});

--- a/src/app/sign/[token]/client.tsx
+++ b/src/app/sign/[token]/client.tsx
@@ -1,14 +1,27 @@
 'use client';
 
 import { useState } from 'react';
-import { motion } from 'motion/react';
-import { FileCheck, Clock, Ban, FileText } from 'lucide-react';
+import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
+import { FileCheck, Clock, Ban, FileQuestion, Mail, Loader2 } from 'lucide-react';
 import { VerificationForm } from '@/components/external-signing/VerificationForm';
 import { AgreementForm } from '@/components/agreement/AgreementForm';
+import { RecipientSheet } from '@/components/external/RecipientSheet';
+import { TerminalStatus } from '@/components/external/TerminalStatus';
+import { Button } from '@/components/ui/button';
 import { withGuardianSection } from '@/lib/external-agreement-templates';
-import { springs } from '@/lib/motion';
+import { springs, ceremonySwap } from '@/lib/motion';
+import { cn } from '@/lib/utils';
+import {
+  LIGHT_RECIPIENT_TITLE,
+  LIGHT_RECIPIENT_MUTED,
+  LIGHT_RECIPIENT_CTA,
+  LIGHT_TERMINAL_ICON,
+  LIGHT_SUCCESS_TEXT,
+} from '@/components/dashboard/lightKit';
 
 const SPRING = springs.smooth;
+
+type Section = { number: number; title: string; content: string };
 
 interface SigningPageClientProps {
   token: string;
@@ -17,167 +30,210 @@ interface SigningPageClientProps {
     maskedEmail?: string;
     templateName?: string;
     personalNote?: string;
-    sections?: { number: number; title: string; content: string }[];
+    sections?: Section[];
     isGuardianSigning?: boolean;
   };
 }
 
+// Terminal screens share one shape (icon chip + headline + line of copy). The
+// expired screen alone carries a self-service action, wired below by status.
+const TERMINALS: Record<
+  string,
+  { iconKey: keyof typeof LIGHT_TERMINAL_ICON; icon: React.ReactNode; title: string; description: string }
+> = {
+  signed: {
+    iconKey: 'signed',
+    icon: <FileCheck className="size-7" />,
+    title: 'Already signed',
+    description: 'This document has already been signed. A copy was sent to your email.',
+  },
+  expired: {
+    iconKey: 'expired',
+    icon: <Clock className="size-7" />,
+    title: 'Link expired',
+    description: "This signing link has expired. Request a fresh one below and we'll email it to you.",
+  },
+  revoked: {
+    iconKey: 'revoked',
+    icon: <Ban className="size-7" />,
+    title: 'Link revoked',
+    description: 'This signing link is no longer valid. Please contact the sender if you believe this is a mistake.',
+  },
+  notfound: {
+    iconKey: 'notfound',
+    icon: <FileQuestion className="size-7" />,
+    title: 'Link not found',
+    description: "We couldn't find this signing request. Please check the link, or contact the sender for a new one.",
+  },
+};
+
 export function SigningPageClient({ token, initialData }: SigningPageClientProps) {
   const alreadyVerified = initialData.status === 'verified' && !!initialData.sections;
   const [verified, setVerified] = useState(alreadyVerified);
-  const [sections, setSections] = useState<{ number: number; title: string; content: string }[] | null>(
+  const [sections, setSections] = useState<Section[] | null>(
     initialData.sections
-      ? (initialData.isGuardianSigning ? withGuardianSection(initialData.sections) : initialData.sections)
-      : null
+      ? initialData.isGuardianSigning
+        ? withGuardianSection(initialData.sections)
+        : initialData.sections
+      : null,
   );
   const [title, setTitle] = useState(initialData.templateName || 'Agreement');
   const [personalNote, setPersonalNote] = useState(initialData.personalNote);
+  const [dismissed, setDismissed] = useState(false);
+  // Drawer → fullscreen on "Continue to sign": AgreementForm signals when the
+  // ceremony leaves the reading step, and the sheet grows to match.
+  const [expanded, setExpanded] = useState(false);
+  const reduce = useReducedMotion();
 
-  // Terminal states
-  if (initialData.status === 'signed') {
+  // ── Terminal states (signed / expired / revoked / not-found) ──
+  // Dismissible: the ceremony is over, so the signer may swipe/tap away. On
+  // dismiss the sheet slides off to reveal a quiet "you can close this" hint.
+  const terminal = TERMINALS[initialData.status];
+  if (terminal) {
     return (
-      <StatusPage
-        icon={<FileCheck className="size-7 text-seeko-accent" />}
-        title="Document already signed"
-        description="This document has already been signed. A copy was sent to your email."
-      />
+      <AnimatePresence>
+        {dismissed ? (
+          <ClosedHint key="closed" />
+        ) : (
+          <RecipientSheet key="terminal" dismissible onDismiss={() => setDismissed(true)}>
+            <TerminalStatus
+              iconKey={terminal.iconKey}
+              icon={terminal.icon}
+              title={terminal.title}
+              description={terminal.description}
+              action={initialData.status === 'expired' ? <ReissueAction token={token} /> : undefined}
+            />
+          </RecipientSheet>
+        )}
+      </AnimatePresence>
     );
   }
 
-  if (initialData.status === 'expired') {
-    return (
-      <StatusPage
-        icon={<Clock className="size-7 text-yellow-400" />}
-        title="Link expired"
-        description="This signing link has expired. Please contact the sender for a new link."
-      />
-    );
-  }
-
-  if (initialData.status === 'revoked') {
-    return (
-      <StatusPage
-        icon={<Ban className="size-7 text-destructive" />}
-        title="Link revoked"
-        description="This signing link is no longer valid."
-      />
-    );
-  }
-
-  // Verification phase
-  if (!verified || !sections) {
-    return (
-      <div className="flex min-h-dvh items-center justify-center bg-background px-4 pb-[env(safe-area-inset-bottom)] pt-[env(safe-area-inset-top)]">
-        <motion.div
-          initial={{ opacity: 0, y: 24 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={SPRING}
-          className="w-full max-w-md"
-        >
-          {/* Card */}
-          <div className="rounded-2xl border border-border bg-card p-6 sm:p-8">
-            {/* Header: logo + document info */}
-            <div className="flex items-start gap-4 mb-6">
-              <div className="flex size-11 shrink-0 items-center justify-center rounded-xl bg-muted ring-1 ring-border">
-                <FileText className="size-5 text-muted-foreground" />
+  // ── Active ceremony (verify → review → sign) ──
+  // One persistent, LOCKED sheet: it can't be swiped away mid-signature. The
+  // inner panel cross-fades from verification to the agreement once the signer
+  // proves their email, so the surface itself never leaves the screen.
+  return (
+    <RecipientSheet expanded={expanded}>
+      <AnimatePresence mode="wait" initial={false}>
+        {!verified || !sections ? (
+          <motion.div key="verify" {...ceremonySwap(reduce)} className="flex flex-col gap-6">
+            {/* Header — no logo (signer feedback): icon chip + the document name */}
+            <div className="flex flex-col items-center gap-4 pt-2 text-center">
+              <div className="flex size-12 items-center justify-center rounded-2xl bg-black/[0.04] text-[#6e6e6e]">
+                <Mail className="size-5" />
               </div>
-              <div className="min-w-0">
-                <h1 className="text-lg font-semibold text-foreground leading-tight">{initialData.templateName}</h1>
-                <p className="text-sm text-muted-foreground mt-0.5">Document signing request</p>
-              </div>
+              <h1 className={cn('text-[22px] leading-tight tracking-[-0.01em]', LIGHT_RECIPIENT_TITLE)}>
+                {initialData.templateName || 'Signature request'}
+              </h1>
             </div>
 
-            {/* Personal note */}
-            {initialData.personalNote && (
-              <motion.div
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                transition={{ delay: 0.1 }}
-                className="mb-6 rounded-lg bg-muted/50 px-4 py-3"
-              >
-                <p className="text-sm text-foreground/70 leading-relaxed italic">
-                  &ldquo;{initialData.personalNote}&rdquo;
-                </p>
-              </motion.div>
-            )}
-
-            {/* Divider */}
-            <div className="h-px bg-border mb-6" />
-
-            {/* Verification */}
             <VerificationForm
+              light
               token={token}
               maskedEmail={initialData.maskedEmail || '***'}
               onVerified={(data) => {
-                const d = data as { sections: { number: number; title: string; content: string }[]; title: string; personalNote?: string };
+                const d = data as { sections: Section[]; title: string; personalNote?: string };
                 setSections(initialData.isGuardianSigning ? withGuardianSection(d.sections) : d.sections);
                 setTitle(d.title);
                 setPersonalNote(d.personalNote);
                 setVerified(true);
               }}
             />
-          </div>
+          </motion.div>
+        ) : (
+          <motion.div key="sign" {...ceremonySwap(reduce)}>
+            <AgreementForm
+              light
+              userId=""
+              userEmail=""
+              sections={sections}
+              title={title}
+              showEngagementType={false}
+              signEndpoint="/api/external-signing/sign"
+              signPayloadExtra={{ token }}
+              successRedirect={null}
+              personalNote={personalNote}
+              isGuardianSigning={initialData.isGuardianSigning}
+              onExpandedChange={setExpanded}
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </RecipientSheet>
+  );
+}
 
-          {/* Footer outside card */}
-          <div className="mt-4 flex items-center justify-center gap-1.5">
-            <img src="/seeko-s.png" alt="SEEKO" className="size-4 opacity-40" />
-            <span className="text-xs text-muted-foreground/50">Powered by SEEKO Studio</span>
-          </div>
-        </motion.div>
-      </div>
+/** Shown after a terminal sheet is dismissed — the page is spent, nothing to do. */
+function ClosedHint() {
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ delay: 0.15, duration: 0.3 }}
+      className="overview-light fixed inset-0 z-40 flex items-center justify-center bg-[var(--ov-bg)] px-6 text-center"
+    >
+      <p className={cn('text-[15px]', LIGHT_RECIPIENT_MUTED)}>You can close this page now.</p>
+    </motion.div>
+  );
+}
+
+/**
+ * Expired-only self-service: emails the signer a fresh link via the reissue
+ * endpoint. The new token is delivered by email (never returned in the response),
+ * so the UI only confirms that a new link is on its way.
+ */
+function ReissueAction({ token }: { token: string }) {
+  const [status, setStatus] = useState<'idle' | 'sending' | 'sent' | 'error'>('idle');
+  const [error, setError] = useState('');
+
+  async function requestNewLink() {
+    setStatus('sending');
+    setError('');
+    try {
+      const res = await fetch('/api/external-signing/reissue', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(data.error || 'Could not send a new link. Please try again.');
+        setStatus('error');
+        return;
+      }
+      setStatus('sent');
+    } catch {
+      setError('Could not send a new link. Please try again.');
+      setStatus('error');
+    }
+  }
+
+  if (status === 'sent') {
+    return (
+      <motion.p
+        initial={{ opacity: 0, y: 6 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={SPRING}
+        className={cn('text-sm leading-relaxed', LIGHT_SUCCESS_TEXT)}
+      >
+        A new link is on its way to your inbox. It may take a minute to arrive.
+      </motion.p>
     );
   }
 
-  // Signing phase — reuse AgreementForm
   return (
-    <div className="flex min-h-dvh flex-col items-center justify-center bg-background px-4 pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
-      <div className="w-full max-w-2xl py-6">
-        <div className="flex items-center justify-center mb-6">
-          <Logo />
-        </div>
-        <AgreementForm
-          userId=""
-          userEmail=""
-          sections={sections}
-          title={title}
-          showEngagementType={false}
-          signEndpoint="/api/external-signing/sign"
-          signPayloadExtra={{ token }}
-          successRedirect={null}
-          personalNote={personalNote}
-          isGuardianSigning={initialData.isGuardianSigning}
-        />
-      </div>
-    </div>
-  );
-}
-
-function StatusPage({ icon, title, description }: { icon: React.ReactNode; title: string; description: string }) {
-  return (
-    <div className="flex min-h-dvh items-center justify-center bg-background px-4 pb-[env(safe-area-inset-bottom)] pt-[env(safe-area-inset-top)]">
-      <div className="flex max-w-md flex-col items-center gap-6 text-center">
-        <Logo />
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={SPRING}
-          className="flex flex-col items-center gap-4 text-center"
-        >
-          <div className="flex size-14 items-center justify-center rounded-full bg-muted ring-1 ring-border">
-            {icon}
-          </div>
-          <h1 className="text-xl font-semibold text-foreground">{title}</h1>
-          <p className="text-sm text-muted-foreground">{description}</p>
-        </motion.div>
-      </div>
-    </div>
-  );
-}
-
-function Logo() {
-  return (
-    <div>
-      <img src="/seeko-s.png" alt="SEEKO" className="size-10 mx-auto" />
+    <div className="flex w-full flex-col items-center gap-2">
+      <Button
+        type="button"
+        onClick={requestNewLink}
+        disabled={status === 'sending'}
+        className={cn('gap-2', LIGHT_RECIPIENT_CTA)}
+      >
+        {status === 'sending' ? <Loader2 className="size-4 animate-spin" /> : <Mail className="size-4" />}
+        {status === 'sending' ? 'Sending…' : 'Request a new link'}
+      </Button>
+      {status === 'error' && <p className="text-sm text-[#d4503e]">{error}</p>}
     </div>
   );
 }

--- a/src/app/sign/[token]/page.tsx
+++ b/src/app/sign/[token]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { getServiceClient } from '@/lib/supabase/service';
 import { getTemplateById } from '@/lib/external-agreement-templates';
+import { isSigningInvite } from '@/lib/invite-filters';
 import { SigningPageClient } from './client';
 import type { ExternalSigningInvite } from '@/lib/types';
 
@@ -24,15 +25,12 @@ export default async function ExternalSignPage({ params }: Props) {
     .eq('token', token)
     .single() as { data: ExternalSigningInvite | null };
 
-  if (!invite) {
-    return (
-      <div className="flex min-h-dvh items-center justify-center bg-background px-4 pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
-        <div className="text-center">
-          <h1 className="text-xl font-semibold text-foreground">Link not found</h1>
-          <p className="mt-2 text-sm text-muted-foreground">This signing link is invalid or has been removed.</p>
-        </div>
-      </div>
-    );
+  // Unknown tokens AND non-signing rows (invoice / doc-share share this table)
+  // resolve to the same not-found terminal — a signing URL must never expose, or
+  // act on, a sibling product's invite. Routed through the client so it wears the
+  // unified light terminal chrome (no logo), exactly like the other end states.
+  if (!isSigningInvite(invite)) {
+    return <SigningPageClient token={token} initialData={{ status: 'notfound' }} />;
   }
 
   // Check expiration

--- a/src/components/agreement/AddressAutocomplete.tsx
+++ b/src/components/agreement/AddressAutocomplete.tsx
@@ -4,6 +4,8 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import { Input } from '@/components/ui/input';
 import { MapPin, Loader2 } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
+import { cn } from '@/lib/utils';
+import { LIGHT_INPUT } from '@/components/dashboard/lightKit';
 
 interface AddressAutocompleteProps {
   value: string;
@@ -11,6 +13,8 @@ interface AddressAutocompleteProps {
   id?: string;
   placeholder?: string;
   required?: boolean;
+  /** Opt into the light signer-ceremony theme. Default false → dark (onboarding untouched). */
+  light?: boolean;
 }
 
 interface NominatimResult {
@@ -24,6 +28,7 @@ export function AddressAutocomplete({
   id,
   placeholder,
   required,
+  light = false,
 }: AddressAutocompleteProps) {
   const [suggestions, setSuggestions] = useState<NominatimResult[]>([]);
   const [loading, setLoading] = useState(false);
@@ -108,10 +113,11 @@ export function AddressAutocomplete({
           placeholder={placeholder}
           required={required}
           autoComplete="off"
+          className={cn(light && LIGHT_INPUT)}
         />
         {loading && (
           <div className="absolute right-3 top-1/2 -translate-y-1/2">
-            <Loader2 className="size-3.5 animate-spin text-muted-foreground" />
+            <Loader2 className={cn('size-3.5 animate-spin', light ? 'text-[#9a9a9a]' : 'text-muted-foreground')} />
           </div>
         )}
       </div>
@@ -123,7 +129,12 @@ export function AddressAutocomplete({
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -4 }}
             transition={{ duration: 0.15 }}
-            className="absolute z-50 mt-1 w-full rounded-lg border border-border bg-popover shadow-xl overflow-hidden"
+            className={cn(
+              'absolute z-50 mt-1 w-full rounded-lg overflow-hidden',
+              light
+                ? 'border border-black/[0.08] bg-white shadow-seeko'
+                : 'border border-border bg-popover shadow-xl'
+            )}
           >
             {suggestions.map((result, i) => (
               <button
@@ -131,18 +142,23 @@ export function AddressAutocomplete({
                 type="button"
                 onClick={() => handleSelect(result)}
                 onMouseEnter={() => setActiveIndex(i)}
-                className={`flex w-full items-start gap-2.5 px-3 py-2.5 text-left text-sm transition-colors ${
-                  i === activeIndex
-                    ? 'bg-muted text-foreground'
-                    : 'text-muted-foreground hover:bg-muted/50'
-                }`}
+                className={cn(
+                  'flex w-full items-start gap-2.5 px-3 py-2.5 text-left text-sm transition-colors',
+                  light
+                    ? i === activeIndex
+                      ? 'bg-black/[0.04] text-[#111]'
+                      : 'text-[#6e6e6e] hover:bg-black/[0.03]'
+                    : i === activeIndex
+                      ? 'bg-muted text-foreground'
+                      : 'text-muted-foreground hover:bg-muted/50'
+                )}
               >
-                <MapPin className="size-3.5 shrink-0 mt-0.5 text-muted-foreground" />
+                <MapPin className={cn('size-3.5 shrink-0 mt-0.5', light ? 'text-[#9a9a9a]' : 'text-muted-foreground')} />
                 <span className="line-clamp-2">{result.display_name}</span>
               </button>
             ))}
-            <div className="border-t border-border px-3 py-1.5">
-              <p className="text-[10px] text-muted-foreground/50">Powered by OpenStreetMap</p>
+            <div className={cn('px-3 py-1.5', light ? 'border-t border-black/[0.06]' : 'border-t border-border')}>
+              <p className={cn('text-[10px]', light ? 'text-[#9a9a9a]' : 'text-muted-foreground/50')}>Powered by OpenStreetMap</p>
             </div>
           </motion.div>
         )}

--- a/src/components/agreement/AgreementForm.tsx
+++ b/src/components/agreement/AgreementForm.tsx
@@ -24,22 +24,69 @@
 
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { motion, AnimatePresence } from 'motion/react';
+import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
 import { acquireScrollLock, releaseScrollLock } from '@/lib/scroll-lock';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
-import { Loader2, ArrowRight, FileText, Check, ArrowDown } from 'lucide-react';
+import { Loader2, ArrowRight, FileText, Check, ArrowDown, Download } from 'lucide-react';
 import { AddressAutocomplete } from '@/components/agreement/AddressAutocomplete';
 import { SignatureDrawing } from '@/components/agreement/SignatureDrawing';
+import { SignaturePad, type SignatureValue } from '@/components/agreement/SignaturePad';
 import { useHaptics } from '@/components/HapticsProvider';
-import DOMPurify from 'dompurify';
+import { sanitizeHtml } from '@/lib/sanitize';
 import { springs } from '@/lib/motion';
+import { cn } from '@/lib/utils';
+import {
+  LIGHT_RECIPIENT_CARD,
+  LIGHT_RECIPIENT_MUTED,
+  LIGHT_RECIPIENT_HAIRLINE,
+  LIGHT_INPUT,
+  LIGHT_RECIPIENT_CTA,
+  LIGHT_SUCCESS_CHIP,
+  LIGHT_SUCCESS_TEXT,
+  LIGHT_FOCUS_RING,
+  BTN_SECONDARY,
+} from '@/components/dashboard/lightKit';
 
 const SPRING = springs.smooth;
 const SPRING_SNAPPY = springs.firm;
+
+// Light signer ceremony only: the read → sign swap is a fast, calm crossfade.
+// The signing form is a high-cognitive-load surface, so a long staggered entrance
+// reads as sluggish (and the height-collapse exit reads as a stall, not a fade).
+// One quick fade for the whole form on a strong front-loaded ease-out; reduced
+// motion stays opacity-only. Dark onboarding keeps its deliberate staggered
+// storyboard untouched (these consts are referenced only behind `light` checks).
+const LIGHT_SWAP_EASE = [0.22, 1, 0.36, 1] as const;
+const LIGHT_PHASE_OUT = { duration: 0.09, ease: LIGHT_SWAP_EASE };
+const LIGHT_PHASE_IN = { duration: 0.15, ease: LIGHT_SWAP_EASE };
+// Light signer ceremony: the CTA is ONE persistent button across the read↔sign swap,
+// NOT two buttons morphed via `layoutId`. A shared-element morph can't bridge an
+// AnimatePresence mode="wait" gap — the source unmounts before the target mounts, so
+// it teleports ("falls/jumps"). Instead the single button stays mounted and motion's
+// `layout` glides it to its new position as the content above changes height — it
+// follows the resizing card (transitions.dev "card resize": 300ms, same ease-out).
+const LIGHT_CTA_GLIDE = { duration: 0.3, ease: LIGHT_SWAP_EASE };
+
+// Light ceremony only: wrap the read↔sign content + the persistent CTA in ONE <form>
+// so the lifted-out submit button still submits. Dark onboarding keeps its sign-phase
+// <motion.form> (the wrapper is a no-op Fragment there → DOM byte-identical).
+function CeremonyShell({
+  light,
+  onSubmit,
+  children,
+}: {
+  light: boolean;
+  onSubmit: (e: React.FormEvent) => void;
+  children: React.ReactNode;
+}) {
+  // `relative` gives popLayout's absolutely-positioned exiting phase a positioning
+  // context so it stays put while it fades (instead of jumping to the page origin).
+  return light ? <form onSubmit={onSubmit} className="relative">{children}</form> : <>{children}</>;
+}
 
 interface AgreementFormProps {
   userId: string;
@@ -62,6 +109,12 @@ interface AgreementFormProps {
   personalNote?: string;
   // Guardian signing for a minor
   isGuardianSigning?: boolean;
+  // Opt into the light signer-ceremony theme. Default false → dark (onboarding untouched).
+  light?: boolean;
+  // Light signer-ceremony only: notify the host sheet when the ceremony leaves the
+  // reading step for the signing act, so it can grow drawer → fullscreen. Onboarding
+  // omits it → no-op (and the sheet chrome doesn't exist there anyway).
+  onExpandedChange?: (expanded: boolean) => void;
 }
 
 export function AgreementForm({
@@ -79,13 +132,43 @@ export function AgreementForm({
   successRedirect,
   personalNote,
   isGuardianSigning = false,
+  light = false,
+  onExpandedChange,
 }: AgreementFormProps) {
   const router = useRouter();
   const { trigger } = useHaptics();
   const scrollRef = useRef<HTMLDivElement>(null);
+  const reduce = useReducedMotion();
+
+  // Reduced-motion-aware field entrance.
+  //   light:  no per-field motion — the whole sign form fades in as ONE fast unit
+  //           (see the motion.form below). Staggering a legal form reads as sluggish
+  //           on a high-attention surface, which is exactly the "too slow" the signer felt.
+  //   dark:   onboarding's deliberate staggered storyboard, untouched (opacity + rise,
+  //           cascading delay on SPRING).
+  //   reduce: quick opacity-only fade (no translate, no stagger) in either theme.
+  const fieldRise = (delay: number) =>
+    reduce
+      ? { initial: { opacity: 0 }, animate: { opacity: 1 }, transition: { duration: 0.12 } }
+      : light
+        ? {}
+        : { initial: { opacity: 0, y: 12 }, animate: { opacity: 1, y: 0 }, transition: { ...SPRING, delay } };
 
   // Phase: 'read' → 'sign' → 'success'
   const [phase, setPhase] = useState<'read' | 'sign' | 'success'>('read');
+
+  // Light lifts the submit button OUT of the sign step (into the persistent CTA), so
+  // its sign step is a plain motion.div inside the outer <form>. Dark keeps the sign
+  // step AS the <motion.form> (submit lives inside it) — unchanged.
+  const SignWrapper = light ? motion.div : motion.form;
+
+  // The signing act (everything past reading) is a full-attention moment: tell the
+  // host sheet to grow drawer → fullscreen (mobile) / taller card (desktop). Reading
+  // stays a peek-sized drawer. onExpandedChange is stable (a useState setter), so this
+  // fires only on phase change; onboarding passes no handler → no-op.
+  useEffect(() => {
+    onExpandedChange?.(phase !== 'read');
+  }, [phase, onExpandedChange]);
   const [scrollProgress, setScrollProgress] = useState(0);
   const [hasScrolledToBottom, setHasScrolledToBottom] = useState(false);
 
@@ -97,6 +180,12 @@ export function AgreementForm({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const [minorName, setMinorName] = useState('');
+  // Light signer-ceremony only: the drawn/typed signature captured by SignaturePad.
+  const [signatureValue, setSignatureValue] = useState<SignatureValue | null>(null);
+  // External signing only: the short-lived signed-copy URL returned by the sign
+  // route, surfaced as a download button on the success dialog. Null when the
+  // (best-effort) mint failed — the success copy then falls back to email-only.
+  const [downloadUrl, setDownloadUrl] = useState<string | null>(null);
 
   // Signature animation: plays inline, then pops up confirmation dialog
   const [signed, setSigned] = useState(false);
@@ -132,7 +221,13 @@ export function AgreementForm({
     }
   }, []);
 
-  const canSubmit = fullName.trim().length > 0 && address.trim().length > 0 && (!isGuardianSigning || minorName.trim().length > 0);
+  // In the light signer ceremony a captured signature is required; onboarding
+  // (dark) derives the signature from the legal name, so it stays ungated.
+  const canSubmit =
+    fullName.trim().length > 0 &&
+    address.trim().length > 0 &&
+    (!isGuardianSigning || minorName.trim().length > 0) &&
+    (!light || signatureValue !== null);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -150,6 +245,16 @@ export function AgreementForm({
           address: address.trim(),
           ...(showEngagementType ? { engagement_type: engagementType } : {}),
           ...(isGuardianSigning ? { minor_name: minorName.trim() } : {}),
+          // Light ceremony plumbs the captured signature; `signature_kind`
+          // disambiguates a drawn PNG dataURL from a typed name so the Phase-4
+          // certificate can validate/render each without sniffing the string.
+          ...(light && signatureValue
+            ? {
+                signature_image:
+                  signatureValue.kind === 'drawn' ? signatureValue.dataUrl : signatureValue.text,
+                signature_kind: signatureValue.kind,
+              }
+            : {}),
           ...signPayloadExtra,
         }),
       });
@@ -162,6 +267,11 @@ export function AgreementForm({
         trigger('error');
         return;
       }
+
+      // External signing returns a short-lived signed-copy URL for the success
+      // dialog's download button. Onboarding omits it (undefined → null), so the
+      // button never renders there.
+      setDownloadUrl(typeof data.downloadUrl === 'string' ? data.downloadUrl : null);
 
       trigger('success');
       setSigKey(k => k + 1);
@@ -201,33 +311,73 @@ export function AgreementForm({
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 0.3 }}
-            className="fixed inset-0 z-[60] flex items-center justify-center bg-black/80 backdrop-blur-md px-4"
+            className={cn(
+              'fixed inset-0 z-[60] flex justify-center',
+              // Light signer ceremony: the success state is a bottom DRAWER on mobile
+              // (continues the ceremony's drawer language) and a centered modal on
+              // desktop. Dark onboarding stays centered + pixel-identical.
+              light
+                ? 'items-end px-0 sm:items-center sm:px-4 bg-black/30 backdrop-blur-sm'
+                : 'items-center px-4 bg-black/80 backdrop-blur-md',
+            )}
           >
             <motion.div
-              initial={{ opacity: 0, y: 40 }}
+              initial={reduce ? { opacity: 0 } : { opacity: 0, y: 40 }}
               animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: 40 }}
-              transition={SPRING}
-              className="mx-0 sm:mx-4 w-full max-w-sm rounded-t-2xl sm:rounded-2xl border border-border bg-card p-8 pb-[max(2rem,env(safe-area-inset-bottom))] sm:pb-8 shadow-2xl"
+              exit={reduce ? { opacity: 0 } : { opacity: 0, y: 40 }}
+              transition={reduce ? { duration: 0.12 } : SPRING}
+              className={cn(
+                'w-full border p-8 pb-[max(2rem,env(safe-area-inset-bottom))] sm:pb-8',
+                light
+                  // Mobile: full-bleed drawer, 28px top corners (matches RecipientSheet).
+                  // Desktop (sm:): unchanged centered modal — max-w-sm, all corners, gutter.
+                  ? 'rounded-t-[28px] border-black/[0.06] bg-white shadow-seeko sm:mx-4 sm:max-w-sm sm:rounded-2xl'
+                  : 'mx-0 max-w-sm rounded-t-2xl border-border bg-card shadow-2xl sm:mx-4 sm:rounded-2xl',
+              )}
             >
               <div className="flex flex-col items-center gap-4">
+                {/* Success check: a check may scale UP for impact, but never from 0
+                    (nothing in the real world appears from nothing) — start at 0.8 +
+                    opacity. Reduced motion gets a plain fade, no spring pop. */}
                 <motion.div
-                  initial={{ scale: 0 }}
-                  animate={{ scale: 1 }}
-                  transition={{ ...SPRING_SNAPPY, delay: 0.15 }}
+                  initial={reduce ? { opacity: 0 } : { scale: 0.8, opacity: 0 }}
+                  animate={reduce ? { opacity: 1 } : { scale: 1, opacity: 1 }}
+                  transition={reduce ? { duration: 0.12 } : { ...SPRING_SNAPPY, delay: 0.15 }}
                 >
-                  <div className="flex size-14 items-center justify-center rounded-full bg-seeko-accent/15 ring-1 ring-seeko-accent/30">
-                    <Check className="size-7 text-seeko-accent" strokeWidth={2.5} />
+                  <div
+                    className={cn(
+                      'flex size-14 items-center justify-center rounded-full ring-1',
+                      light ? `${LIGHT_SUCCESS_CHIP} ring-[#15803d]/20` : 'bg-seeko-accent/15 ring-seeko-accent/30',
+                    )}
+                  >
+                    <Check className={cn('size-7', light ? LIGHT_SUCCESS_TEXT : 'text-seeko-accent')} strokeWidth={2.5} />
                   </div>
                 </motion.div>
                 <div className="text-center">
-                  <p className="text-lg font-semibold text-foreground">Agreement Signed</p>
-                  <p className="mt-1.5 text-sm text-muted-foreground leading-relaxed">
+                  <p className={cn('text-lg font-semibold', light ? 'text-[#111]' : 'text-foreground')}>Agreement Signed</p>
+                  <p className={cn('mt-1.5 text-sm leading-relaxed', light ? LIGHT_RECIPIENT_MUTED : 'text-muted-foreground')}>
                     {successRedirect === null
-                      ? 'A signed copy has been sent to your email. You may close this page.'
+                      ? downloadUrl
+                        ? 'A signed copy was emailed to you. You can also download it below.'
+                        : 'A signed copy has been sent to your email. You may close this page.'
                       : 'A signed copy has been sent to your email. Redirecting you now...'}
                   </p>
                 </div>
+                {/* External signing only: download the just-minted signed copy.
+                    A real anchor (not a button) so it works without JS and the
+                    browser handles the PDF. Opens in a new tab to keep the
+                    success screen intact. */}
+                {successRedirect === null && downloadUrl && (
+                  <a
+                    href={downloadUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={cn(BTN_SECONDARY, 'mt-1 inline-flex w-full items-center justify-center gap-2', LIGHT_FOCUS_RING)}
+                  >
+                    <Download className="size-4" strokeWidth={2} />
+                    Download signed copy
+                  </a>
+                )}
               </div>
             </motion.div>
           </motion.div>
@@ -238,16 +388,24 @@ export function AgreementForm({
       <AnimatePresence mode="wait">
         <motion.div
           key="form"
-          exit={{ opacity: 0, y: -12 }}
-          transition={SPRING}
+          exit={reduce ? { opacity: 0 } : { opacity: 0, y: -12 }}
+          transition={reduce ? { duration: 0.12 } : SPRING}
         >
-          <Card className="overflow-visible">
-            <CardContent className="pt-6">
+          {/* In light the RecipientSheet IS the white surface, so the Card chrome
+              (bg / border / shadow / padding) is neutralized and only its layout
+              remains. Dark onboarding keeps the full card. */}
+          <Card className={cn('overflow-visible', light && 'border-0 bg-transparent p-0 shadow-none')}>
+            <CardContent className={cn(light ? 'p-0' : 'pt-6')}>
               {/* Personal note from sender */}
               {personalNote && (
-                <div className="mb-4 rounded-lg border border-seeko-accent/20 bg-seeko-accent/5 px-4 py-3">
-                  <p className="text-xs font-medium text-seeko-accent mb-1">Note from sender</p>
-                  <p className="text-sm text-muted-foreground">{personalNote}</p>
+                <div
+                  className={cn(
+                    'mb-4 rounded-lg border px-4 py-3',
+                    light ? 'border-black/[0.06] bg-black/[0.02]' : 'border-seeko-accent/20 bg-seeko-accent/5',
+                  )}
+                >
+                  <p className={cn('text-xs font-medium mb-1', light ? 'text-[#6e6e6e]' : 'text-seeko-accent')}>Note from sender</p>
+                  <p className={cn('text-sm', light ? 'text-[#2a2a2a]' : 'text-muted-foreground')}>{personalNote}</p>
                 </div>
               )}
 
@@ -267,78 +425,159 @@ export function AgreementForm({
                 </div>
               )}
 
-              <AnimatePresence mode="wait">
+              <CeremonyShell light={light} onSubmit={handleSubmit}>
+              {/* light: popLayout pulls the EXITING phase out of flow (position:absolute)
+                  so the entering phase takes its place in the SAME frame — the content
+                  height steps read→sign once, with no empty intermediate. That lets the
+                  persistent CTA below glide monotonically to its new spot instead of
+                  chasing the collapse up and falling back (the "jump"). dark: keeps
+                  mode="wait" (exit-then-enter) so onboarding's height-collapse is untouched. */}
+              <AnimatePresence mode={light ? 'popLayout' : 'wait'} initial={false}>
                 {phase === 'read' ? (
                   <motion.div
                     key="read-phase"
-                    exit={{ opacity: 0, height: 0 }}
-                    transition={{ duration: 0.3 }}
+                    // light: a fast opacity fade-OUT only (read → sign). No enter animation, so the
+                    // reverse (sign → read) snaps in instantly — fading it back in while the sheet
+                    // shrinks read as choppy. The surface itself resizes (RecipientSheet CARD_RESIZE),
+                    // so collapsing height here too is redundant. dark: onboarding's height-collapse, untouched.
+                    exit={reduce ? { opacity: 0 } : light ? { opacity: 0 } : { opacity: 0, height: 0 }}
+                    transition={light && !reduce ? LIGHT_PHASE_OUT : { duration: reduce ? 0.12 : 0.3 }}
                     className="overflow-hidden"
                   >
-                    {/* Agreement header + progress */}
-                    <div className="flex items-center justify-between mb-2">
-                      <div className="flex items-center gap-2 text-sm font-medium text-foreground">
-                        <FileText className="size-4 text-muted-foreground" />
-                        {title}
+                    {light ? (
+                      /* Mockup header: doc-icon chip + name + read instruction.
+                         The % readout and progress bar are dropped in favor of the
+                         bottom-fade cue on the scroll body + the scroll hint below. */
+                      <div className="mb-4 flex items-start gap-3">
+                        <div className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-black/[0.04] text-[#6e6e6e]">
+                          <FileText className="size-[18px]" />
+                        </div>
+                        <div className="min-w-0 pt-0.5">
+                          <h2 className="text-[16px] font-semibold leading-tight tracking-[-0.01em] text-[#111]">{title}</h2>
+                          <p className={cn('mt-0.5 text-[13px]', LIGHT_RECIPIENT_MUTED)}>Read each section before signing.</p>
+                        </div>
                       </div>
-                      <span className="text-xs text-muted-foreground tabular-nums">
-                        {Math.round(scrollProgress * 100)}%
-                      </span>
-                    </div>
+                    ) : (
+                      <>
+                        {/* Agreement header + progress */}
+                        <div className="flex items-center justify-between mb-2">
+                          <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+                            <FileText className="size-4 text-muted-foreground" />
+                            {title}
+                          </div>
+                          <span className="text-xs tabular-nums text-muted-foreground">
+                            {Math.round(scrollProgress * 100)}%
+                          </span>
+                        </div>
 
-                    {/* Progress bar */}
-                    <div className="h-0.5 w-full rounded-full bg-border mb-3 overflow-hidden">
-                      <motion.div
-                        className="h-full bg-seeko-accent rounded-full"
-                        style={{ width: `${scrollProgress * 100}%` }}
-                        transition={{ duration: 0.1 }}
-                      />
-                    </div>
+                        {/* Progress bar */}
+                        <div className="h-0.5 w-full rounded-full mb-3 overflow-hidden bg-border">
+                          <motion.div
+                            className="h-full rounded-full bg-seeko-accent"
+                            style={{ width: `${scrollProgress * 100}%` }}
+                            transition={{ duration: 0.1 }}
+                          />
+                        </div>
+                      </>
+                    )}
 
-                    {/* Scrollable agreement text */}
+                    {/* Scrollable agreement text — wrapped so the light theme can
+                        lay a bottom fade over it as a "more below" cue. */}
+                    <div className="relative">
                     <div
                       ref={scrollRef}
                       onScroll={handleScroll}
-                      className="max-h-[min(32rem,60dvh)] overflow-y-auto rounded-md bg-muted/20 p-4 sm:p-5 prose prose-sm prose-invert max-w-none
-                        [scrollbar-width:thin]
-                        [&_h3]:text-base [&_h3]:font-semibold [&_h3]:text-foreground [&_h3]:mt-6 [&_h3]:mb-2
-                        [&_p]:text-sm [&_p]:text-muted-foreground [&_p]:leading-relaxed [&_p]:mb-3
-                        [&_ul]:text-sm [&_ul]:text-muted-foreground [&_ul]:ml-4 [&_ul]:mb-3 [&_li]:mb-1"
+                      className={cn(
+                        'max-h-[min(32rem,60dvh)] overflow-y-auto rounded-md p-4 sm:p-5 prose prose-sm max-w-none [scrollbar-width:thin]',
+                        '[&_h3]:text-base [&_h3]:font-semibold [&_h3]:mt-6 [&_h3]:mb-2',
+                        '[&_p]:text-sm [&_p]:leading-relaxed [&_p]:mb-3',
+                        '[&_ul]:text-sm [&_ul]:ml-4 [&_ul]:mb-3 [&_li]:mb-1',
+                        light
+                          ? 'max-h-[min(20rem,42dvh)] rounded-xl bg-[#fafafa] ring-1 ring-inset ring-black/[0.05] [scrollbar-color:#d4d4d4_transparent] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-black/15 [&::-webkit-scrollbar-track]:bg-transparent [&_h3]:!mt-0 [&_h3]:!mb-1.5 [&_h3]:tracking-[-0.01em] [&_h3]:text-balance [&_h3]:text-[#111] [&_p]:!mb-0 [&_p]:text-pretty [&_p]:text-[#4a4a4a] [&_p+p]:!mt-3 [&_ul]:text-[#4a4a4a]'
+                          : 'bg-muted/20 prose-invert [&_h3]:text-foreground [&_p]:text-muted-foreground [&_ul]:text-muted-foreground',
+                      )}
                     >
-                      {sections.map((section) => (
-                        <div key={section.number}>
-                          <h3>
-                            <span className="inline-flex size-6 items-center justify-center rounded bg-muted text-xs font-mono text-muted-foreground mr-2 align-middle">
-                              {section.number}
-                            </span>
-                            {section.title}
-                          </h3>
-                          <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(section.content) }} />
+                      {light ? (
+                        <div className="space-y-6">
+                          {sections.map((section) => (
+                            // Editorial clause numeral: a quiet figure hanging in the left gutter
+                            // (not a UI chip), with the body hanging-indented under the title so
+                            // each clause reads as a set legal section. Number stays muted ink
+                            // (azure is reserved for interactive meaning) and is tabular so digit
+                            // widths don't jitter from clause to clause.
+                            // items-start (not items-baseline) + matched numeral leading: cap-aligned
+                            // by design (numeral shoulder to title cap), deterministically — do NOT
+                            // revert to baseline. items-baseline only cap-aligned by luck of
+                            // leading-none and silently dropped the numeral ~23px on a 2-line title.
+                            <div
+                              key={section.number}
+                              className="grid grid-cols-[1.5rem_1fr] items-start gap-x-3"
+                            >
+                              <span className="select-none text-right text-[18px] font-normal leading-[1.5] tabular-nums text-[#9a9a9a]">
+                                {section.number}
+                              </span>
+                              <div className="min-w-0">
+                                <h3>{section.title}</h3>
+                                <div dangerouslySetInnerHTML={{ __html: sanitizeHtml(section.content) }} />
+                              </div>
+                            </div>
+                          ))}
                         </div>
-                      ))}
-                      <div className="mt-8 pt-4 border-t border-border">
-                        <p className="text-xs text-muted-foreground italic">
+                      ) : (
+                        sections.map((section) => (
+                          <div key={section.number}>
+                            <h3>
+                              <span
+                                className={cn(
+                                  'inline-flex size-6 items-center justify-center rounded text-xs font-mono mr-2 align-middle',
+                                  'bg-muted text-muted-foreground',
+                                )}
+                              >
+                                {section.number}
+                              </span>
+                              {section.title}
+                            </h3>
+                            <div dangerouslySetInnerHTML={{ __html: sanitizeHtml(section.content) }} />
+                          </div>
+                        ))
+                      )}
+                      <div className={cn('mt-8 pt-4 border-t', light ? LIGHT_RECIPIENT_HAIRLINE : 'border-border')}>
+                        <p className={cn('text-xs italic', light ? LIGHT_RECIPIENT_MUTED : 'text-muted-foreground')}>
                           End of agreement — {sections.length} sections. Please continue below to sign.
                         </p>
                       </div>
                     </div>
+                    {light && !hasScrolledToBottom && (
+                      <div
+                        aria-hidden
+                        className="pointer-events-none absolute inset-x-0 bottom-0 h-14 rounded-b-xl bg-gradient-to-t from-[#fafafa] via-[#fafafa]/80 to-transparent"
+                      />
+                    )}
+                    </div>
 
-                    {/* Scroll hint / Continue button */}
+                    {/* Scroll hint / Continue button — DARK only. Light lifts BOTH into the
+                        persistent CTA below the content swap, so the button can glide
+                        read→sign (one element) instead of unmounting and teleporting. */}
+                    {!light && (
                     <div className="mt-4">
                       <AnimatePresence mode="wait">
                         {hasScrolledToBottom ? (
                           <motion.div
                             key="continue"
-                            initial={{ opacity: 0, y: 8 }}
+                            // light: shares a layoutId with the sign-phase "Sign agreement" button so
+                            // the CTA box resizes/repositions between the two phases (card-resize feel)
+                            // instead of fade-popping. dark: no shared morph, onboarding's plain rise.
+                            layoutId={light && !reduce ? 'signer-cta' : undefined}
+                            initial={reduce ? { opacity: 0 } : { opacity: 0, y: 8 }}
                             animate={{ opacity: 1, y: 0 }}
-                            transition={SPRING}
+                            transition={reduce ? { duration: 0.12 } : SPRING}
                           >
                             <Button
                               type="button"
-                              className="w-full gap-2"
+                              className={cn('w-full gap-2', light && LIGHT_RECIPIENT_CTA)}
                               onClick={() => setPhase('sign')}
                             >
-                              Continue to Sign
+                              {light ? 'Continue to sign' : 'Continue to Sign'}
                               <ArrowRight className="size-4" />
                             </Button>
                           </motion.div>
@@ -348,63 +587,73 @@ export function AgreementForm({
                             initial={{ opacity: 0 }}
                             animate={{ opacity: 1 }}
                             exit={{ opacity: 0 }}
-                            className="flex items-center justify-center gap-2 text-xs text-muted-foreground"
+                            className={cn('flex items-center justify-center gap-2 text-xs', light ? LIGHT_RECIPIENT_MUTED : 'text-muted-foreground')}
                           >
+                            {/* Static under reduced motion — an infinite bob is a
+                                WCAG 2.2.2 (pause/stop/hide) concern. */}
                             <motion.div
-                              animate={{ y: [0, 4, 0] }}
-                              transition={{ repeat: Infinity, duration: 1.5 }}
+                              animate={reduce ? { y: 0 } : { y: [0, 4, 0] }}
+                              transition={reduce ? undefined : { repeat: Infinity, duration: 1.5 }}
                             >
                               <ArrowDown className="size-3.5" />
                             </motion.div>
-                            Scroll to read the full agreement
+                            {light ? 'Scroll to read all' : 'Scroll to read the full agreement'}
                           </motion.div>
                         )}
                       </AnimatePresence>
                     </div>
+                    )}
                   </motion.div>
                 ) : (
-                  <motion.form
+                  <SignWrapper
                     key="sign-phase"
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: 1 }}
-                    transition={{ ...SPRING, delay: 0.15 }}
-                    onSubmit={handleSubmit}
-                    className="space-y-5"
+                    {...(light ? {} : { onSubmit: handleSubmit })}
+                    // light: the whole form fades in as one fast unit (+ a 6px settle), no
+                    // entrance delay and no per-field stagger (fieldRise is inert in light) —
+                    // the items appear together, immediately. No exit, so sign → read snaps back
+                    // (fading out here while the sheet shrinks read as choppy).
+                    // dark: onboarding's gentle opacity ramp + per-field stagger, untouched.
+                    initial={reduce ? { opacity: 0 } : light ? { opacity: 0, y: 6 } : { opacity: 0 }}
+                    animate={reduce ? { opacity: 1 } : light ? { opacity: 1, y: 0 } : { opacity: 1 }}
+                    transition={reduce ? { duration: 0.12 } : light ? LIGHT_PHASE_IN : { ...SPRING, delay: 0.15 }}
+                    className={cn('space-y-5', light && 'space-y-4')}
                   >
                     {/* Collapsed agreement reference */}
                     <button
                       type="button"
                       onClick={() => setPhase('read')}
-                      className="flex w-full items-center gap-2 rounded-lg border border-border bg-muted/30 px-4 py-3 text-left transition-colors hover:bg-muted/50"
+                      className={cn(
+                        'flex w-full items-center gap-2 rounded-lg border px-4 py-3 text-left transition-colors',
+                        light ? 'border-black/[0.06] bg-black/[0.02] hover:bg-black/[0.04]' : 'border-border bg-muted/30 hover:bg-muted/50',
+                        light && LIGHT_FOCUS_RING,
+                      )}
                     >
-                      <FileText className="size-4 text-seeko-accent shrink-0" />
+                      <FileText className={cn('size-4 shrink-0', light ? 'text-[#9a9a9a]' : 'text-seeko-accent')} />
                       <div className="flex-1 min-w-0">
-                        <p className="text-sm font-medium text-foreground">{title}</p>
-                        <p className="text-xs text-muted-foreground">{sections.length} sections — read in full</p>
+                        <p className={cn('text-sm font-medium', light ? 'text-[#111]' : 'text-foreground')}>{title}</p>
+                        <p className={cn('text-xs', light ? LIGHT_RECIPIENT_MUTED : 'text-muted-foreground')}>{sections.length} sections — read in full</p>
                       </div>
-                      <Check className="size-4 text-seeko-accent shrink-0" />
+                      <Check className={cn('size-4 shrink-0', light ? LIGHT_SUCCESS_TEXT : 'text-seeko-accent')} />
                     </button>
 
-                    <Separator />
+                    <Separator className={cn(light && 'bg-black/[0.06]')} />
 
                     <div className="text-center">
-                      <p className="text-sm font-medium text-foreground">
+                      <p className={cn('text-sm font-medium', light ? 'text-[#111]' : 'text-foreground')}>
                         {isGuardianSigning ? 'Sign as Guardian' : 'Sign the Agreement'}
                       </p>
-                      <p className="mt-1 text-xs text-muted-foreground">
+                      <p className={cn('mt-1 text-xs', light ? LIGHT_RECIPIENT_MUTED : 'text-muted-foreground')}>
                         {isGuardianSigning
                           ? 'By signing below, you agree as the legal guardian of the named minor to all terms outlined above.'
                           : 'By signing below, you agree to all terms outlined above.'}
-                        {' '}A signed PDF will be emailed to you for your records.
+                        {!light && ' A signed PDF will be emailed to you for your records.'}
                       </p>
                     </div>
 
                     {/* Engagement type */}
                     {showEngagementType && (
                       <motion.fieldset
-                        initial={{ opacity: 0, y: 12 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        transition={{ ...SPRING, delay: 0.2 }}
+                        {...fieldRise(0.2)}
                         className="space-y-2"
                       >
                         <Label>Engagement Type</Label>
@@ -432,12 +681,10 @@ export function AgreementForm({
 
                     {/* Legal name */}
                     <motion.div
-                      initial={{ opacity: 0, y: 12 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      transition={{ ...SPRING, delay: 0.3 }}
+                      {...fieldRise(0.3)}
                       className="space-y-2"
                     >
-                      <Label htmlFor="full-name">Legal Full Name</Label>
+                      <Label htmlFor="full-name" className={cn(light && 'text-[#2a2a2a]')}>Legal Full Name</Label>
                       <Input
                         id="full-name"
                         value={fullName}
@@ -445,104 +692,114 @@ export function AgreementForm({
                         placeholder="As it appears on official documents"
                         autoFocus
                         required
+                        className={cn(light && LIGHT_INPUT)}
                       />
                     </motion.div>
 
                     {/* Address */}
                     <motion.div
-                      initial={{ opacity: 0, y: 12 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      transition={{ ...SPRING, delay: 0.4 }}
+                      {...fieldRise(0.4)}
                       className="space-y-2"
                     >
-                      <Label htmlFor="address">Address</Label>
+                      <Label htmlFor="address" className={cn(light && 'text-[#2a2a2a]')}>Address</Label>
                       <AddressAutocomplete
                         id="address"
                         value={address}
                         onChange={setAddress}
                         placeholder="Start typing your address..."
                         required
+                        light={light}
                       />
                     </motion.div>
 
                     {/* Minor's name (guardian signing only) */}
                     {isGuardianSigning && (
                       <motion.div
-                        initial={{ opacity: 0, y: 12 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        transition={{ ...SPRING, delay: 0.45 }}
+                        {...fieldRise(0.45)}
                         className="space-y-2"
                       >
-                        <Label htmlFor="minor-name">Minor&apos;s Full Legal Name</Label>
+                        <Label htmlFor="minor-name" className={cn(light && 'text-[#2a2a2a]')}>Minor&apos;s Full Legal Name</Label>
                         <Input
                           id="minor-name"
                           value={minorName}
                           onChange={(e) => setMinorName(e.target.value)}
                           placeholder="Full legal name of the minor"
                           required
+                          className={cn(light && LIGHT_INPUT)}
                         />
-                        <p className="text-xs text-muted-foreground">
+                        <p className={cn('text-xs', light ? LIGHT_RECIPIENT_MUTED : 'text-muted-foreground')}>
                           The person under 18 you are signing on behalf of
                         </p>
                       </motion.div>
                     )}
 
-                    {/* Signature preview — SVG path drawing animation */}
-                    {fullName.trim() && (
-                      <motion.div
-                        initial={{ opacity: 0 }}
-                        animate={{ opacity: 1 }}
-                        transition={SPRING}
-                      >
-                        <div className="rounded-lg border border-border bg-muted/20 px-4 sm:px-6 py-5 text-center">
-                          <p className="text-[10px] uppercase tracking-widest text-muted-foreground mb-3">Digital Signature</p>
-                          <SignatureDrawing
-                            text={fullName.trim()}
-                            fontSize={SIG.fontSize}
-                            signed={signed}
-                            sigKey={sigKey}
-                            charDelay={SIG.charDelay}
-                            charDuration={SIG.charDuration}
-                            initialDelay={SIG.initialDelay}
-                            className="mx-auto max-w-sm"
-                          />
-                          {/* Underline — grows with name while typing, plays draw animation on signed */}
-                          {signed ? (
-                            <motion.div
-                              key={`underline-${sigKey}`}
-                              initial={{ scaleX: 0 }}
-                              animate={{ scaleX: 1 }}
-                              transition={{
-                                duration: 0.6,
-                                delay: SIG.initialDelay + fullName.trim().length * SIG.charDelay + 0.1,
-                                ease: [0.22, 0.03, 0.26, 1],
-                              }}
-                              className="mx-auto mt-2 h-px bg-foreground/30 origin-left"
-                              style={{ width: Math.min(fullName.trim().length * 14 + 32, 240) }}
-                            />
-                          ) : (
-                            <motion.div
-                              className="mx-auto mt-2 h-px bg-foreground/20"
-                              animate={{ width: Math.min(fullName.trim().length * 14 + 32, 240) }}
-                              transition={{ duration: 0.3, ease: [0.22, 0.03, 0.26, 1] }}
-                            />
-                          )}
-                        </div>
+                    {/* Signature — light ceremony uses the interactive draw/type pad;
+                        dark onboarding keeps the auto-handwriting preview of the name. */}
+                    {light ? (
+                      <motion.div {...fieldRise(0)} className="space-y-2">
+                        <Label className="text-[#2a2a2a]">Signature</Label>
+                        <SignaturePad light onChange={setSignatureValue} />
                       </motion.div>
+                    ) : (
+                      fullName.trim() && (
+                        <motion.div
+                          initial={{ opacity: 0 }}
+                          animate={{ opacity: 1 }}
+                          transition={SPRING}
+                        >
+                          <div className="rounded-lg border border-border bg-muted/20 px-4 sm:px-6 py-5 text-center">
+                            <p className="text-xs font-medium text-muted-foreground mb-3">Signature</p>
+                            <SignatureDrawing
+                              text={fullName.trim()}
+                              fontSize={SIG.fontSize}
+                              signed={signed}
+                              sigKey={sigKey}
+                              charDelay={SIG.charDelay}
+                              charDuration={SIG.charDuration}
+                              initialDelay={SIG.initialDelay}
+                              className="mx-auto max-w-sm"
+                            />
+                            {/* Underline — grows with name while typing, plays draw animation on signed */}
+                            {signed ? (
+                              <motion.div
+                                key={`underline-${sigKey}`}
+                                initial={{ scaleX: 0 }}
+                                animate={{ scaleX: 1 }}
+                                transition={{
+                                  duration: 0.6,
+                                  delay: SIG.initialDelay + fullName.trim().length * SIG.charDelay + 0.1,
+                                  ease: [0.22, 0.03, 0.26, 1],
+                                }}
+                                className="mx-auto mt-2 h-px bg-foreground/30 origin-left"
+                                style={{ width: Math.min(fullName.trim().length * 14 + 32, 240) }}
+                              />
+                            ) : (
+                              <motion.div
+                                className="mx-auto mt-2 h-px bg-foreground/20"
+                                animate={{ width: Math.min(fullName.trim().length * 14 + 32, 240) }}
+                                transition={{ duration: 0.3, ease: [0.22, 0.03, 0.26, 1] }}
+                              />
+                            )}
+                          </div>
+                        </motion.div>
+                      )
                     )}
 
                     {error && (
-                      <p className="text-sm text-destructive bg-destructive/10 px-3 py-2 rounded-lg">
+                      <p
+                        className={cn(
+                          'text-sm px-3 py-2 rounded-lg',
+                          light ? 'text-[#d4503e] bg-[#d4503e]/10' : 'text-destructive bg-destructive/10',
+                        )}
+                      >
                         {error}
                       </p>
                     )}
 
-                    {/* Submit */}
-                    <motion.div
-                      initial={{ opacity: 0, y: 12 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      transition={{ ...SPRING, delay: 0.5 }}
-                    >
+                    {/* Submit — DARK onboarding only. Light's submit is the persistent CTA
+                        below the content swap, so it glides read→sign as one element. */}
+                    {!light && (
+                    <motion.div {...fieldRise(0.5)}>
                       <Button
                         type="submit"
                         disabled={saving || signed || !canSubmit}
@@ -572,9 +829,107 @@ export function AgreementForm({
                         </AnimatePresence>
                       </Button>
                     </motion.div>
-                  </motion.form>
+                    )}
+                  </SignWrapper>
                 )}
               </AnimatePresence>
+
+              {/* ── Persistent CTA (light ceremony only) ──
+                  ONE button across read↔sign. It never unmounts at the phase boundary, so
+                  `layout` glides it to its new position as the content above changes height
+                  — it follows the resizing card instead of falling/jumping. The label
+                  crossfades in place; reduced motion drops the glide. */}
+              {light && (
+                <motion.div
+                  layout={reduce ? false : 'position'}
+                  transition={LIGHT_CTA_GLIDE}
+                  className="mt-4"
+                >
+                  <AnimatePresence mode="wait" initial={false}>
+                    {phase === 'read' && !hasScrolledToBottom ? (
+                      <motion.div
+                        key="scroll-hint"
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={{ opacity: 0 }}
+                        transition={{ duration: 0.15 }}
+                        className={cn('flex items-center justify-center gap-2 text-xs', LIGHT_RECIPIENT_MUTED)}
+                      >
+                        {/* Static under reduced motion — an infinite bob is a
+                            WCAG 2.2.2 (pause/stop/hide) concern. */}
+                        <motion.div
+                          animate={reduce ? { y: 0 } : { y: [0, 4, 0] }}
+                          transition={reduce ? undefined : { repeat: Infinity, duration: 1.5 }}
+                        >
+                          <ArrowDown className="size-3.5" />
+                        </motion.div>
+                        Scroll to read all
+                      </motion.div>
+                    ) : (
+                      // Same key in read(scrolled) AND sign → React keeps this exact node
+                      // mounted across the swap, so the outer `layout` glides it.
+                      <motion.div key="signer-cta">
+                        <Button
+                          type={phase === 'read' ? 'button' : 'submit'}
+                          onClick={phase === 'read' ? () => setPhase('sign') : undefined}
+                          disabled={phase === 'sign' && (saving || signed || !canSubmit)}
+                          // The visible label crossfades between phases via AnimatePresence,
+                          // so pin the accessible name to phase/saving state rather than the
+                          // transient label children — screen readers get one stable name
+                          // (no mid-animation flicker), and it matches each settled label.
+                          aria-label={phase === 'read' ? 'Continue to sign' : saving ? 'Signing' : 'Sign agreement'}
+                          className={cn('w-full gap-2', LIGHT_RECIPIENT_CTA)}
+                        >
+                          <AnimatePresence mode="wait" initial={false}>
+                            <motion.span
+                              key={phase === 'read' ? 'continue' : saving ? 'saving' : 'sign'}
+                              initial={{ opacity: 0 }}
+                              animate={{ opacity: 1 }}
+                              exit={{ opacity: 0 }}
+                              transition={{ duration: 0.15 }}
+                              className="inline-flex items-center gap-2"
+                            >
+                              {phase === 'read' ? (
+                                <>
+                                  Continue to sign
+                                  <ArrowRight className="size-4" />
+                                </>
+                              ) : saving ? (
+                                <>
+                                  <Loader2 className="size-4 animate-spin" />
+                                  Signing...
+                                </>
+                              ) : (
+                                <>
+                                  <Check className="size-4" strokeWidth={2.5} />
+                                  Sign agreement
+                                </>
+                              )}
+                            </motion.span>
+                          </AnimatePresence>
+                        </Button>
+                      </motion.div>
+                    )}
+                  </AnimatePresence>
+                </motion.div>
+              )}
+
+              {/* E-signature consent (ESIGN Act / UETA) — light, sign step only. Sits
+                  below the persistent CTA so it never shifts the button's glide target. */}
+              {light && phase === 'sign' && (
+                <motion.p
+                  key="esign-consent"
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  transition={{ duration: 0.2, delay: 0.12 }}
+                  className={cn('mt-4 text-center text-[11px] leading-relaxed', LIGHT_RECIPIENT_MUTED)}
+                >
+                  By selecting &ldquo;Sign agreement,&rdquo; you consent to sign this document
+                  electronically under the U.S. ESIGN Act and UETA, and agree your electronic
+                  signature is legally binding.
+                </motion.p>
+              )}
+              </CeremonyShell>
             </CardContent>
           </Card>
         </motion.div>

--- a/src/components/agreement/SignatureDrawing.tsx
+++ b/src/components/agreement/SignatureDrawing.tsx
@@ -12,6 +12,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
+import { cn } from '@/lib/utils';
 
 const DRAW_DURATION = 0.3;
 const DRAW_EASING = [0.22, 0.03, 0.26, 1] as [number, number, number, number];
@@ -25,6 +26,8 @@ interface SignatureDrawingProps {
   charDuration?: number;
   initialDelay?: number;
   className?: string;
+  /** Opt into the light signer-ceremony theme. Default false → dark (onboarding untouched). */
+  light?: boolean;
 }
 
 export function SignatureDrawing({
@@ -36,6 +39,7 @@ export function SignatureDrawing({
   charDuration = DRAW_DURATION,
   initialDelay = 0.2,
   className,
+  light = false,
 }: SignatureDrawingProps) {
   const prevTextRef = useRef('');
   const [charStates, setCharStates] = useState<{ char: string; isNew: boolean }[]>([]);
@@ -78,7 +82,7 @@ export function SignatureDrawing({
                   delay,
                   ease: DRAW_EASING,
                 }}
-                className="inline-block leading-tight text-foreground"
+                className={cn('inline-block leading-tight', light ? 'text-[#111]' : 'text-foreground')}
                 style={{
                   fontFamily: 'var(--font-caveat), cursive',
                   fontSize,

--- a/src/components/agreement/SignaturePad.tsx
+++ b/src/components/agreement/SignaturePad.tsx
@@ -1,0 +1,346 @@
+'use client';
+
+import { useRef, useState, useEffect, useLayoutEffect, useCallback } from 'react';
+import { Pen, Type as TypeIcon } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { LIGHT_RECIPIENT_MUTED, LIGHT_FOCUS_RING, LIGHT_FOCUS_RING_WITHIN } from '@/components/dashboard/lightKit';
+
+// useLayoutEffect runs pre-paint (so the typed signature is sized BEFORE it shows,
+// never a flash of clipped text) but warns under SSR — fall back to useEffect there.
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
+/**
+ * The single signature value the pad produces. Exactly one mode is ever live:
+ * switching modes clears the other, so the parent never has to disambiguate a
+ * drawn-vs-typed signature in the payload.
+ *  - `drawn`: a PNG dataURL of the canvas strokes (transparent background, so it
+ *     drops cleanly into the Phase-4 certificate PDF with no white box).
+ *  - `typed`: the name string, rendered in the handwriting face.
+ */
+export type SignatureValue =
+  | { kind: 'drawn'; dataUrl: string }
+  | { kind: 'typed'; text: string };
+
+interface SignaturePadProps {
+  /** Called with the live value, or `null` when the pad is empty / cleared. */
+  onChange: (value: SignatureValue | null) => void;
+  /** Opt into the light signer-ceremony theme. Default false → dark (safe to reuse). */
+  light?: boolean;
+}
+
+type Mode = 'draw' | 'type';
+
+const PAD_HEIGHT = 140;
+// Typed signature scales between these so a long legal name never clips at the
+// pad edges (worst-case legal names run ~30+ chars). Max = the design size; min
+// is deliberately low (a clipped signature is far worse than a small one on a
+// legal surface — the fit must win over the floor). A margin keeps the tail from
+// kissing the inset edge so sub-pixel overflow can't reintroduce the clip.
+const TYPED_MAX_PX = 34;
+const TYPED_MIN_PX = 12;
+const TYPED_FIT_MARGIN = 10;
+
+export function SignaturePad({ onChange, light = false }: SignaturePadProps) {
+  const [mode, setMode] = useState<Mode>('draw');
+  const [hasInk, setHasInk] = useState(false);
+  const [typed, setTyped] = useState('');
+  // Live font size for the typed signature, shrunk to fit the pad width.
+  const [typedFontPx, setTypedFontPx] = useState(TYPED_MAX_PX);
+
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const ctxRef = useRef<CanvasRenderingContext2D | null>(null);
+  const drawingRef = useRef(false);
+  const lastRef = useRef<{ x: number; y: number } | null>(null);
+  const typedInputRef = useRef<HTMLInputElement>(null);
+  const typedMeasureRef = useRef<HTMLSpanElement>(null);
+
+  // Size the backing store to the device pixel ratio so strokes stay crisp, and
+  // prime the stroke style. Re-runs whenever we (re)enter draw mode, since the
+  // canvas unmounts in type mode.
+  const setupCanvas = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const rect = canvas.getBoundingClientRect();
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = Math.max(1, Math.round(rect.width * dpr));
+    canvas.height = Math.max(1, Math.round(rect.height * dpr));
+    ctx.scale(dpr, dpr);
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.lineWidth = 2.2;
+    ctx.strokeStyle = light ? '#111111' : '#fafafa';
+    ctxRef.current = ctx;
+  }, [light]);
+
+  useEffect(() => {
+    if (mode === 'draw') setupCanvas();
+  }, [mode, setupCanvas]);
+
+  // Shrink the typed signature to fit the pad. Measured against a hidden span in
+  // the same handwriting face at TYPED_MAX_PX, then scaled down by the overflow
+  // ratio so the name stays centered and whole instead of scroll-clipping at the
+  // input's left edge. Empty → back to full size.
+  //
+  // Runs in useLayoutEffect (pre-paint, so a long name is never shown clipped for
+  // a frame) AND re-fits once `document.fonts.ready` resolves: measuring before
+  // the Caveat web font settles reads the fallback face's metrics and under-shoots
+  // the ratio, which is exactly how the clip slipped through the old post-paint
+  // useEffect. A ResizeObserver re-fits on width changes (mobile sheet ⇄ desktop
+  // dialog, orientation). The TYPED_FIT_MARGIN guards sub-pixel overflow.
+  useIsomorphicLayoutEffect(() => {
+    if (mode !== 'type') return;
+    let cancelled = false;
+
+    const fit = () => {
+      if (cancelled) return;
+      const input = typedInputRef.current;
+      const measure = typedMeasureRef.current;
+      if (!input || !measure) return;
+      if (!typed.trim()) {
+        setTypedFontPx(TYPED_MAX_PX);
+        return;
+      }
+      const available = input.clientWidth - TYPED_FIT_MARGIN;
+      const textWidth = measure.offsetWidth; // rendered at TYPED_MAX_PX
+      if (available <= 0 || !textWidth || textWidth <= available) {
+        setTypedFontPx(TYPED_MAX_PX);
+        return;
+      }
+      const fitted = Math.floor(TYPED_MAX_PX * (available / textWidth));
+      setTypedFontPx(Math.max(TYPED_MIN_PX, fitted));
+    };
+
+    fit();
+    if (typeof document !== 'undefined' && document.fonts?.ready) {
+      document.fonts.ready.then(fit).catch(() => {});
+    }
+    let ro: ResizeObserver | undefined;
+    const input = typedInputRef.current;
+    if (input && typeof ResizeObserver !== 'undefined') {
+      ro = new ResizeObserver(fit);
+      ro.observe(input);
+    }
+    return () => {
+      cancelled = true;
+      ro?.disconnect();
+    };
+  }, [typed, mode]);
+
+  function pointerPos(e: React.PointerEvent<HTMLCanvasElement>) {
+    const rect = canvasRef.current!.getBoundingClientRect();
+    return { x: e.clientX - rect.left, y: e.clientY - rect.top };
+  }
+
+  function handlePointerDown(e: React.PointerEvent<HTMLCanvasElement>) {
+    const canvas = canvasRef.current;
+    const ctx = ctxRef.current;
+    if (!canvas || !ctx) return;
+    drawingRef.current = true;
+    if (typeof canvas.setPointerCapture === 'function') {
+      try { canvas.setPointerCapture(e.pointerId); } catch { /* not supported */ }
+    }
+    const { x, y } = pointerPos(e);
+    lastRef.current = { x, y };
+    // A lone tap should leave a dot, not nothing.
+    ctx.beginPath();
+    ctx.moveTo(x, y);
+    ctx.lineTo(x + 0.1, y + 0.1);
+    ctx.stroke();
+    if (!hasInk) setHasInk(true);
+  }
+
+  function handlePointerMove(e: React.PointerEvent<HTMLCanvasElement>) {
+    if (!drawingRef.current) return;
+    const ctx = ctxRef.current;
+    const last = lastRef.current;
+    if (!ctx || !last) return;
+    const { x, y } = pointerPos(e);
+    ctx.beginPath();
+    ctx.moveTo(last.x, last.y);
+    ctx.lineTo(x, y);
+    ctx.stroke();
+    lastRef.current = { x, y };
+  }
+
+  function commitDrawn() {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    onChange({ kind: 'drawn', dataUrl: canvas.toDataURL('image/png') });
+  }
+
+  function handlePointerUp(e: React.PointerEvent<HTMLCanvasElement>) {
+    if (!drawingRef.current) return;
+    drawingRef.current = false;
+    const canvas = canvasRef.current;
+    if (canvas && typeof canvas.releasePointerCapture === 'function') {
+      try { canvas.releasePointerCapture(e.pointerId); } catch { /* not supported */ }
+    }
+    commitDrawn();
+  }
+
+  function handleClear() {
+    const canvas = canvasRef.current;
+    const ctx = ctxRef.current;
+    if (canvas && ctx) ctx.clearRect(0, 0, canvas.width, canvas.height);
+    lastRef.current = null;
+    setHasInk(false);
+    onChange(null);
+  }
+
+  function handleTyped(e: React.ChangeEvent<HTMLInputElement>) {
+    const text = e.target.value;
+    setTyped(text);
+    onChange(text.trim() ? { kind: 'typed', text } : null);
+  }
+
+  function switchMode(next: Mode) {
+    if (next === mode) return;
+    // Only one mode's value is ever live — entering a mode resets both sources so
+    // the payload can't carry a stale drawn signature behind a typed one.
+    setMode(next);
+    setHasInk(false);
+    setTyped('');
+    lastRef.current = null;
+    onChange(null);
+  }
+
+  // ── Theme tokens ──
+  const trackCls = light ? 'bg-[#f4f4f4]' : 'bg-muted/50';
+  const segActiveCls = light
+    ? 'bg-white text-[#111] shadow-seeko'
+    : 'bg-card text-foreground shadow';
+  const segIdleCls = light
+    ? 'text-[#6e6e6e] hover:text-[#111]'
+    : 'text-muted-foreground hover:text-foreground';
+  // In type mode the real control is the transparent inset <input>; ring the frame
+  // (not the input) when it takes keyboard focus, so the pad shows focus like any
+  // bordered field. The canvas (draw mode) isn't focusable, so this never fires there.
+  const padFrameCls = light
+    ? `border-black/[0.10] bg-white ${LIGHT_FOCUS_RING_WITHIN}`
+    : 'border-border bg-muted/20';
+  const baselineCls = light ? 'bg-black/[0.10]' : 'bg-foreground/15';
+  // Instructional copy is active guidance on a legal step — it must clear AA, so it
+  // uses the #6e6e6e muted tier (4.74:1), not the #9a9a9a fine-print tier (~2.8:1).
+  const helperCls = light ? LIGHT_RECIPIENT_MUTED : 'text-muted-foreground';
+  const clearCls = light
+    ? 'text-[#6e6e6e] hover:text-[#111]'
+    : 'text-muted-foreground hover:text-foreground';
+
+  return (
+    <div className="space-y-2.5">
+      {/* Draw / Type segmented control */}
+      <div className={cn('inline-flex w-full gap-1 rounded-full p-1', trackCls)}>
+        {([
+          { id: 'draw' as const, label: 'Draw', Icon: Pen },
+          { id: 'type' as const, label: 'Type', Icon: TypeIcon },
+        ]).map(({ id, label, Icon }) => {
+          const active = mode === id;
+          return (
+            <button
+              key={id}
+              type="button"
+              aria-pressed={active}
+              onClick={() => switchMode(id)}
+              className={cn(
+                'flex flex-1 items-center justify-center gap-1.5 rounded-full px-3 py-1.5 text-[13px] font-medium',
+                'transition-[color,background-color,box-shadow] duration-150 ease-out active:scale-[0.98] motion-reduce:active:scale-100',
+                active ? segActiveCls : segIdleCls,
+                light && LIGHT_FOCUS_RING,
+              )}
+            >
+              <Icon aria-hidden className="size-3.5" strokeWidth={2} />
+              {label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Pad frame — concentric rounded-xl inside the card's rounded-2xl */}
+      <div
+        className={cn('relative overflow-hidden rounded-xl border', padFrameCls)}
+        style={{ height: PAD_HEIGHT }}
+      >
+        {/* Baseline guide — sits behind the ink, never part of the exported PNG */}
+        <div
+          aria-hidden
+          className={cn('pointer-events-none absolute inset-x-5 bottom-9 h-px', baselineCls)}
+        />
+
+        {mode === 'draw' ? (
+          <canvas
+            ref={canvasRef}
+            data-testid="signature-canvas"
+            onPointerDown={handlePointerDown}
+            onPointerMove={handlePointerMove}
+            onPointerUp={handlePointerUp}
+            onPointerLeave={handlePointerUp}
+            className="absolute inset-0 h-full w-full cursor-crosshair touch-none"
+          />
+        ) : (
+          <>
+            <input
+              ref={typedInputRef}
+              value={typed}
+              onChange={handleTyped}
+              placeholder="Type your full name"
+              aria-label="Type your signature"
+              autoComplete="off"
+              spellCheck={false}
+              style={{ fontFamily: 'var(--font-caveat), cursive', fontSize: typedFontPx }}
+              className={cn(
+                'absolute inset-x-5 bottom-[2.75rem] overflow-hidden bg-transparent text-center leading-none outline-none',
+                'transition-[font-size] duration-100 ease-out motion-reduce:transition-none',
+                light ? 'text-[#111] placeholder:text-[#c8c8c8]' : 'text-foreground placeholder:text-muted-foreground/50',
+              )}
+            />
+            {/* Off-screen measurer: the typed name at full size, used to derive the
+                shrink ratio above. Mirrors the input's font face so the width
+                measurement matches what the user actually sees. */}
+            <span
+              ref={typedMeasureRef}
+              aria-hidden
+              style={{
+                fontFamily: 'var(--font-caveat), cursive',
+                fontSize: TYPED_MAX_PX,
+                position: 'absolute',
+                left: -9999,
+                top: 0,
+                whiteSpace: 'pre',
+                visibility: 'hidden',
+                pointerEvents: 'none',
+              }}
+            >
+              {typed || ' '}
+            </span>
+          </>
+        )}
+      </div>
+
+      {/* Helper + Clear */}
+      <div className="flex min-h-5 items-center justify-between">
+        <p className={cn('text-[11px]', helperCls)}>
+          {mode === 'draw'
+            ? 'Draw your signature with your finger or mouse.'
+            : 'Your typed name will be used as your signature.'}
+        </p>
+        {mode === 'draw' && (
+          <button
+            type="button"
+            onClick={handleClear}
+            disabled={!hasInk}
+            className={cn(
+              'rounded-md px-1.5 py-0.5 text-[12px] font-medium transition-[color,opacity] duration-150 ease-out',
+              'active:scale-[0.97] motion-reduce:active:scale-100 disabled:cursor-not-allowed disabled:opacity-40',
+              clearCls,
+              light && LIGHT_FOCUS_RING,
+            )}
+          >
+            Clear
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/agreement/__tests__/AgreementForm.signature.test.tsx
+++ b/src/components/agreement/__tests__/AgreementForm.signature.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { AgreementForm } from '../AgreementForm';
+
+// AgreementForm pulls in the router, haptics, and scroll-lock — none relevant to
+// the signature-wiring behavior under test, so stub them.
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }) }));
+vi.mock('@/components/HapticsProvider', () => ({ useHaptics: () => ({ trigger: vi.fn() }) }));
+vi.mock('@/lib/scroll-lock', () => ({ acquireScrollLock: vi.fn(), releaseScrollLock: vi.fn() }));
+
+const SECTIONS = [{ number: 1, title: 'Terms', content: '<p>Be excellent to each other.</p>' }];
+
+function signCall() {
+  return (global.fetch as ReturnType<typeof vi.fn>).mock.calls.find(
+    (c) => typeof c[0] === 'string' && c[0].includes('/sign'),
+  );
+}
+
+describe('AgreementForm — light signer signature wiring', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+  });
+
+  it('gates submit on a signature and sends signature_image + signature_kind', async () => {
+    render(
+      <AgreementForm
+        light
+        userId=""
+        userEmail=""
+        sections={SECTIONS}
+        title="External NDA"
+        showEngagementType={false}
+        signEndpoint="/api/external-signing/sign"
+        signPayloadExtra={{ token: 'tok-123' }}
+        successRedirect={null}
+      />,
+    );
+
+    // jsdom reports zero scroll height, so the form treats the agreement as fully
+    // read and surfaces "Continue to Sign" immediately.
+    fireEvent.click(await screen.findByRole('button', { name: /continue to sign/i }));
+
+    // The read→sign swap runs through AnimatePresence; await the field's arrival.
+    fireEvent.change(await screen.findByLabelText(/legal full name/i), { target: { value: 'Jane Doe' } });
+    fireEvent.change(screen.getByLabelText(/^address$/i), { target: { value: '123 Main St' } });
+
+    const submit = screen.getByRole('button', { name: /sign agreement/i });
+    expect(submit).toBeDisabled(); // no signature captured yet
+
+    // Capture a typed signature in the pad.
+    fireEvent.click(screen.getByRole('button', { name: /^type$/i }));
+    fireEvent.change(screen.getByPlaceholderText(/type your full name/i), {
+      target: { value: 'Jane Doe' },
+    });
+
+    expect(submit).toBeEnabled();
+    fireEvent.click(submit);
+
+    await waitFor(() => expect(signCall()).toBeTruthy());
+    const body = JSON.parse(signCall()![1].body as string);
+    expect(body).toMatchObject({
+      full_name: 'Jane Doe',
+      address: '123 Main St',
+      token: 'tok-123',
+      signature_image: 'Jane Doe',
+      signature_kind: 'typed',
+    });
+  });
+
+  it('does not gate submit on a signature in dark onboarding mode', async () => {
+    render(
+      <AgreementForm
+        userId="u1"
+        userEmail="x@y.z"
+        sections={SECTIONS}
+        title="NDA"
+        showEngagementType={false}
+        signEndpoint="/api/agreement/sign"
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /continue to sign/i }));
+    fireEvent.change(await screen.findByLabelText(/legal full name/i), { target: { value: 'Jane Doe' } });
+    fireEvent.change(screen.getByLabelText(/^address$/i), { target: { value: '123 Main St' } });
+
+    // Onboarding derives the signature from the legal name — no pad, submit enabled.
+    expect(screen.getByRole('button', { name: /i agree.*sign/i })).toBeEnabled();
+    expect(screen.queryByRole('button', { name: /^type$/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/agreement/__tests__/SignaturePad.test.tsx
+++ b/src/components/agreement/__tests__/SignaturePad.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SignaturePad } from '../SignaturePad';
+
+// jsdom ships no canvas backend, so the pad's 2D context + PNG export must be
+// stubbed. These mocks only need to satisfy the calls SignaturePad makes while
+// drawing; the assertions below are about the component's behavior contract, not
+// pixel output.
+beforeAll(() => {
+  HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
+    scale: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    stroke: vi.fn(),
+    closePath: vi.fn(),
+    clearRect: vi.fn(),
+    lineCap: '',
+    lineJoin: '',
+    lineWidth: 0,
+    strokeStyle: '',
+  })) as unknown as typeof HTMLCanvasElement.prototype.getContext;
+  HTMLCanvasElement.prototype.toDataURL = vi.fn(() => 'data:image/png;base64,SIGNED');
+});
+
+function drawStroke(canvas: HTMLElement) {
+  fireEvent.pointerDown(canvas, { clientX: 10, clientY: 10, pointerId: 1 });
+  fireEvent.pointerMove(canvas, { clientX: 40, clientY: 30, pointerId: 1 });
+  fireEvent.pointerUp(canvas, { clientX: 40, clientY: 30, pointerId: 1 });
+}
+
+describe('SignaturePad', () => {
+  it('starts empty: Clear is disabled and no drawn value is emitted', () => {
+    const onChange = vi.fn();
+    render(<SignaturePad onChange={onChange} />);
+
+    expect(screen.getByRole('button', { name: /clear/i })).toBeDisabled();
+    expect(onChange).not.toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'drawn' }),
+    );
+  });
+
+  it('drawing a stroke enables Clear and emits a non-empty drawn dataURL', () => {
+    const onChange = vi.fn();
+    render(<SignaturePad onChange={onChange} />);
+
+    drawStroke(screen.getByTestId('signature-canvas'));
+
+    expect(screen.getByRole('button', { name: /clear/i })).toBeEnabled();
+    const last = onChange.mock.calls.at(-1)?.[0];
+    expect(last).toMatchObject({ kind: 'drawn' });
+    expect(last.dataUrl).toBeTruthy();
+  });
+
+  it('clearing a drawn stroke disables Clear again and emits null', () => {
+    const onChange = vi.fn();
+    render(<SignaturePad onChange={onChange} />);
+
+    drawStroke(screen.getByTestId('signature-canvas'));
+    fireEvent.click(screen.getByRole('button', { name: /clear/i }));
+
+    expect(screen.getByRole('button', { name: /clear/i })).toBeDisabled();
+    expect(onChange).toHaveBeenLastCalledWith(null);
+  });
+
+  it('Type mode emits the typed name as the signature value', () => {
+    const onChange = vi.fn();
+    render(<SignaturePad onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /^type$/i }));
+    fireEvent.change(screen.getByPlaceholderText(/type your full name/i), {
+      target: { value: 'Jane Doe' },
+    });
+
+    expect(onChange).toHaveBeenLastCalledWith({ kind: 'typed', text: 'Jane Doe' });
+  });
+
+  it('clearing the typed name (empty) emits null', () => {
+    const onChange = vi.fn();
+    render(<SignaturePad onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /^type$/i }));
+    const input = screen.getByPlaceholderText(/type your full name/i);
+    fireEvent.change(input, { target: { value: 'Jane' } });
+    fireEvent.change(input, { target: { value: '' } });
+
+    expect(onChange).toHaveBeenLastCalledWith(null);
+  });
+
+  it('switching from a drawn signature to Type mode clears the drawn value', () => {
+    const onChange = vi.fn();
+    render(<SignaturePad onChange={onChange} />);
+
+    drawStroke(screen.getByTestId('signature-canvas'));
+    expect(onChange.mock.calls.at(-1)?.[0]).toMatchObject({ kind: 'drawn' });
+
+    fireEvent.click(screen.getByRole('button', { name: /^type$/i }));
+
+    expect(onChange).toHaveBeenLastCalledWith(null);
+  });
+
+  it('switching from a typed name back to Draw mode clears the typed value', () => {
+    const onChange = vi.fn();
+    render(<SignaturePad onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /^type$/i }));
+    fireEvent.change(screen.getByPlaceholderText(/type your full name/i), {
+      target: { value: 'Jane Doe' },
+    });
+    expect(onChange).toHaveBeenLastCalledWith({ kind: 'typed', text: 'Jane Doe' });
+
+    fireEvent.click(screen.getByRole('button', { name: /^draw$/i }));
+
+    expect(onChange).toHaveBeenLastCalledWith(null);
+    expect(screen.getByRole('button', { name: /clear/i })).toBeDisabled();
+  });
+});

--- a/src/components/dashboard/lightKit.ts
+++ b/src/components/dashboard/lightKit.ts
@@ -1,0 +1,154 @@
+/* ── Light form-control class kits (shadcn primitives are dark-themed via
+ * `@theme inline` tokens that bake literal hex into utilities at build time,
+ * so a runtime token override can't relight them — we override per-element
+ * via className, which twMerge resolves last-wins). ───────────────────── */
+export const LIGHT_INPUT =
+  'border border-black/[0.08] bg-white text-[#2a2a2a] placeholder:text-[#b3b3b3] rounded-lg focus-visible:ring-2 focus-visible:ring-[#0d7aff]/30';
+export const BTN_BASE =
+  'rounded-full px-4 h-9 text-[13px] font-medium transition-[background-color,transform] duration-150 ease-out active:scale-[0.98]';
+export const BTN_PRIMARY = `${BTN_BASE} bg-[#111] text-white hover:bg-[#2a2a2a]`;
+export const BTN_SECONDARY = `${BTN_BASE} bg-[#f4f4f4] text-[#2a2a2a] hover:bg-[#ececec]`;
+export const CARD_TITLE = 'text-[15px] font-semibold text-[#111]';
+export const CARD_DESC = 'text-[13px] text-[#808080]';
+export const HAIRLINE = 'h-px bg-black/[0.06]';
+/* Dialog footer/action buttons in the light theme: black primary, subtle ghost.
+ * Appended to shadcn <Button> className so twMerge recolors them last-wins. */
+export const DIALOG_SAVE = 'bg-[#111] text-white hover:bg-[#2a2a2a]';
+export const DIALOG_CANCEL = 'text-[#505050] hover:bg-black/[0.04] hover:text-[#111]';
+
+/* Restrained AA-on-white department label colors (see 2026-05-26 phase1-team
+ * plan; derived via /color-expert). Distinct dept identity, all ≥4.5:1 on white.
+ * `#0d7aff` is reserved for the online dot (graphic, 3:1) — Coding text uses the
+ * deepened `#0a63cc` to clear AA. */
+export const LIGHT_DEPT_COLOR: Record<string, string> = {
+  'Coding':         'text-[#0a63cc]',
+  'Visual Art':     'text-[#3f5fb5]',
+  'UI/UX':          'text-[#6e4fc4]',
+  'Animation':      'text-[#946a00]',
+  'Asset Creation': 'text-[#bd3f7c]',
+};
+/* Matching department badge backgrounds: hue/10 tint + label text. Amber uses
+ * the brighter `#b8801a` for the wash with the darker `#946a00` for the text. */
+export const LIGHT_DEPT_BADGE: Record<string, string> = {
+  'Coding':         'bg-[#0a63cc]/10 text-[#0a63cc]',
+  'Visual Art':     'bg-[#3f5fb5]/10 text-[#3f5fb5]',
+  'UI/UX':          'bg-[#6e4fc4]/10 text-[#6e4fc4]',
+  'Animation':      'bg-[#b8801a]/10 text-[#946a00]',
+  'Asset Creation': 'bg-[#bd3f7c]/10 text-[#bd3f7c]',
+};
+
+/* Invoice-request status badge colors on white (Payments admin). Mirrors the dark
+ * INVOICE_STATUS_COLOR keys, mapped to the AA-on-white ladder: azure `#0a63cc` for
+ * verified/approved, amber `#946a00` for submitted, destructive `#d4503e` for
+ * rejected/revoked, neutral grey for pending/expired. */
+export const LIGHT_INVOICE_STATUS: Record<string, string> = {
+  pending:  'text-[#808080] border-black/[0.08]',
+  verified: 'text-[#0a63cc] border-[#0a63cc]/30 bg-[#0a63cc]/10',
+  signed:   'text-[#946a00] border-[#b8801a]/40 bg-[#b8801a]/10',
+  approved: 'text-[#0a63cc] border-[#0a63cc]/30 bg-[#0a63cc]/10',
+  rejected: 'text-[#d4503e] border-[#d4503e]/30 bg-[#d4503e]/10',
+  expired:  'text-[#9a9a9a] border-black/[0.08]',
+  revoked:  'text-[#d4503e] border-[#d4503e]/30 bg-[#d4503e]/10',
+};
+
+/* External-signing invite status on white (External Signing admin). The loudness
+ * ladder differs from invoices: here `pending` is the LOUD status (it blocks an
+ * external party from acting) and `signed`/`expired` are quiet (done/dead), the
+ * inverse emphasis of LIGHT_INVOICE_STATUS. Mapped to the same AA-on-white ramp:
+ * amber `#946a00` = pending (needs attention), azure `#0a63cc` = verified (mid-flow),
+ * neutral grey = signed/expired (quiet), destructive `#d4503e` = revoked. */
+export const LIGHT_SIGNING_STATUS: Record<string, string> = {
+  pending:  'text-[#946a00] border-[#b8801a]/40 bg-[#b8801a]/10',
+  verified: 'text-[#0a63cc] border-[#0a63cc]/30 bg-[#0a63cc]/10',
+  signed:   'text-[#808080] border-black/[0.08]',
+  expired:  'text-[#9a9a9a] border-black/[0.08]',
+  revoked:  'text-[#d4503e] border-[#d4503e]/30 bg-[#d4503e]/10',
+};
+
+/* ── Light recipient-ceremony kit (external signer `/sign/[token]`, migrated
+ * dark→light to rejoin the design system). Built on the same AA-on-white ramp
+ * as the kits above and reuses the canonical `shadow-seeko` elevation token
+ * (never re-inline a shadow) so the ceremony card reads as the SAME material as
+ * every other light app card — that consistency is the entire point of the
+ * migration. Decisions from the before-critique (docs/qa/external-signing/):
+ * lift the card with shadow-over-border (not a faint hairline), and preserve
+ * the terminal color ladder signed=azure / expired=amber / revoked=red. ──── */
+
+// Hero ceremony card: white surface lifted by the canonical shadow. Its 0.5px
+// hairline ring IS the border (shadow-over-border); the soft drop matches all
+// other light app cards. `rounded-2xl` outer — nest inner elements (collapsed
+// agreement ref, inputs, OTP cells) at smaller radii for concentric corners.
+export const LIGHT_RECIPIENT_CARD = 'bg-white rounded-2xl shadow-seeko';
+// Card / section title ("External NDA", "Sign the Agreement").
+export const LIGHT_RECIPIENT_TITLE = 'text-[#111] font-semibold';
+// Secondary copy on the card ("Document signing request", the sign sub-copy).
+// `#6e6e6e` (4.74:1 on white) clears WCAG AA for body text — the signer mockup's
+// original `#A2A2A2` (~2.6:1) failed it. Darker than the generic `#808080` muted
+// used elsewhere precisely because this copy carries real meaning on the ceremony.
+export const LIGHT_RECIPIENT_MUTED = 'text-[#6e6e6e]';
+// Faintest text — fine print only. (There is no "Powered by" footer; the signer
+// migration removed the footer + logo, so reserve this strictly for decorative /
+// non-essential glyphs — never for instructional copy, which must clear AA.)
+export const LIGHT_RECIPIENT_FAINT = 'text-[#9a9a9a]';
+// Divider / inset border within the ceremony (apply with border-t / border-b).
+export const LIGHT_RECIPIENT_HAIRLINE = 'border-black/[0.06]';
+
+// Shared focus-visible ring for every light-ceremony control on the white
+// surface. The global `--color-ring` is a near-white dark-theme ring (rgba(240,
+// 240,240,0.18) — invisible on white), so the shadcn <Button> base ring and every
+// plain <button> on the ceremony (segmented Draw/Type, Clear, Resend, the
+// collapsed agreement toggle, the sheet close) would have NO visible keyboard
+// focus indicator. They all reuse this azure ring — the design lock reserves
+// `#0d7aff` for focus — mirroring the azure ring already proven on LIGHT_INPUT /
+// LIGHT_OTP_CELL, with an offset so it reads on both the white card and the
+// black-pill CTA. Append to a control's className; twMerge resolves it last-wins
+// over the dark `ring-ring` default.
+export const LIGHT_FOCUS_RING =
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0d7aff]/40 focus-visible:ring-offset-2 focus-visible:ring-offset-white';
+
+// Frame-level variant of LIGHT_FOCUS_RING: rings a styled CONTAINER when one of
+// its focusable children takes keyboard focus (`:has(:focus-visible)`). For the
+// signature pad, whose real control is a transparent, inset <input> — a ring on
+// the input itself would float mid-pad, so the bordered frame lights up instead,
+// exactly as a single bordered field would. Same azure/offset as LIGHT_FOCUS_RING;
+// keyboard-only (`:focus-visible`, not `:focus`) so a mouse click doesn't ring it.
+// The frame's own `overflow-hidden` clips its content, not its box-shadow, so the
+// offset ring still paints outside the border box.
+export const LIGHT_FOCUS_RING_WITHIN =
+  'has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-[#0d7aff]/40 has-[:focus-visible]:ring-offset-2 has-[:focus-visible]:ring-offset-white';
+
+// Primary ceremony CTA (Send Code / Continue to Sign / I Agree & Sign). The
+// canonical black pill (BTN_PRIMARY) lifted to a 44px hero height with the shared
+// shadow-seeko elevation, carrying the azure LIGHT_FOCUS_RING (the shadcn base
+// ring is the near-white dark `ring-ring`, invisible on this white surface).
+// `w-full` so it spans the capped ceremony card. Append to a shadcn <Button> so
+// twMerge recolors/resizes it last-wins over the dark default variant.
+export const LIGHT_RECIPIENT_CTA = `${BTN_PRIMARY} h-11 w-full shadow-seeko ${LIGHT_FOCUS_RING}`;
+
+// OTP digit cell (VerificationForm). White cell, large AA-dark digit, azure
+// focus ring matching LIGHT_INPUT; `rounded-xl` nests concentrically in the card.
+export const LIGHT_OTP_CELL =
+  'border border-black/[0.10] bg-white text-[#111] rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0d7aff]/30 focus-visible:border-[#0d7aff]';
+
+// Terminal-state icon chip (StatusPage + not-found) + the success-check token.
+// Ladder REVISED from Phase 0 (was signed=azure / expired=amber) to match the
+// user-authored Paper signer mockup + the /color-expert + /interface-craft gate:
+//   signed  = deep green  #15803d (5.02:1) — "done/safe"; distinct from the azure
+//             brand accent so azure keeps meaning "interactive" (not success).
+//   expired = neutral ink #6e6e6e (4.74:1) — stale, NOT alarming; amber over-alarmed.
+//   revoked = destructive #d4503e — a deliberate hard stop (admin killed it),
+//             reusing the kit's destructive so revoked reads consistently.
+//   notfound= neutral grey chip so a stale/invalid link still reads as branded.
+// Each value pairs a /10 tint background with the icon color for a circular chip.
+// LIGHT_SUCCESS_TEXT is the same green for the inline signed-confirmation check.
+export const LIGHT_TERMINAL_ICON: Record<string, string> = {
+  signed:   'bg-[#15803d]/10 text-[#15803d]',
+  expired:  'bg-black/[0.04] text-[#6e6e6e]',
+  revoked:  'bg-[#d4503e]/10 text-[#d4503e]',
+  notfound: 'bg-black/[0.04] text-[#9a9a9a]',
+};
+// Success affordance shared by the signed terminal chip + the just-signed
+// confirmation check in AgreementForm (replaces the azure seeko-accent check in
+// the light ceremony). Kept as a literal class so the Tailwind v4 scanner sees it.
+export const LIGHT_SUCCESS_CHIP = 'bg-[#15803d]/10 text-[#15803d]';
+export const LIGHT_SUCCESS_TEXT = 'text-[#15803d]';

--- a/src/components/external-signing/VerificationForm.tsx
+++ b/src/components/external-signing/VerificationForm.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { motion, AnimatePresence } from 'motion/react';
+import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
 import { Mail, Loader2, RotateCw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { springs } from '@/lib/motion';
+import { cn } from '@/lib/utils';
+import { LIGHT_OTP_CELL, LIGHT_RECIPIENT_CTA, LIGHT_RECIPIENT_MUTED, LIGHT_FOCUS_RING } from '@/components/dashboard/lightKit';
 
 interface VerificationFormProps {
   token: string;
@@ -12,6 +14,8 @@ interface VerificationFormProps {
   onVerified: (data: Record<string, unknown>) => void;
   sendCodeEndpoint?: string;
   verifyEndpoint?: string;
+  /** Opt into the light signer-ceremony theme. Default false → dark. */
+  light?: boolean;
 }
 
 const SPRING = springs.smooth;
@@ -42,6 +46,7 @@ export function VerificationForm({
   onVerified,
   sendCodeEndpoint = '/api/external-signing/send-code',
   verifyEndpoint = '/api/external-signing/verify',
+  light = false,
 }: VerificationFormProps) {
   const [codeSent, setCodeSent] = useState(false);
   const [digits, setDigits] = useState<string[]>(Array(CODE_LENGTH).fill(''));
@@ -50,6 +55,7 @@ export function VerificationForm({
   const [error, setError] = useState('');
   const [resendCooldown, setResendCooldown] = useState(0);
   const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
+  const reduce = useReducedMotion();
 
   // Restore persisted state after hydration (avoids SSR mismatch)
   useEffect(() => {
@@ -189,18 +195,19 @@ export function VerificationForm({
             key="send"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
-            exit={{ opacity: 0, y: -10 }}
-            transition={SPRING}
+            exit={reduce ? { opacity: 0 } : { opacity: 0, y: -10 }}
+            transition={reduce ? { duration: 0.12 } : SPRING}
             className="flex flex-col items-center gap-4"
           >
-            <p className="text-sm text-muted-foreground">
-              We&apos;ll send a code to <span className="font-mono text-xs text-foreground/60">{maskedEmail}</span>
+            <p className={cn('text-sm', light ? LIGHT_RECIPIENT_MUTED : 'text-muted-foreground')}>
+              We&apos;ll send a code to{' '}
+              <span className={cn('font-mono text-xs', light ? 'text-[#111]' : 'text-foreground/60')}>{maskedEmail}</span>
             </p>
             <Button
               type="button"
               onClick={handleSendCode}
               disabled={sending}
-              className="w-full gap-2"
+              className={cn('w-full gap-2', light && LIGHT_RECIPIENT_CTA)}
             >
               {sending ? <Loader2 className="size-4 animate-spin" /> : <Mail className="size-4" />}
               {sending ? 'Sending...' : 'Send Code'}
@@ -210,12 +217,12 @@ export function VerificationForm({
           /* ── Enter code phase ────────────────────────── */
           <motion.div
             key="verify"
-            initial={{ opacity: 0, y: 10 }}
+            initial={reduce ? { opacity: 0 } : { opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
-            transition={SPRING}
+            transition={reduce ? { duration: 0.12 } : SPRING}
             className="flex flex-col items-center gap-5"
           >
-            <p className="text-sm text-muted-foreground">
+            <p className={cn('text-sm', light ? LIGHT_RECIPIENT_MUTED : 'text-muted-foreground')}>
               Enter the code sent to your email
             </p>
 
@@ -233,12 +240,15 @@ export function VerificationForm({
                   onChange={(e) => handleDigitChange(i, e.target.value)}
                   onKeyDown={(e) => handleDigitKeyDown(i, e)}
                   disabled={verifying}
-                  initial={{ opacity: 0, y: 12 }}
+                  initial={reduce ? { opacity: 0 } : { opacity: 0, y: 12 }}
                   animate={{ opacity: 1, y: 0 }}
-                  transition={{ ...SPRING, delay: i * 0.04 }}
-                  className="size-12 sm:size-14 rounded-xl border border-border bg-muted text-center text-xl sm:text-2xl font-semibold text-foreground font-mono
-                    focus:outline-none focus:ring-2 focus:ring-foreground/20 focus:border-foreground/40
-                    disabled:opacity-50 transition-colors"
+                  transition={reduce ? { duration: 0.12 } : { ...SPRING, delay: i * 0.04 }}
+                  className={cn(
+                    'size-12 sm:size-14 rounded-xl text-center text-xl sm:text-2xl font-semibold font-mono transition-colors disabled:opacity-50',
+                    light
+                      ? LIGHT_OTP_CELL
+                      : 'border border-border bg-muted text-foreground focus:outline-none focus:ring-2 focus:ring-foreground/20 focus:border-foreground/40',
+                  )}
                 />
               ))}
             </div>
@@ -248,7 +258,7 @@ export function VerificationForm({
               <motion.div
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
-                className="flex items-center gap-2 text-sm text-muted-foreground"
+                className={cn('flex items-center gap-2 text-sm', light ? LIGHT_RECIPIENT_MUTED : 'text-muted-foreground')}
               >
                 <Loader2 className="size-4 animate-spin" />
                 Verifying...
@@ -260,7 +270,11 @@ export function VerificationForm({
               type="button"
               onClick={handleResendCode}
               disabled={resendCooldown > 0 || sending}
-              className="min-h-[44px] px-4 text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-40 disabled:cursor-default flex items-center gap-1.5"
+              className={cn(
+                'min-h-[44px] rounded-md px-4 text-xs transition-colors disabled:opacity-40 disabled:cursor-default flex items-center gap-1.5',
+                light ? 'text-[#6e6e6e] hover:text-[#111]' : 'text-muted-foreground hover:text-foreground',
+                light && LIGHT_FOCUS_RING,
+              )}
             >
               <RotateCw className="size-3" />
               {resendCooldown > 0 ? `Resend in ${resendCooldown}s` : "Didn\u2019t receive it? Resend"}
@@ -273,10 +287,13 @@ export function VerificationForm({
       <AnimatePresence>
         {error && (
           <motion.p
-            initial={{ opacity: 0, y: 6 }}
+            initial={reduce ? { opacity: 0 } : { opacity: 0, y: 6 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0 }}
-            className="text-sm text-destructive bg-destructive/10 px-4 py-2 rounded-lg"
+            className={cn(
+              'text-sm px-4 py-2 rounded-lg',
+              light ? 'text-[#d4503e] bg-[#d4503e]/10' : 'text-destructive bg-destructive/10',
+            )}
           >
             {error}
           </motion.p>

--- a/src/components/external/RecipientSheet.tsx
+++ b/src/components/external/RecipientSheet.tsx
@@ -1,0 +1,269 @@
+'use client';
+
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { motion, useReducedMotion } from 'motion/react';
+import { X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { acquireScrollLock, releaseScrollLock } from '@/lib/scroll-lock';
+import { LIGHT_FOCUS_RING } from '@/components/dashboard/lightKit';
+
+// Tabbable elements inside the dialog, for the focus trap. Disabled controls and
+// tabindex=-1 are excluded; visibility is filtered at runtime (getClientRects).
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+// Smooth rise with the barest settle — no playful bounce on a legal ceremony.
+const SHEET_SPRING = { type: 'spring' as const, visualDuration: 0.42, bounce: 0.06 };
+// Asymmetric closes (transitions.dev: close faster than open). The mobile sheet
+// slides down on Emil's iOS drawer curve; the desktop dialog accelerates out
+// with the app's modal exit (matches MODAL.card.exitTransition in lib/motion).
+const DRAWER_EXIT = { duration: 0.3, ease: [0.32, 0.72, 0, 1] as const };
+const MODAL_EXIT = { duration: 0.15, ease: [0.4, 0, 1, 1] as const };
+// prefers-reduced-motion: opacity only, no rise/scale/slide (every transitions.dev recipe ships this guard).
+const REDUCED = { duration: 0.12 };
+// Drawer → fullscreen (mobile) / taller card (desktop) on "Continue to sign".
+// transitions.dev "Card resize": a height tween on a strong ease-out so the surface
+// visibly grows into the signing act. Height-only (mobile is already full-width; the
+// desktop card stays width-capped). 200ms (not the 300ms recipe default) — the signer
+// pressed "Continue", so the grow must feel immediate, not deliberate; the front-loaded
+// curve covers most of the travel in the first ~80ms. Reduced motion snaps — see RESIZE_SNAP.
+const CARD_RESIZE = { duration: 0.2, ease: [0.22, 1, 0.36, 1] as const };
+const RESIZE_SNAP = { duration: 0 };
+
+/**
+ * SSR/jsdom-safe viewport probe. `mounted` stays false until the first client
+ * effect, so the animated sheet is held back one frame and mounts only once the
+ * breakpoint is resolved. Without that gate the desktop dialog mounts
+ * mobile-first (matchMedia can't run during SSR, so isDesktop starts false then
+ * flips post-paint); motion captures the mobile `initial` (y:100%) and, when the
+ * flip swaps `animate` to the scale branch, the y key is dropped mid-flight and
+ * the dialog strands off-screen at translateY(100%). `mounted` + `isDesktop` are
+ * set together so the sheet never observes the flip. Defaults to mobile.
+ */
+function useViewport() {
+  const [state, setState] = useState({ mounted: false, isDesktop: false });
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) {
+      setState({ mounted: true, isDesktop: false });
+      return;
+    }
+    const mq = window.matchMedia('(min-width: 640px)');
+    const sync = () => setState({ mounted: true, isDesktop: mq.matches });
+    sync();
+    mq.addEventListener('change', sync);
+    return () => mq.removeEventListener('change', sync);
+  }, []);
+  return state;
+}
+
+interface RecipientSheetProps {
+  children: ReactNode;
+  /**
+   * Whether the signer may dismiss the sheet (drag down / tap scrim / close button).
+   * Default false → a locked ceremony that can't be swiped away mid-signature.
+   * Terminal screens (signed / expired / revoked / not-found) opt in.
+   */
+  dismissible?: boolean;
+  onDismiss?: () => void;
+  /**
+   * Grow the sheet for the signing act: drawer → fullscreen on mobile, taller
+   * card on desktop. Default false → the peek-sized reading drawer. Driven by the
+   * signer ceremony's phase; onboarding never sets it.
+   */
+  expanded?: boolean;
+}
+
+/**
+ * The signer ceremony's chrome: a bottom sheet on mobile that rises from the
+ * edge, and a centered dialog on desktop. One surface, two viewports. Locked by
+ * default; terminal screens pass `dismissible`. Wrap in <AnimatePresence> at the
+ * call site to animate the exit.
+ */
+export function RecipientSheet({ children, dismissible = false, onDismiss, expanded = false }: RecipientSheetProps) {
+  const { mounted, isDesktop } = useViewport();
+  const reduce = useReducedMotion();
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  // Latest dismiss intent, read by the (stable) keydown handler so the listener
+  // never re-subscribes on a new inline onDismiss identity — which would otherwise
+  // re-run the focus-in effect and steal focus from an input the signer is typing.
+  // Updated in an effect (not during render) so it's concurrent-safe; the handler
+  // only reads it on a real keypress, which always fires after commit.
+  const dismissRef = useRef<{ dismissible: boolean; onDismiss?: () => void }>({ dismissible, onDismiss });
+  useEffect(() => {
+    dismissRef.current = { dismissible, onDismiss };
+  }, [dismissible, onDismiss]);
+
+  useEffect(() => {
+    acquireScrollLock();
+    return () => releaseScrollLock();
+  }, []);
+
+  // Modal focus management — satisfies the aria-modal contract this dialog asserts.
+  // On mount, move focus into the dialog container (it's tabIndex={-1}) so keyboard
+  // and screen-reader users land inside the modal instead of on document.body, and
+  // trap Tab/Shift+Tab so focus can't escape to the inert page behind the scrim
+  // (the scrim blocks pointers when locked but not keyboard focus). Escape closes —
+  // but ONLY when dismissible, so the locked verify/review/sign ceremony stays
+  // un-escapable. Depends on `mounted` only: the container is focused once when the
+  // sheet appears, and the listener is stable (reads dismissRef), so neither steals
+  // focus from the inner phases (which self-manage: OTP cell / legal-name input).
+  useEffect(() => {
+    if (!mounted) return;
+    const node = dialogRef.current;
+    if (!node) return;
+    node.focus();
+
+    function onKeyDown(e: KeyboardEvent) {
+      const current = dialogRef.current;
+      if (!current) return;
+      if (e.key === 'Escape') {
+        if (dismissRef.current.dismissible) {
+          e.preventDefault();
+          dismissRef.current.onDismiss?.();
+        }
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      const focusables = Array.from(
+        current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+      ).filter((el) => el.getClientRects().length > 0);
+      if (focusables.length === 0) {
+        e.preventDefault();
+        current.focus();
+        return;
+      }
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey) {
+        if (active === first || active === current || !current.contains(active)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else if (active === last || !current.contains(active)) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [mounted]);
+
+  const dismissOnScrim = dismissible ? onDismiss : undefined;
+
+  // Card-resize targets, resolved against the fixed inset-0 parent (a definite
+  // height, so % resolves cleanly and motion can tween auto ↔ %). Expanded: mobile
+  // fills the viewport and squares off its top corners so it no longer reads as a
+  // drawer; the desktop card keeps its width + radius and just grows taller.
+  // Collapsed: natural drawer/card height.
+  const sheetHeight = expanded ? (isDesktop ? '94%' : '100%') : 'auto';
+  const topRadius = !isDesktop && expanded ? 0 : 28;
+  const bottomRadius = isDesktop ? 28 : 0;
+  const resize = {
+    height: sheetHeight,
+    borderTopLeftRadius: topRadius,
+    borderTopRightRadius: topRadius,
+    borderBottomLeftRadius: bottomRadius,
+    borderBottomRightRadius: bottomRadius,
+  };
+  // Per-property transition: the resize props use the card-resize curve (or snap
+  // under reduced motion); the entrance keeps the sheet spring for y/scale/opacity.
+  const resizeTransition = reduce
+    ? { height: RESIZE_SNAP, borderTopLeftRadius: RESIZE_SNAP, borderTopRightRadius: RESIZE_SNAP, borderBottomLeftRadius: RESIZE_SNAP, borderBottomRightRadius: RESIZE_SNAP }
+    : { height: CARD_RESIZE, borderTopLeftRadius: CARD_RESIZE, borderTopRightRadius: CARD_RESIZE, borderBottomLeftRadius: CARD_RESIZE, borderBottomRightRadius: CARD_RESIZE };
+
+  return (
+    <div className="overview-light fixed inset-0 z-50 flex flex-col items-center bg-[var(--ov-bg)] sm:justify-center">
+      {/* Scrim — inert when the ceremony is locked */}
+      <motion.div
+        data-testid="sheet-scrim"
+        aria-hidden
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.25 }}
+        onClick={dismissOnScrim}
+        className={cn(
+          'absolute inset-0 bg-black/20 backdrop-blur-[2px]',
+          dismissOnScrim ? 'cursor-pointer' : 'pointer-events-none',
+        )}
+      />
+
+      {/* Sheet (mobile) / Dialog (desktop). Held until `mounted` so `initial`
+          captures the resolved breakpoint — see useViewport. */}
+      {mounted && (
+        <motion.div
+          ref={dialogRef}
+          role="dialog"
+          aria-modal="true"
+          tabIndex={-1}
+          // Desktop dialog scales from center; mobile sheet rises from the edge.
+          initial={reduce ? { opacity: 0 } : isDesktop ? { opacity: 0, scale: 0.96 } : { y: '100%' }}
+          // Rest state is complete and viewport-agnostic (opacity+scale+y) so a
+          // mid-flight breakpoint flip can never drop a key and strand the transform.
+          // `resize` adds the card-resize target (height + corner radii) so the sheet
+          // grows into the signing act; on mount it equals the className values, so
+          // only y/scale/opacity animate in — the resize animates later when expanded flips.
+          animate={reduce ? { opacity: 1, ...resize } : { opacity: 1, scale: 1, y: 0, ...resize }}
+          exit={
+            reduce
+              ? { opacity: 0, transition: REDUCED }
+              : isDesktop
+                ? { opacity: 0, scale: 0.96, transition: MODAL_EXIT }
+                : { y: '100%', transition: DRAWER_EXIT }
+          }
+          transition={reduce ? { ...REDUCED, ...resizeTransition } : { ...SHEET_SPRING, ...resizeTransition }}
+          drag={dismissible && !isDesktop ? 'y' : false}
+          dragConstraints={{ top: 0, bottom: 0 }}
+          dragElastic={{ top: 0, bottom: 0.6 }}
+          onDragEnd={(_e, info) => {
+            if (dismissible && (info.offset.y > 100 || info.velocity.y > 300)) onDismiss?.();
+          }}
+          className={cn(
+            'relative mt-auto flex w-full flex-col overflow-hidden bg-white sm:mt-0',
+            // Container is programmatically focused on mount (focus move-in for the
+            // aria-modal contract) — suppress the default outline on that focus.
+            'focus:outline-none',
+            // Radii are also driven inline by motion (card-resize); these are the
+            // first-paint / no-JS fallback and must match the collapsed targets.
+            'rounded-t-[28px] sm:max-w-[420px] sm:rounded-[28px]',
+            'shadow-[0_-10px_40px_-12px_rgba(0,0,0,0.18)] sm:shadow-seeko',
+            // Collapsed: capped below full height so a dimmed strip of page shows
+            // above the sheet — that gap is what reads as a "drawer". Expanded: the
+            // cap must not clamp the animated height (mobile fills, desktop → 94dvh).
+            expanded ? 'max-h-none sm:max-h-[94dvh]' : 'max-h-[88dvh] sm:max-h-[88dvh]',
+          )}
+        >
+          {/* Drag affordance — gesture hint on dismissible mobile sheets */}
+          {dismissible && !isDesktop && (
+            <div className="flex shrink-0 justify-center pt-3 pb-1">
+              <div className="h-1 w-9 rounded-full bg-black/[0.12]" />
+            </div>
+          )}
+
+          {/* Accessible close — present on every dismissible sheet/dialog */}
+          {dismissible && (
+            <button
+              type="button"
+              onClick={onDismiss}
+              aria-label="Close"
+              className={cn(
+                'absolute right-4 top-4 z-10 flex size-8 items-center justify-center rounded-full bg-black/[0.04] text-[#6e6e6e] transition-colors hover:bg-black/[0.08] active:scale-95',
+                LIGHT_FOCUS_RING,
+              )}
+            >
+              <X className="size-4" />
+            </button>
+          )}
+
+          {/* Scrollable content — the sheet owns padding so screens stay clean */}
+          <div className="flex-1 overflow-y-auto overscroll-contain px-6 pt-6 pb-[max(1.5rem,env(safe-area-inset-bottom))] sm:px-8 sm:pb-8 sm:pt-8">
+            {children}
+          </div>
+        </motion.div>
+      )}
+    </div>
+  );
+}

--- a/src/components/external/TerminalStatus.tsx
+++ b/src/components/external/TerminalStatus.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { motion, useReducedMotion } from 'motion/react';
+import type { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+import { springs } from '@/lib/motion';
+import {
+  LIGHT_TERMINAL_ICON,
+  LIGHT_RECIPIENT_TITLE,
+  LIGHT_RECIPIENT_MUTED,
+} from '@/components/dashboard/lightKit';
+
+interface TerminalStatusProps {
+  /** Selects the icon-chip color from the terminal ladder (signed/expired/revoked/notfound). */
+  iconKey: keyof typeof LIGHT_TERMINAL_ICON;
+  /** The chip glyph; inherits the ladder color via `currentColor`. */
+  icon: ReactNode;
+  title: string;
+  description: string;
+  /** Optional CTA slot (e.g. the expired "Request a new link" action). */
+  action?: ReactNode;
+}
+
+/**
+ * The signer ceremony's end state: a centered icon chip + headline + line of
+ * copy, rendered inside the RecipientSheet. Light-only and reused by every
+ * terminal screen (signed / expired / revoked / not-found) so they read as one
+ * coherent family. A Phase-5 primitive pulled forward — the chrome is being
+ * rebuilt anyway, so the shared shape lands now rather than twice.
+ */
+export function TerminalStatus({ iconKey, icon, title, description, action }: TerminalStatusProps) {
+  const reduce = useReducedMotion();
+  return (
+    <motion.div
+      // The app fade (springs.smooth opacity+y rise), riding in just behind the
+      // sheet surface; opacity-only under prefers-reduced-motion.
+      initial={reduce ? { opacity: 0 } : { opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={reduce ? { duration: 0.12 } : { ...springs.smooth, delay: 0.04 }}
+      className="flex flex-col items-center gap-5 py-6 text-center"
+    >
+      <div className={cn('flex size-14 items-center justify-center rounded-full', LIGHT_TERMINAL_ICON[iconKey])}>
+        {icon}
+      </div>
+      <div className="flex flex-col gap-2">
+        <h1 className={cn('text-[26px] leading-[1.15] tracking-[-0.02em]', LIGHT_RECIPIENT_TITLE)}>{title}</h1>
+        <p className={cn('mx-auto max-w-[30ch] text-[16px] leading-relaxed', LIGHT_RECIPIENT_MUTED)}>
+          {description}
+        </p>
+      </div>
+      {action && <div className="w-full pt-1">{action}</div>}
+    </motion.div>
+  );
+}

--- a/src/components/external/__tests__/RecipientSheet.test.tsx
+++ b/src/components/external/__tests__/RecipientSheet.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RecipientSheet } from '../RecipientSheet';
+
+// Scroll-lock touches the DOM body; stub it so the component mounts cleanly.
+vi.mock('@/lib/scroll-lock', () => ({ acquireScrollLock: vi.fn(), releaseScrollLock: vi.fn() }));
+
+describe('RecipientSheet — dismiss gating', () => {
+  beforeEach(() => {
+    // jsdom has no matchMedia → the hook must default to mobile without crashing.
+    // (intentionally left undefined to prove the guard)
+  });
+
+  it('locks the ceremony: scrim click is inert and no close control renders when not dismissible', () => {
+    const onDismiss = vi.fn();
+    render(
+      <RecipientSheet onDismiss={onDismiss}>
+        <p>Sign here</p>
+      </RecipientSheet>,
+    );
+
+    // A non-dismissible sheet must NOT close when the signer taps outside it.
+    fireEvent.click(screen.getByTestId('sheet-scrim'));
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    // And it exposes no close affordance at all.
+    expect(screen.queryByRole('button', { name: /close/i })).not.toBeInTheDocument();
+    expect(screen.getByText('Sign here')).toBeInTheDocument();
+  });
+
+  it('dismisses on scrim click and exposes an accessible close control when dismissible', () => {
+    const onDismiss = vi.fn();
+    render(
+      <RecipientSheet dismissible onDismiss={onDismiss}>
+        <p>All set</p>
+      </RecipientSheet>,
+    );
+
+    const close = screen.getByRole('button', { name: /close/i });
+    expect(close).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('sheet-scrim'));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(close);
+    expect(onDismiss).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/agreement-hash.ts
+++ b/src/lib/agreement-hash.ts
@@ -1,0 +1,38 @@
+/**
+ * Integrity hash for a signed agreement's content.
+ *
+ * Produces a SHA-256 digest (64 lowercase hex chars) over the exact title +
+ * ordered sections the signer agreed to. The hash is printed on the Certificate
+ * of Completion so the document is self-verifying: re-hashing the stored
+ * agreement text must reproduce the printed value, proving the content was not
+ * altered after signing.
+ *
+ * Canonicalization uses JSON.stringify over an explicitly-shaped object, which
+ * is deterministic (fixed key order: number → title → content), order-sensitive
+ * (the sections array order is preserved), and field-boundary safe (JSON quoting
+ * disambiguates field edges, so text cannot migrate between title and content
+ * without changing the digest). A naive `title + content` concat would collide.
+ *
+ * Web Crypto (`crypto.subtle`) is available as a global in the Node runtime that
+ * runs the sign route and in the Vitest/Node test environment, so no import is
+ * needed.
+ */
+export async function computeAgreementHash(
+  title: string,
+  sections: { number: number; title: string; content: string }[],
+): Promise<string> {
+  const canonical = JSON.stringify({
+    title,
+    sections: sections.map((s) => ({
+      number: s.number,
+      title: s.title,
+      content: s.content,
+    })),
+  });
+
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(canonical));
+
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}

--- a/src/lib/agreement-pdf.ts
+++ b/src/lib/agreement-pdf.ts
@@ -15,6 +15,62 @@ interface PdfInput {
   title: string;
   sections: { number: number; title: string; content: string }[];
   signer: PdfSigner;
+  /* ── Certificate of Completion (external signing only) ──────────────────
+   * When `envelopeId` OR `integrityHash` is provided, a Certificate of
+   * Completion page is appended documenting the electronic-execution audit
+   * trail (ESIGN/UETA). Onboarding omits these → no certificate page, so the
+   * onboarding PDF is byte-for-byte unchanged. `ip`/`userAgent` are optional
+   * even when the certificate is rendered: legacy/missing-header signs print
+   * "Not recorded" for the absent field rather than fabricating a value. */
+  envelopeId?: string | null;
+  integrityHash?: string | null;
+  ip?: string | null;
+  userAgent?: string | null;
+}
+
+export interface CertificateFields {
+  envelopeId?: string | null;
+  integrityHash?: string | null;
+  ip?: string | null;
+  userAgent?: string | null;
+  signerName: string;
+  signerEmail: string;
+  signedAt: Date;
+}
+
+const NOT_RECORDED = 'Not recorded';
+
+/** A field's value, or "Not recorded" when null/undefined/blank. Never fabricate
+ * an audit value (a spoofed IP/UA would poison the legal record) — absence is
+ * surfaced honestly. */
+function orNotRecorded(v: string | null | undefined): string {
+  return v && v.trim() ? v : NOT_RECORDED;
+}
+
+/** Pure builder for the Certificate of Completion's label/value rows. Extracted
+ * so the formatting + "Not recorded" degradation is unit-testable without
+ * parsing a PDF. The signed timestamp is stamped in UTC with an explicit
+ * timezone label so the certificate is unambiguous and host-timezone-independent. */
+export function buildCertificateRows(f: CertificateFields): { label: string; value: string }[] {
+  const signedStr = f.signedAt.toLocaleString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit',
+    timeZoneName: 'short',
+    timeZone: 'UTC',
+  });
+  return [
+    { label: 'Envelope ID', value: orNotRecorded(f.envelopeId) },
+    { label: 'Signer', value: orNotRecorded(f.signerName) },
+    { label: 'Email', value: orNotRecorded(f.signerEmail) },
+    { label: 'Signed', value: signedStr },
+    { label: 'IP Address', value: orNotRecorded(f.ip) },
+    { label: 'User Agent', value: orNotRecorded(f.userAgent) },
+    { label: 'Document Hash (SHA-256)', value: orNotRecorded(f.integrityHash) },
+  ];
 }
 
 /** Strip HTML tags for plain-text PDF rendering */
@@ -306,7 +362,52 @@ export async function generateAgreementPdf(input: PdfInput): Promise<Uint8Array>
     color: GRAY,
   });
 
-  // Add footer to last page
+  /* ── Certificate of Completion ───────────────────────────
+   * Appended only for audited e-signs (envelopeId/integrityHash present), on
+   * its own page. `newPage()` foots the final agreement page and opens the
+   * certificate page; the trailing addFooter then foots the certificate page. */
+  if (input.envelopeId || input.integrityHash) {
+    newPage();
+
+    drawCentered('CERTIFICATE OF COMPLETION', 14, timesBold);
+    y -= 8;
+    drawRule();
+    y -= 6;
+
+    drawWrapped(
+      'This certificate records the electronic execution of the agreement above, captured by SEEKO Studio in accordance with the U.S. ESIGN Act and the Uniform Electronic Transactions Act (UETA).',
+      9.5, timesItalic, 13
+    );
+    y -= 14;
+
+    const rows = buildCertificateRows({
+      envelopeId: input.envelopeId,
+      integrityHash: input.integrityHash,
+      ip: input.ip,
+      userAgent: input.userAgent,
+      signerName: input.signer.fullName,
+      signerEmail: input.signer.email,
+      signedAt: input.signer.signedAt,
+    });
+
+    for (const { label, value } of rows) {
+      ensureSpace(30);
+      // Uppercase field label (matches this document's existing title/heading
+      // convention; this is a formal legal certificate, not app UI chrome).
+      page.drawText(label.toUpperCase(), { x: MARGIN, y, size: 8, font: timesBold, color: GRAY });
+      y -= 13;
+      drawWrapped(value, 10.5, timesRoman, 14);
+      y -= 9;
+    }
+
+    y -= 6;
+    drawWrapped(
+      'The signer consented to transact electronically and to the use of electronic records and signatures for this agreement. The document hash above uniquely identifies the exact agreement content that was signed; any later modification of that content would produce a different hash.',
+      8.5, timesItalic, 12
+    );
+  }
+
+  // Add footer to the last page (agreement page, or certificate page if appended)
   addFooter(page, pageNum);
 
   return doc.save();

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,4 +1,5 @@
 import { Resend } from 'resend';
+import { sanitizeEmailHtml } from './sanitize';
 
 let resend: Resend | null = null;
 
@@ -134,7 +135,7 @@ function buildAgreementHtml(
             </td>
             <td style="padding-left:12px;">
               <p style="margin:0 0 6px;font-size:15px;font-weight:600;color:#111;">${esc(s.title)}</p>
-              <div style="font-size:14px;color:#555;line-height:1.65;">${s.content}</div>
+              <div style="font-size:14px;color:#555;line-height:1.65;">${sanitizeEmailHtml(s.content)}</div>
             </td>
           </tr>
         </table>
@@ -276,6 +277,27 @@ export async function sendExternalInviteEmail({
       ${divider()}
       ${footer("If you didn't expect this email, you can safely ignore it.")}
     `),
+  });
+}
+
+/* ── 3b. Signing Link Reissued (admin notify) ────────────── */
+
+export interface SendReissueNotificationEmailParams {
+  recipientEmail: string;
+  templateName: string;
+}
+
+/** Admin heads-up when a signer self-serves a fresh link via the expired-link flow. */
+export async function sendReissueNotificationEmail({
+  recipientEmail,
+  templateName,
+}: SendReissueNotificationEmailParams): Promise<void> {
+  const r = getResend();
+  await r.emails.send({
+    from: FROM_EMAIL,
+    to: ADMIN_EMAIL,
+    subject: `Signing link reissued: ${templateName}`,
+    text: `${recipientEmail} requested a fresh signing link for "${templateName}". A new link has been sent and the invite reset to pending.`,
   });
 }
 

--- a/src/lib/invite-filters.ts
+++ b/src/lib/invite-filters.ts
@@ -27,6 +27,31 @@ export function excludeDocShare(invites: ExternalSigningInvite[]): ExternalSigni
   return invites.filter(i => i.template_type !== 'doc_share');
 }
 
+/**
+ * The signing products (`preset` + `custom`) within the shared
+ * `external_signing_invites` table, which serves three sibling products
+ * (signing / invoice / doc-share). Used by `isSigningInvite` below — the per-row
+ * cross-product isolation guard every signing route runs before acting on a token.
+ */
+export const SIGNING_TEMPLATE_TYPES = new Set<ExternalSigningInvite['template_type']>(['preset', 'custom']);
+
+/**
+ * Single source of truth for the cross-product isolation guard. Every route that
+ * fetches a row from the shared `external_signing_invites` table by token/id MUST
+ * reject non-signing rows with this helper before acting — otherwise an invoice or
+ * doc-share token could be operated on through a signing route. Returns `false` for
+ * a missing row so callers can fold the not-found and wrong-product cases into one
+ * identical 404 (no enumeration oracle). See `.claude/claude-security-guidance.md`.
+ *
+ * It is a type guard: a truthy result narrows away `null | undefined`, so callers
+ * get the not-found check for free and cannot forget it.
+ */
+export function isSigningInvite<T extends { template_type: ExternalSigningInvite['template_type'] }>(
+  invite: T | null | undefined,
+): invite is T {
+  return !!invite && SIGNING_TEMPLATE_TYPES.has(invite.template_type);
+}
+
 export type InviteGroup = {
   email: string;
   invites: ExternalSigningInvite[];

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -52,3 +52,54 @@ export const SLIDEOUT = {
   animate: { x: 0 },
   exit: { x: '100%' },
 } as const;
+
+// ── Signer-ceremony phase swap (verify ↔ sign) ─────────────────
+/**
+ * Cross-blur phase swap for the external-signing ceremony's locked sheet,
+ * used inside <AnimatePresence mode="wait">. It is the app's standard fade —
+ * the FadeRise opacity+y rise on `springs.smooth`, as on /activity and
+ * /settings — enriched with the transitions.dev "panel reveal" cross-blur:
+ * a 2px blur on enter/exit so the swap reads as a real open even though the
+ * compact verify panel and the taller sign panel are very different heights.
+ * The blur masks that height jump (Emil: "blur masks imperfect transitions"),
+ * and the exit accelerates out faster than the enter (transitions.dev: close
+ * quicker than open).
+ *
+ * STORYBOARD (mode="wait" → old phase exits fully, then new phase enters):
+ *   EXIT   opacity 1→0 · y 0→-6 · blur 0→2px   — 180ms accelerate-out
+ *   ENTER  opacity 0→1 · y 8→0  · blur 2px→0    — springs.smooth (the app fade);
+ *          blur rides its own 280ms ease-out so the spring can't pull it past 0
+ *   reduced-motion → opacity-only 120ms, no y, no blur (matches MODAL.reduced)
+ */
+export const CEREMONY_SWAP = {
+  enter: { opacity: 0, y: 8, filter: 'blur(2px)' },
+  rest: { opacity: 1, y: 0, filter: 'blur(0px)' },
+  exit: { opacity: 0, y: -6, filter: 'blur(2px)' },
+  /** Blur on a clean ease-out — a spring would overshoot blur below 0 → flicker. */
+  blurTransition: { duration: 0.28, ease: 'easeOut' as const },
+  exitTransition: { duration: 0.18, ease: [0.4, 0, 1, 1] as const },
+  reduced: { duration: 0.12 },
+} as const;
+
+/**
+ * Per-phase entrance props for the ceremony swap, reduced-motion aware.
+ * Spread onto each phase's `motion.div` inside the locked sheet's
+ * <AnimatePresence mode="wait">.
+ */
+export function ceremonySwap(reduce: boolean | null) {
+  if (reduce) {
+    return {
+      initial: { opacity: 0 },
+      animate: { opacity: 1 },
+      exit: { opacity: 0, transition: CEREMONY_SWAP.reduced },
+      transition: CEREMONY_SWAP.reduced,
+    };
+  }
+  return {
+    initial: CEREMONY_SWAP.enter,
+    animate: CEREMONY_SWAP.rest,
+    exit: { ...CEREMONY_SWAP.exit, transition: CEREMONY_SWAP.exitTransition },
+    // opacity + y ride springs.smooth (the app fade); blur rides its own ease-out
+    transition: { ...springs.smooth, filter: CEREMONY_SWAP.blurTransition },
+  };
+}

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -1,0 +1,37 @@
+import DOMPurify from 'isomorphic-dompurify';
+
+/**
+ * SSR-safe HTML sanitizer.
+ *
+ * The bare `dompurify` default export has no `.sanitize` when there is no DOM,
+ * so server-rendering the agreement / doc-share components under Next 16 threw
+ * `DOMPurify.sanitize is not a function` (a 500). `isomorphic-dompurify` wires
+ * up jsdom on the server and the native DOM in the browser, so this works in
+ * both contexts. Centralized here so every call site is SSR-safe by default and
+ * the dependency stays swappable for the planned framework migration.
+ */
+export function sanitizeHtml(dirty: string): string {
+  return DOMPurify.sanitize(dirty ?? '');
+}
+
+/**
+ * Strict allow-list sanitizer for HTML that goes into an *email* body.
+ *
+ * Email section content (`custom_sections[].content`, `custom_title`) is derived
+ * from an uploaded PDF → Claude → stored HTML and is NEVER sanitized at insert,
+ * so it is attacker-influenced. A plain `sanitizeHtml` pass keeps anchors and
+ * images, which in an email sent from the trusted `noreply@seekostudios.com`
+ * domain become phishing links and tracking pixels. This keeps only inert
+ * structural/formatting tags and drops every link, image, style, and handler.
+ *
+ * Use this — not `esc()` or `sanitizeHtml` — at any email `html:` content sink.
+ * See `.claude/claude-security-guidance.md` §2.
+ */
+export function sanitizeEmailHtml(dirty: string): string {
+  return DOMPurify.sanitize(dirty ?? '', {
+    ALLOWED_TAGS: ['p', 'br', 'ul', 'ol', 'li', 'strong', 'em', 'b', 'i'],
+    ALLOWED_ATTR: [],
+    FORBID_TAGS: ['a', 'img', 'style', 'script', 'iframe', 'link', 'object', 'embed'],
+    FORBID_ATTR: ['style', 'href', 'src', 'srcset', 'class', 'id', 'target'],
+  });
+}


### PR DESCRIPTION
## External signing — light signer ceremony + completion certificate + hardening

Clean, self-contained slice of the external-signing work, cut fresh off `main` so the build is coherent (supersedes the red build on #114, whose committed HEAD depended on unrelated in-flight dashboard WIP).

**Scope: the public signer ceremony only.** No admin relight, no settings/docs/team/payments relights, no dashboard skeletons — those are entangled with the unfinished dashboard redesign and ship separately.

### What's in here
- **Signer ceremony dark → light** — `RecipientSheet`, `AgreementForm`, `SignatureDrawing`, `SignaturePad`, `AddressAutocomplete`, `VerificationForm` relit via opt-in `light` prop (default `false`, so onboarding `/agreement` stays pixel/motion-identical dark).
- **`TerminalStatus`** — light icon-chip terminal screens (signed / expired / revoked) with quiet contact CTA.
- **Completion certificate** — `computeAgreementHash` (SHA-256) + a *Certificate of Completion* page appended to the signed PDF (envelope ID, signer, timestamp w/ timezone, IP, user-agent, integrity hash, ESIGN/UETA consent; renders "Not recorded" when audit fields are absent — legacy rows degrade gracefully, no retroactive regen).
- **Token-gated `GET /download`** — 30-min signed URL; 404 if missing, 409 if not yet `signed`; IP rate-limited.
- **Reliability fix** — `sign/route.ts` now returns 502 and stays `verified` on storage-upload failure (no false `signed` flip, no email) instead of marking signed with no PDF stored.
- **`/reissue`** — public, token-gated "request a new link" for expired invites.
- **Admin scope** — `onlySigning()` allow-list so invoice/doc-share rows can't leak into the signing table.
- **`isomorphic-dompurify`** — SSR-safe sanitizer (the one new dependency vs `main`).

### Tests
14 suites: `agreement-hash`, `agreement-pdf`, `sign-certificate`, `sign-upload-failure`, `download`, `reissue`, `RecipientSheet`, `SignaturePad`, `AgreementForm.signature`, `client-expired-reissue`, `client-notfound`, plus existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
